### PR TITLE
feat: add CrossBarIF, CrossBarIFInput, CrossBarIFOutput interface

### DIFF
--- a/examples/interface/crossbar_demo.py
+++ b/examples/interface/crossbar_demo.py
@@ -1,0 +1,145 @@
+"""
+crossbar_demo.py — demonstration of CrossBarIF with 2 inputs and 2 outputs.
+
+Routing rule: if words[0] is even the burst goes to output port 0;
+              if words[0] is odd  the burst goes to output port 1.
+
+Two sources send bursts concurrently.  The demo prints each burst as it
+arrives at its destination and asserts that every burst reached the
+correct output.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from pysilicon.hw.clock import Clock
+from pysilicon.hw.interface import CrossBarIF, CrossBarIFInput, CrossBarIFOutput, Words
+from pysilicon.simulation.simobj import ProcessGen, SimObj
+from pysilicon.simulation.simulation import Simulation
+
+
+def route_by_first_word(words: Words, port_in: int) -> int:
+    """Route even first-word values to output 0, odd to output 1."""
+    return int(words[0]) % 2
+
+
+@dataclass
+class Source(SimObj):
+    """Sends a list of bursts through a CrossBarIFInput endpoint."""
+
+    tx_packets: list[Words] = field(default_factory=list)
+    """Bursts to send, in order."""
+
+    tx_gap: float = 1.0
+    """Simulation time to wait between consecutive bursts."""
+
+    bitwidth: int = 32
+
+    def __init_subclass__(cls, **kwargs):
+        return super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.input_ep = CrossBarIFInput(sim=self.sim, bitwidth=self.bitwidth)
+        self.tx_times: list[float] = []
+
+    def run_proc(self) -> ProcessGen:
+        for i, packet in enumerate(self.tx_packets):
+            print(f"[{self.name}] sending burst {i}: {packet} at t={self.env.now:.1f}")
+            yield self.process(self.input_ep.write(packet))
+            self.tx_times.append(self.now)
+            yield self.timeout(self.tx_gap)
+
+
+@dataclass
+class Sink(SimObj):
+    """Receives bursts from a CrossBarIFOutput endpoint."""
+
+    rx_gap: float = 0.0
+    """Processing delay for each received burst."""
+
+    bitwidth: int = 32
+    queue_size: int | None = None
+
+    def __init_subclass__(cls, **kwargs):
+        return super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.rx_packets: list[Words] = []
+        self.rx_times: list[float] = []
+        self.output_ep = CrossBarIFOutput(
+            sim=self.sim,
+            bitwidth=self.bitwidth,
+            rx_proc=self.rx_proc,
+            queue_size=self.queue_size,
+        )
+
+    def rx_proc(self, words: Words) -> ProcessGen:
+        print(f"[{self.name}] received: {words} at t={self.env.now:.1f}")
+        self.rx_packets.append(np.array(words, copy=True))
+        self.rx_times.append(self.now)
+        yield self.timeout(self.rx_gap)
+
+
+class CrossBarDemo:
+    """2-input × 2-output crossbar demonstration."""
+
+    def __init__(self) -> None:
+        self.sim = Simulation()
+        self.clk = Clock(freq=10.0)
+
+        # Bursts from source 0 — first words are all even → go to out_0
+        packets_0: list[Words] = [
+            np.array([2, 3, 4], dtype=np.uint32),
+            np.array([10, 11], dtype=np.uint32),
+        ]
+        # Bursts from source 1 — first words are all odd → go to out_1
+        packets_1: list[Words] = [
+            np.array([1, 2, 3], dtype=np.uint32),
+            np.array([7, 8], dtype=np.uint32),
+        ]
+
+        self.src0 = Source(sim=self.sim, tx_packets=packets_0, tx_gap=0.1)
+        self.src1 = Source(sim=self.sim, tx_packets=packets_1, tx_gap=0.1)
+        self.sink0 = Sink(sim=self.sim)
+        self.sink1 = Sink(sim=self.sim)
+
+        self.xbar = CrossBarIF(
+            sim=self.sim,
+            clk=self.clk,
+            nports_in=2,
+            nports_out=2,
+            bitwidth=32,
+            route_fn=route_by_first_word,
+        )
+
+        self.xbar.bind("in_0", self.src0.input_ep)
+        self.xbar.bind("in_1", self.src1.input_ep)
+        self.xbar.bind("out_0", self.sink0.output_ep)
+        self.xbar.bind("out_1", self.sink1.output_ep)
+
+    def run_and_check(self) -> None:
+        self.sim.run_sim()
+
+        # sink0 should receive all bursts from src0 (even first word)
+        assert len(self.sink0.rx_packets) == 2, (
+            f"sink0 expected 2 packets, got {len(self.sink0.rx_packets)}"
+        )
+        for tx, rx in zip(self.src0.tx_packets, self.sink0.rx_packets, strict=True):
+            assert np.array_equal(tx, rx), f"sink0 data mismatch: {tx} != {rx}"
+
+        # sink1 should receive all bursts from src1 (odd first word)
+        assert len(self.sink1.rx_packets) == 2, (
+            f"sink1 expected 2 packets, got {len(self.sink1.rx_packets)}"
+        )
+        for tx, rx in zip(self.src1.tx_packets, self.sink1.rx_packets, strict=True):
+            assert np.array_equal(tx, rx), f"sink1 data mismatch: {tx} != {rx}"
+
+        print("All routing checks passed.")
+
+
+if __name__ == "__main__":
+    CrossBarDemo().run_and_check()

--- a/pysilicon/hw/interface.py
+++ b/pysilicon/hw/interface.py
@@ -63,7 +63,7 @@ class InterfaceEndpoint(SimObj):
     """
 
     comp : Component | None = field(init=False)
-    """The component that owns this endpoint. 
+    """The component that owns this endpoint.
     Set when the endpoint is added to a component.
     """
 
@@ -79,7 +79,7 @@ class InterfaceEndpoint(SimObj):
         super().__post_init__()
         self.comp = None
         self.interface = None
-   
+
 
     def bind(self, interface: Interface, ep_name: str) -> None:
         """
@@ -103,7 +103,7 @@ class Interface(SimObj):
     endpoint_names: tuple[str, ...] = field(init=False)
     endpoints: dict[str, InterfaceEndpoint | None] = field(init=False)
     """
-    Dictionary mapping valid endpoint names to the currently 
+    Dictionary mapping valid endpoint names to the currently
     bound endpoint (or None if unbound)."""
 
     def __init_subclass__(cls, **kwargs):
@@ -138,510 +138,39 @@ class StreamType(Enum):
 
 class TransferNotifyType(Enum):
     """
-    Methods for notifying the receiver side of interface during 
+    Methods for notifying the receiver side of interface during
     a transfer.
 
-    - end_only:  Only notify at the end of a transfer.  
-    This mode is ideal when the RX sides only begins processing after the 
+    - end_only:  Only notify at the end of a transfer.
+    This mode is ideal when the RX sides only begins processing after the
     full data burst is received.
 
     - begin_end: Notify at both the beginning and end of a transfer.
-    This mode is ideal when the RX side can begin processing as 
+    This mode is ideal when the RX side can begin processing as
     soon as the RX starts.
 
     - per_word: Notify for every beat/word transferred. This mode is
     the most cycle accurate but also the most expensive to simulate.
     The mode will not be initially supported.
     """
-    end_only = "end_only"  
-    begin_end = "begin_end" 
-    per_word = "per_word" 
+    end_only = "end_only"
+    begin_end = "begin_end"
+    per_word = "per_word"
 
 
-
-@dataclass
-class StreamIF(Interface):
-    """
-    A stream interface with 'master' (TX) and 'slave' (RX) sides.
-    """
-
-    stream_type: StreamType | None  =  None
-    """
-    The type of stream protocol to use for this interface.
-    If None, the stream type will be inferred from the types of 
-    endpoints that are bound to this interface.
-    """
-
-    bitwidth: int | None = None
-    """
-    The bitwidth of the stream interface. Must be positive.
-    If None, the bitwidth will be inferred from the types of endpoints"""
-
-    notify_type: TransferNotifyType | None = None  
-    """
-    The method for notifying the receiver side of transfers on 
-    this interface. If None, the notify type will be inferred 
-    from the slave endpoint.   """
-
-    clk : Clock | None = None
-    """
-    Clock signal for this stream interface.  Note that the 
-    clocks on the endpoints, if any, are not used so they may
-    be in a difference clock domain.
-    """
-
-    latency_init : float = 0.
-    """
-    Optional fixed latency in cycles to apply to all transfers 
-    on this interface.  The total latency for a transfer will be
-    
-        latency_init + nwords.
-    """
-
-    type_name = 'stream_if'
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-    def __post_init__(self) -> None:
-        self.endpoint_names = ('master', 'slave')
-        super().__post_init__()
-        if self.bitwidth is not None and self.bitwidth <= 0:
-            raise ValueError("bitwidth must be positive")
-        if self.clk is None:
-            raise ValueError("clock must be provided for StreamIF")
-
-    def write(
-            self, 
-            words: Words) -> ProcessGen:
-        """
-        Write a burst of word to the master (TX) side of this interface.
-        This will trigger the RX process on the slave side to process the 
-        incoming data.
-
-        Parameters
-        ----------
-        words : Words
-            The block of words to write. 
-        """
-        if self.endpoints['slave'] is None:
-            raise RuntimeError(f"Cannot write to AXI4-Stream interface '{self.name}' because the slave side is not bound to an endpoint")
-        slave = self.endpoints['slave']
-
-        # Wait until the end of the burst
-        cycles = self.latency_init + words.shape[0]
-        dly = cycles / self.clk.freq
-        if (dly > 0):
-            yield self.timeout(dly)
-
-        with slave.bus.request() as req:
-
-            # Wait for the stream to be available
-            yield req
-
-            # Get the number of words
-            nwords_rem = words.shape[0]
-
-            # Wait for at least one unit of space in the RX queue
-            # to be available
-            if (nwords_rem > 0):
-                yield slave.nrx.put(1)
-                nwords_rem -= 1
-
-            # First, we fill the RX queue
-            nwords_rx = min(nwords_rem, slave.nrx.capacity - slave.nrx.level)
-            if (nwords_rx > 0):
-                yield slave.nrx.put(nwords_rx)
-                nwords_rem -= nwords_rx
-            
-            # If there are remaining words, we fill the TX queue
-            if (nwords_rem > 0):
-                yield slave.ntx.put(nwords_rem)
-                nwords_rem = 0
-
-            # Finally, we write the words to the slave's data buffer
-            yield slave.data_buffer.put(words)
-
-       
-    def bind(self, ep_name: str, endpoint: InterfaceEndpoint) -> None:
-        if ep_name not in ['master', 'slave']:
-            raise KeyError(f"Stream interface only has 'master' and 'slave' sides, but got '{ep_name}'")
-        if ep_name == "slave" and not isinstance(endpoint, StreamIFSlave):
-            raise TypeError("slave side of StreamIF must bind to StreamIFSlave")
-        if ep_name == "master" and not isinstance(endpoint, StreamIFMaster):
-            raise TypeError("master side of StreamIF must bind to StreamIFMaster")
-        if self.stream_type is None:
-            self.stream_type = endpoint.stream_type
-        if endpoint.stream_type != self.stream_type:
-            raise ValueError(
-                f"Endpoint stream type {endpoint.stream_type.value} does not match interface stream type {self.stream_type.value}"
-            )
-        if (ep_name == "slave"):
-            if self.notify_type is None:
-                self.notify_type = endpoint.notify_type
-            if (self.notify_type != endpoint.notify_type):
-                raise ValueError(
-                    f"Endpoint notify type {endpoint.notify_type.value} does not match interface notify type {self.notify_type.value}"
-                )
-            if self.notify_type == TransferNotifyType.per_word:
-                raise NotImplementedError("per_word notify type is not yet supported")
-        if (self.bitwidth is None):
-            self.bitwidth = endpoint.bitwidth
-        if (self.bitwidth != endpoint.bitwidth):
-            raise ValueError(f"Endpoint bitwidth {endpoint.bitwidth} does not match interface bitwidth {self.bitwidth}")
-        if (self.stream_type is None):
-            self.stream_type = endpoint.stream_type
-        if (self.stream_type != endpoint.stream_type):
-            raise ValueError(f"Endpoint stream type {endpoint.stream_type.value} does not match interface stream type {self.stream_type.value}")  
-        super().bind(ep_name, endpoint)
-
+# ---------------------------------------------------------------------------
+# Shared base classes
+# ---------------------------------------------------------------------------
 
 @dataclass
-class StreamIFSlave(InterfaceEndpoint):
+class QueuedTransferIFSlave(InterfaceEndpoint):
     """
-    A stream slave (RX) endpoint that is realized as a function call.
-    """
-
-    stream_type: StreamType = StreamType.axi4
-    """The type of stream protocol to use for this interface."""
-
-    bitwidth: int = 32
-    """The bitwidth of the stream interface."""
-
-    notify_type: TransferNotifyType = TransferNotifyType.end_only
-    """The method for notifying the receiver side of transfers on 
-    this interface. """
-
-    rx_proc : RxProc | None = None
-    """
-    An optional process to call when words are written to the master (TX) 
-    side of the interface. 
-    """
-
-    notify_end_proc : Callable[[], ProcessGen] | None = None
-    """
-    An optional process to call at the end of a transfer when
-    `notify_type == begin_end`. This allows the slave to be notified of
-    both the beginning and end of a transfer. """
-
-    queue_size : int | None = None
-    """
-    An optional size for an internal transaction queue that 
-    buffers incoming transfers.  Size is in words. If None, the 
-    queue is unbounded.
-    """
-
-    data_buffer : simpy.Store = field(init=False)
-    """
-    Buffer for storing incoming bursts of words. Each entry is a 
-    burst/block of words, not just a single word.  
-    """
-
-    bus : simpy.Resource = field(init=False)
-    """
-    A resource used to indicate whether a transfer is currently being 
-    processed.  The write process will request this resource before writing
-    """
-
-    nrx : simpy.Container = field(init=False)
-    """Number of pending words in the RX queue"""
-
-    ntx : simpy.Container = field(init=False)
-    """Number of pending words in the TX queue."""
-
-    type_name = 'stream_if_slave'
-
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-   
-        self.data_buffer = simpy.Store(self.env)
-        self.bus = simpy.Resource(self.env, capacity=1)
-        if self.queue_size is not None:
-            capacity = self.queue_size
-        else:            
-            capacity = float('inf')
-        self.nrx = simpy.Container(self.env, init=0,capacity=capacity)
-        self.ntx = simpy.Container(self.env, init=0)
-
-
-    def run_proc(self) -> ProcessGen:
-        """
-        Continual run loop for the slave to processing incoming transfers
-        """
-        while True:
-            # Wait for the block of words to be available
-            words = yield self.data_buffer.get()
-            nwords = words.shape[0]
-                
-
-            # Update the queue state.  Frst, we pull from the TX queue
-            btx = min(nwords, self.ntx.level)
-            if (btx > 0):
-                yield self.ntx.get(btx)
-            
-            # Pull from the RX queue for the remaining words
-            brx = nwords-btx
-            if (brx > 0):
-                if (self.nrx.level < brx):
-                    raise RuntimeError(f"Not enough words in RX queue to read {nwords} words. RX queue level: {self.nrx.level}, TX queue level: {self.ntx.level}")
-                yield self.nrx.get(brx)
-
-            if self.rx_proc is not None:
-                yield self.env.process(self.rx_proc(words))
-        
-
-@dataclass
-class StreamIFMaster(InterfaceEndpoint):
-    """
-    A stream master (TX) endpoint that provides a write function.
-    """
-
-    stream_type: StreamType = StreamType.axi4
-    """The type of stream protocol to use for this interface."""
-
-    bitwidth: int = 32
-    """The bitwidth of the stream interface."""
-
-    notify_type: TransferNotifyType = TransferNotifyType.end_only
-    """
-    The method for notifying the receiver side of transfers on 
-    this interface. """
-
-    type_name = 'stream_if_master'
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-    
-
-    def write(self, words: Words) -> ProcessGen:
-        """
-        Write a burst of word to the master (TX) side of this interface.
-        The write will block until the slave side has sufficient RX
-        queue capacity.
-
-        Parameters
-        ----------
-        words : Words
-            The block of words to write.
-
-        Example
-        -------
-        ```
-        words = np.array([1, 2, 3], dtype=np.uint32)
-        yield env.process( master_ep.write(words) )
-        ```
-        """
-        if self.interface is None:
-            raise RuntimeError(f"Cannot write to AXI4-Stream master endpoint because it is not bound to an interface")
-
-        yield self.process( self.interface.write(words) )
-
-
-@dataclass
-class CrossBarIF(Interface):
-    """
-    A crossbar interface connecting ``nports_in`` input ports to ``nports_out``
-    output ports.  Each transfer arriving at an input port is routed to exactly
-    one output port via a configurable ``route_fn``.
-
-    Endpoint names
-    --------------
-    ``'in_0'``, ``'in_1'``, … ``'in_{nports_in-1}'``  — bind :class:`CrossBarIFInput`
-    ``'out_0'``, ``'out_1'``, … ``'out_{nports_out-1}'`` — bind :class:`CrossBarIFOutput`
-    """
-
-    nports_in: int = 2
-    """Number of input ports."""
-
-    nports_out: int = 2
-    """Number of output ports."""
-
-    bitwidth: int | None = None
-    """Data bitwidth. Inferred from the first endpoint bound if ``None``."""
-
-    clk: Clock | None = None
-    """Clock signal for this crossbar interface."""
-
-    latency_init: float = 0.
-    """Fixed latency in cycles added to every transfer (modelled as ``(latency_init + nwords) / clk.freq`` seconds)."""
-
-    route_fn: Callable[[Words, int], int] | None = None
-    """
-    Routing function ``(words, port_in) -> port_out``.
-    If ``None``, the default mapping ``port_out = port_in % nports_out`` is used.
-    """
-
-    type_name = 'crossbar_if'
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-    def __post_init__(self) -> None:
-        self.endpoint_names = tuple(
-            [f'in_{i}' for i in range(self.nports_in)] +
-            [f'out_{j}' for j in range(self.nports_out)]
-        )
-        super().__post_init__()
-        if self.nports_in < 1:
-            raise ValueError("nports_in must be at least 1")
-        if self.nports_out < 1:
-            raise ValueError("nports_out must be at least 1")
-        if self.bitwidth is not None and self.bitwidth <= 0:
-            raise ValueError("bitwidth must be positive")
-        if self.clk is None:
-            raise ValueError("clock must be provided for CrossBarIF")
-
-    def write(self, words: Words, port_in: int) -> ProcessGen:
-        """
-        Route words arriving at ``port_in`` to the appropriate output port.
-
-        Parameters
-        ----------
-        words : Words
-            The block of words to transfer.
-        port_in : int
-            Index of the input port the words arrived on.
-        """
-        if port_in < 0 or port_in >= self.nports_in:
-            raise ValueError(f"port_in {port_in} out of range [0, {self.nports_in})")
-
-        port_out = self.route_fn(words, port_in) if self.route_fn is not None else port_in % self.nports_out
-
-        if port_out < 0 or port_out >= self.nports_out:
-            raise ValueError(
-                f"route_fn returned port_out {port_out} which is out of range [0, {self.nports_out})"
-            )
-
-        out_ep = self.endpoints[f'out_{port_out}']
-        if out_ep is None:
-            raise RuntimeError(f"Output port out_{port_out} is not bound on crossbar '{self.name}'")
-
-        cycles = self.latency_init + words.shape[0]
-        dly = cycles / self.clk.freq
-        if dly > 0:
-            yield self.timeout(dly)
-
-        with out_ep.bus.request() as req:
-            yield req
-
-            nwords_rem = words.shape[0]
-
-            if nwords_rem > 0:
-                yield out_ep.nrx.put(1)
-                nwords_rem -= 1
-
-            nwords_rx = min(nwords_rem, out_ep.nrx.capacity - out_ep.nrx.level)
-            if nwords_rx > 0:
-                yield out_ep.nrx.put(nwords_rx)
-                nwords_rem -= nwords_rx
-
-            if nwords_rem > 0:
-                yield out_ep.ntx.put(nwords_rem)
-
-            yield out_ep.data_buffer.put(words)
-
-    def bind(self, ep_name: str, endpoint: InterfaceEndpoint) -> None:
-        if ep_name.startswith('in_'):
-            try:
-                idx = int(ep_name[3:])
-            except ValueError:
-                raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
-            if idx >= self.nports_in:
-                raise KeyError(
-                    f"Input port index {idx} is out of range for crossbar with {self.nports_in} input(s)"
-                )
-            if not isinstance(endpoint, CrossBarIFInput):
-                raise TypeError("Input sides of CrossBarIF must bind to CrossBarIFInput")
-        elif ep_name.startswith('out_'):
-            try:
-                idx = int(ep_name[4:])
-            except ValueError:
-                raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
-            if idx >= self.nports_out:
-                raise KeyError(
-                    f"Output port index {idx} is out of range for crossbar with {self.nports_out} output(s)"
-                )
-            if not isinstance(endpoint, CrossBarIFOutput):
-                raise TypeError("Output sides of CrossBarIF must bind to CrossBarIFOutput")
-        else:
-            raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
-
-        if self.bitwidth is None:
-            self.bitwidth = endpoint.bitwidth
-        if self.bitwidth != endpoint.bitwidth:
-            raise ValueError(
-                f"Endpoint bitwidth {endpoint.bitwidth} does not match interface bitwidth {self.bitwidth}"
-            )
-
-        if ep_name.startswith('in_'):
-            endpoint.port_in = idx
-
-        super().bind(ep_name, endpoint)
-
-
-@dataclass
-class CrossBarIFInput(InterfaceEndpoint):
-    """
-    An input endpoint for a :class:`CrossBarIF`.
-
-    An upstream master calls :meth:`write` to push a burst of words into the
-    crossbar; the crossbar's routing function determines which output port
-    receives the data.
-    """
-
-    bitwidth: int = 32
-    """Bitwidth of the data words."""
-
-    port_in: int = field(init=False)
-    """Index of the input port this endpoint is bound to. Set by :meth:`CrossBarIF.bind`."""
-
-    type_name = 'crossbar_if_input'
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self.port_in = -1
-
-    def write(self, words: Words) -> ProcessGen:
-        """
-        Write a burst of words into the crossbar at this input port.
-
-        Parameters
-        ----------
-        words : Words
-            The block of words to write.
-
-        Example
-        -------
-        ```
-        words = np.array([1, 2, 3], dtype=np.uint32)
-        yield env.process( input_ep.write(words) )
-        ```
-        """
-        if self.interface is None:
-            raise RuntimeError(
-                "Cannot write: CrossBarIFInput is not bound to a CrossBarIF"
-            )
-        yield self.process(self.interface.write(words, self.port_in))
-
-
-@dataclass
-class CrossBarIFOutput(InterfaceEndpoint):
-    """
-    An output endpoint for a :class:`CrossBarIF`.
-
-    Words routed to this port are buffered internally and delivered to the
-    optional :attr:`rx_proc` callback, mirroring the behaviour of
-    :class:`StreamIFSlave`.
+    Base class for slave/output endpoints that buffer incoming word bursts.
+
+    Provides the SimPy resources (``data_buffer``, ``bus``, ``nrx``, ``ntx``)
+    and the ``run_proc`` loop shared by :class:`StreamIFSlave` and
+    :class:`CrossBarIFOutput`.  Protocol-specific fields (stream type, notify
+    type, etc.) are added in subclasses.
     """
 
     bitwidth: int = 32
@@ -651,21 +180,19 @@ class CrossBarIFOutput(InterfaceEndpoint):
     """Optional process called with each received burst of words."""
 
     queue_size: int | None = None
-    """Optional RX queue depth in words. ``None`` means unbounded."""
+    """RX queue depth in words.  ``None`` means unbounded."""
 
     data_buffer: simpy.Store = field(init=False)
     """Buffer holding incoming bursts; each entry is one full burst."""
 
     bus: simpy.Resource = field(init=False)
-    """Serialises concurrent writes from different input ports."""
+    """Serialises concurrent writes to this endpoint."""
 
     nrx: simpy.Container = field(init=False)
     """Number of words pending in the RX queue."""
 
     ntx: simpy.Container = field(init=False)
     """Number of words pending in the TX (overflow) queue."""
-
-    type_name = 'crossbar_if_output'
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -699,3 +226,411 @@ class CrossBarIFOutput(InterfaceEndpoint):
 
             if self.rx_proc is not None:
                 yield self.env.process(self.rx_proc(words))
+
+
+@dataclass
+class QueuedTransferIFMaster(InterfaceEndpoint):
+    """
+    Base class for master/input endpoints that push word bursts into an interface.
+
+    Provides a ``write`` method that dispatches to the bound interface.
+    Subclasses override :meth:`_make_write_call` when the interface's
+    ``write`` signature differs (e.g. :class:`CrossBarIFInput` passes
+    ``port_in``).
+    """
+
+    bitwidth: int = 32
+    """Bitwidth of the data words."""
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def _make_write_call(self, words: Words) -> ProcessGen:
+        """Return the generator that writes *words* to the bound interface."""
+        return self.interface.write(words)
+
+    def write(self, words: Words) -> ProcessGen:
+        """
+        Write a burst of words through the bound interface.
+
+        Parameters
+        ----------
+        words : Words
+            The block of words to write.
+
+        Example
+        -------
+        ```
+        words = np.array([1, 2, 3], dtype=np.uint32)
+        yield env.process( master_ep.write(words) )
+        ```
+        """
+        if self.interface is None:
+            raise RuntimeError(
+                f"Cannot write: {type(self).__name__} is not bound to an interface"
+            )
+        yield self.process(self._make_write_call(words))
+
+
+@dataclass
+class QueuedTransferIF(Interface):
+    """
+    Base class for interfaces that transfer queued word bursts with optional latency.
+
+    Provides shared ``bitwidth``, ``clk``, and ``latency_init`` fields, a
+    ``_push_to_endpoint`` generator for the common write path, and
+    ``_validate_and_set_bitwidth`` for bind-time checking.  Protocol-specific
+    routing and endpoint-type validation are implemented in subclasses.
+    """
+
+    bitwidth: int | None = None
+    """
+    Data bitwidth.  Inferred from the first bound endpoint when ``None``.
+    """
+
+    clk: Clock | None = None
+    """Clock signal for this interface."""
+
+    latency_init: float = 0.
+    """
+    Fixed latency in cycles added to every transfer.  Total transfer time is
+    ``(latency_init + nwords) / clk.freq`` seconds.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        # endpoint_names must be set by the concrete subclass before calling super()
+        super().__post_init__()
+        if self.bitwidth is not None and self.bitwidth <= 0:
+            raise ValueError("bitwidth must be positive")
+        if self.clk is None:
+            raise ValueError(f"clock must be provided for {type(self).__name__}")
+
+    def _validate_and_set_bitwidth(self, endpoint: InterfaceEndpoint) -> None:
+        """Infer or check that *endpoint* bitwidth matches the interface bitwidth."""
+        if self.bitwidth is None:
+            self.bitwidth = endpoint.bitwidth
+        if self.bitwidth != endpoint.bitwidth:
+            raise ValueError(
+                f"Endpoint bitwidth {endpoint.bitwidth} does not match "
+                f"interface bitwidth {self.bitwidth}"
+            )
+
+    def _push_to_endpoint(
+        self, ep: QueuedTransferIFSlave, words: Words
+    ) -> ProcessGen:
+        """
+        Model transfer latency then push *words* into *ep*'s buffer.
+
+        This is the shared write path used by all ``QueuedTransferIF`` subclasses.
+        """
+        cycles = self.latency_init + words.shape[0]
+        dly = cycles / self.clk.freq
+        if dly > 0:
+            yield self.timeout(dly)
+
+        with ep.bus.request() as req:
+            yield req
+
+            nwords_rem = words.shape[0]
+
+            if nwords_rem > 0:
+                yield ep.nrx.put(1)
+                nwords_rem -= 1
+
+            nwords_rx = min(nwords_rem, ep.nrx.capacity - ep.nrx.level)
+            if nwords_rx > 0:
+                yield ep.nrx.put(nwords_rx)
+                nwords_rem -= nwords_rx
+
+            if nwords_rem > 0:
+                yield ep.ntx.put(nwords_rem)
+
+            yield ep.data_buffer.put(words)
+
+
+# ---------------------------------------------------------------------------
+# Stream interface
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StreamIF(QueuedTransferIF):
+    """
+    A stream interface with 'master' (TX) and 'slave' (RX) sides.
+    """
+
+    stream_type: StreamType | None = None
+    """
+    The type of stream protocol to use for this interface.
+    If None, the stream type will be inferred from the types of
+    endpoints that are bound to this interface.
+    """
+
+    notify_type: TransferNotifyType | None = None
+    """
+    The method for notifying the receiver side of transfers on
+    this interface. If None, the notify type will be inferred
+    from the slave endpoint.
+    """
+
+    type_name = 'stream_if'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        self.endpoint_names = ('master', 'slave')
+        super().__post_init__()
+
+    def write(self, words: Words) -> ProcessGen:
+        """
+        Write a burst of words to the master (TX) side of this interface.
+        This will trigger the RX process on the slave side to process the
+        incoming data.
+
+        Parameters
+        ----------
+        words : Words
+            The block of words to write.
+        """
+        if self.endpoints['slave'] is None:
+            raise RuntimeError(
+                f"Cannot write to StreamIF '{self.name}' because the slave side is not bound"
+            )
+        slave = self.endpoints['slave']
+        yield from self._push_to_endpoint(slave, words)
+
+    def bind(self, ep_name: str, endpoint: InterfaceEndpoint) -> None:
+        if ep_name not in ('master', 'slave'):
+            raise KeyError(
+                f"Stream interface only has 'master' and 'slave' sides, but got '{ep_name}'"
+            )
+        if ep_name == "slave" and not isinstance(endpoint, StreamIFSlave):
+            raise TypeError("slave side of StreamIF must bind to StreamIFSlave")
+        if ep_name == "master" and not isinstance(endpoint, StreamIFMaster):
+            raise TypeError("master side of StreamIF must bind to StreamIFMaster")
+        if self.stream_type is None:
+            self.stream_type = endpoint.stream_type
+        if endpoint.stream_type != self.stream_type:
+            raise ValueError(
+                f"Endpoint stream type {endpoint.stream_type.value} does not match "
+                f"interface stream type {self.stream_type.value}"
+            )
+        if ep_name == "slave":
+            if self.notify_type is None:
+                self.notify_type = endpoint.notify_type
+            if self.notify_type != endpoint.notify_type:
+                raise ValueError(
+                    f"Endpoint notify type {endpoint.notify_type.value} does not match "
+                    f"interface notify type {self.notify_type.value}"
+                )
+            if self.notify_type == TransferNotifyType.per_word:
+                raise NotImplementedError("per_word notify type is not yet supported")
+        self._validate_and_set_bitwidth(endpoint)
+        super().bind(ep_name, endpoint)
+
+
+@dataclass
+class StreamIFSlave(QueuedTransferIFSlave):
+    """
+    A stream slave (RX) endpoint that is realized as a function call.
+    """
+
+    stream_type: StreamType = StreamType.axi4
+    """The type of stream protocol to use for this interface."""
+
+    notify_type: TransferNotifyType = TransferNotifyType.end_only
+    """The method for notifying the receiver side of transfers on this interface."""
+
+    notify_end_proc: Callable[[], ProcessGen] | None = None
+    """
+    An optional process to call at the end of a transfer when
+    `notify_type == begin_end`. This allows the slave to be notified of
+    both the beginning and end of a transfer.
+    """
+
+    type_name = 'stream_if_slave'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+
+@dataclass
+class StreamIFMaster(QueuedTransferIFMaster):
+    """
+    A stream master (TX) endpoint that provides a write function.
+    """
+
+    stream_type: StreamType = StreamType.axi4
+    """The type of stream protocol to use for this interface."""
+
+    notify_type: TransferNotifyType = TransferNotifyType.end_only
+    """
+    The method for notifying the receiver side of transfers on
+    this interface.
+    """
+
+    type_name = 'stream_if_master'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Crossbar interface
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CrossBarIF(QueuedTransferIF):
+    """
+    A crossbar interface connecting ``nports_in`` input ports to ``nports_out``
+    output ports.  Each transfer arriving at an input port is routed to exactly
+    one output port via a configurable ``route_fn``.
+
+    Endpoint names
+    --------------
+    ``'in_0'``, ``'in_1'``, … ``'in_{nports_in-1}'``  — bind :class:`CrossBarIFInput`
+    ``'out_0'``, ``'out_1'``, … ``'out_{nports_out-1}'`` — bind :class:`CrossBarIFOutput`
+    """
+
+    nports_in: int = 2
+    """Number of input ports."""
+
+    nports_out: int = 2
+    """Number of output ports."""
+
+    route_fn: Callable[[Words, int], int] | None = None
+    """
+    Routing function ``(words, port_in) -> port_out``.
+    If ``None``, the default mapping ``port_out = port_in % nports_out`` is used.
+    """
+
+    type_name = 'crossbar_if'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        # Validate port counts before building endpoint_names (used by super().__post_init__)
+        if self.nports_in < 1:
+            raise ValueError("nports_in must be at least 1")
+        if self.nports_out < 1:
+            raise ValueError("nports_out must be at least 1")
+        self.endpoint_names = tuple(
+            [f'in_{i}' for i in range(self.nports_in)] +
+            [f'out_{j}' for j in range(self.nports_out)]
+        )
+        super().__post_init__()
+
+    def write(self, words: Words, port_in: int) -> ProcessGen:
+        """
+        Route words arriving at ``port_in`` to the appropriate output port.
+
+        Parameters
+        ----------
+        words : Words
+            The block of words to transfer.
+        port_in : int
+            Index of the input port the words arrived on.
+        """
+        if port_in < 0 or port_in >= self.nports_in:
+            raise ValueError(f"port_in {port_in} out of range [0, {self.nports_in})")
+
+        port_out = (
+            self.route_fn(words, port_in)
+            if self.route_fn is not None
+            else port_in % self.nports_out
+        )
+
+        if port_out < 0 or port_out >= self.nports_out:
+            raise ValueError(
+                f"route_fn returned port_out {port_out} which is out of range "
+                f"[0, {self.nports_out})"
+            )
+
+        out_ep = self.endpoints[f'out_{port_out}']
+        if out_ep is None:
+            raise RuntimeError(
+                f"Output port out_{port_out} is not bound on crossbar '{self.name}'"
+            )
+
+        yield from self._push_to_endpoint(out_ep, words)
+
+    def bind(self, ep_name: str, endpoint: InterfaceEndpoint) -> None:
+        if ep_name.startswith('in_'):
+            try:
+                idx = int(ep_name[3:])
+            except ValueError:
+                raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
+            if idx >= self.nports_in:
+                raise KeyError(
+                    f"Input port index {idx} is out of range for crossbar with "
+                    f"{self.nports_in} input(s)"
+                )
+            if not isinstance(endpoint, CrossBarIFInput):
+                raise TypeError("Input sides of CrossBarIF must bind to CrossBarIFInput")
+        elif ep_name.startswith('out_'):
+            try:
+                idx = int(ep_name[4:])
+            except ValueError:
+                raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
+            if idx >= self.nports_out:
+                raise KeyError(
+                    f"Output port index {idx} is out of range for crossbar with "
+                    f"{self.nports_out} output(s)"
+                )
+            if not isinstance(endpoint, CrossBarIFOutput):
+                raise TypeError("Output sides of CrossBarIF must bind to CrossBarIFOutput")
+        else:
+            raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
+
+        self._validate_and_set_bitwidth(endpoint)
+
+        if ep_name.startswith('in_'):
+            endpoint.port_in = idx
+
+        super().bind(ep_name, endpoint)
+
+
+@dataclass
+class CrossBarIFInput(QueuedTransferIFMaster):
+    """
+    An input endpoint for a :class:`CrossBarIF`.
+
+    An upstream master calls :meth:`write` to push a burst of words into the
+    crossbar; the crossbar's routing function determines which output port
+    receives the data.
+    """
+
+    port_in: int = field(init=False)
+    """Index of the input port this endpoint is bound to. Set by :meth:`CrossBarIF.bind`."""
+
+    type_name = 'crossbar_if_input'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.port_in = -1
+
+    def _make_write_call(self, words: Words) -> ProcessGen:
+        return self.interface.write(words, self.port_in)
+
+
+@dataclass
+class CrossBarIFOutput(QueuedTransferIFSlave):
+    """
+    An output endpoint for a :class:`CrossBarIF`.
+
+    Words routed to this port are buffered internally and delivered to the
+    optional :attr:`rx_proc` callback, mirroring the behaviour of
+    :class:`StreamIFSlave`.
+    """
+
+    type_name = 'crossbar_if_output'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)

--- a/pysilicon/hw/interface.py
+++ b/pysilicon/hw/interface.py
@@ -423,14 +423,14 @@ class StreamIFMaster(InterfaceEndpoint):
     def write(self, words: Words) -> ProcessGen:
         """
         Write a burst of word to the master (TX) side of this interface.
-        The write will block until the slave side has sufficient RX 
+        The write will block until the slave side has sufficient RX
         queue capacity.
 
         Parameters
         ----------
         words : Words
-            The block of words to write. 
-        
+            The block of words to write.
+
         Example
         -------
         ```
@@ -440,6 +440,262 @@ class StreamIFMaster(InterfaceEndpoint):
         """
         if self.interface is None:
             raise RuntimeError(f"Cannot write to AXI4-Stream master endpoint because it is not bound to an interface")
-        
+
         yield self.process( self.interface.write(words) )
-        
+
+
+@dataclass
+class CrossBarIF(Interface):
+    """
+    A crossbar interface connecting ``nports_in`` input ports to ``nports_out``
+    output ports.  Each transfer arriving at an input port is routed to exactly
+    one output port via a configurable ``route_fn``.
+
+    Endpoint names
+    --------------
+    ``'in_0'``, ``'in_1'``, … ``'in_{nports_in-1}'``  — bind :class:`CrossBarIFInput`
+    ``'out_0'``, ``'out_1'``, … ``'out_{nports_out-1}'`` — bind :class:`CrossBarIFOutput`
+    """
+
+    nports_in: int = 2
+    """Number of input ports."""
+
+    nports_out: int = 2
+    """Number of output ports."""
+
+    bitwidth: int | None = None
+    """Data bitwidth. Inferred from the first endpoint bound if ``None``."""
+
+    clk: Clock | None = None
+    """Clock signal for this crossbar interface."""
+
+    latency_init: float = 0.
+    """Fixed latency in cycles added to every transfer (modelled as ``(latency_init + nwords) / clk.freq`` seconds)."""
+
+    route_fn: Callable[[Words, int], int] | None = None
+    """
+    Routing function ``(words, port_in) -> port_out``.
+    If ``None``, the default mapping ``port_out = port_in % nports_out`` is used.
+    """
+
+    type_name = 'crossbar_if'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        self.endpoint_names = tuple(
+            [f'in_{i}' for i in range(self.nports_in)] +
+            [f'out_{j}' for j in range(self.nports_out)]
+        )
+        super().__post_init__()
+        if self.nports_in < 1:
+            raise ValueError("nports_in must be at least 1")
+        if self.nports_out < 1:
+            raise ValueError("nports_out must be at least 1")
+        if self.bitwidth is not None and self.bitwidth <= 0:
+            raise ValueError("bitwidth must be positive")
+        if self.clk is None:
+            raise ValueError("clock must be provided for CrossBarIF")
+
+    def write(self, words: Words, port_in: int) -> ProcessGen:
+        """
+        Route words arriving at ``port_in`` to the appropriate output port.
+
+        Parameters
+        ----------
+        words : Words
+            The block of words to transfer.
+        port_in : int
+            Index of the input port the words arrived on.
+        """
+        if port_in < 0 or port_in >= self.nports_in:
+            raise ValueError(f"port_in {port_in} out of range [0, {self.nports_in})")
+
+        port_out = self.route_fn(words, port_in) if self.route_fn is not None else port_in % self.nports_out
+
+        if port_out < 0 or port_out >= self.nports_out:
+            raise ValueError(
+                f"route_fn returned port_out {port_out} which is out of range [0, {self.nports_out})"
+            )
+
+        out_ep = self.endpoints[f'out_{port_out}']
+        if out_ep is None:
+            raise RuntimeError(f"Output port out_{port_out} is not bound on crossbar '{self.name}'")
+
+        cycles = self.latency_init + words.shape[0]
+        dly = cycles / self.clk.freq
+        if dly > 0:
+            yield self.timeout(dly)
+
+        with out_ep.bus.request() as req:
+            yield req
+
+            nwords_rem = words.shape[0]
+
+            if nwords_rem > 0:
+                yield out_ep.nrx.put(1)
+                nwords_rem -= 1
+
+            nwords_rx = min(nwords_rem, out_ep.nrx.capacity - out_ep.nrx.level)
+            if nwords_rx > 0:
+                yield out_ep.nrx.put(nwords_rx)
+                nwords_rem -= nwords_rx
+
+            if nwords_rem > 0:
+                yield out_ep.ntx.put(nwords_rem)
+
+            yield out_ep.data_buffer.put(words)
+
+    def bind(self, ep_name: str, endpoint: InterfaceEndpoint) -> None:
+        if ep_name.startswith('in_'):
+            try:
+                idx = int(ep_name[3:])
+            except ValueError:
+                raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
+            if idx >= self.nports_in:
+                raise KeyError(
+                    f"Input port index {idx} is out of range for crossbar with {self.nports_in} input(s)"
+                )
+            if not isinstance(endpoint, CrossBarIFInput):
+                raise TypeError("Input sides of CrossBarIF must bind to CrossBarIFInput")
+        elif ep_name.startswith('out_'):
+            try:
+                idx = int(ep_name[4:])
+            except ValueError:
+                raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
+            if idx >= self.nports_out:
+                raise KeyError(
+                    f"Output port index {idx} is out of range for crossbar with {self.nports_out} output(s)"
+                )
+            if not isinstance(endpoint, CrossBarIFOutput):
+                raise TypeError("Output sides of CrossBarIF must bind to CrossBarIFOutput")
+        else:
+            raise KeyError(f"Invalid endpoint name '{ep_name}' for CrossBarIF")
+
+        if self.bitwidth is None:
+            self.bitwidth = endpoint.bitwidth
+        if self.bitwidth != endpoint.bitwidth:
+            raise ValueError(
+                f"Endpoint bitwidth {endpoint.bitwidth} does not match interface bitwidth {self.bitwidth}"
+            )
+
+        if ep_name.startswith('in_'):
+            endpoint.port_in = idx
+
+        super().bind(ep_name, endpoint)
+
+
+@dataclass
+class CrossBarIFInput(InterfaceEndpoint):
+    """
+    An input endpoint for a :class:`CrossBarIF`.
+
+    An upstream master calls :meth:`write` to push a burst of words into the
+    crossbar; the crossbar's routing function determines which output port
+    receives the data.
+    """
+
+    bitwidth: int = 32
+    """Bitwidth of the data words."""
+
+    port_in: int = field(init=False)
+    """Index of the input port this endpoint is bound to. Set by :meth:`CrossBarIF.bind`."""
+
+    type_name = 'crossbar_if_input'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.port_in = -1
+
+    def write(self, words: Words) -> ProcessGen:
+        """
+        Write a burst of words into the crossbar at this input port.
+
+        Parameters
+        ----------
+        words : Words
+            The block of words to write.
+
+        Example
+        -------
+        ```
+        words = np.array([1, 2, 3], dtype=np.uint32)
+        yield env.process( input_ep.write(words) )
+        ```
+        """
+        if self.interface is None:
+            raise RuntimeError(
+                "Cannot write: CrossBarIFInput is not bound to a CrossBarIF"
+            )
+        yield self.process(self.interface.write(words, self.port_in))
+
+
+@dataclass
+class CrossBarIFOutput(InterfaceEndpoint):
+    """
+    An output endpoint for a :class:`CrossBarIF`.
+
+    Words routed to this port are buffered internally and delivered to the
+    optional :attr:`rx_proc` callback, mirroring the behaviour of
+    :class:`StreamIFSlave`.
+    """
+
+    bitwidth: int = 32
+    """Bitwidth of the data words."""
+
+    rx_proc: RxProc | None = None
+    """Optional process called with each received burst of words."""
+
+    queue_size: int | None = None
+    """Optional RX queue depth in words. ``None`` means unbounded."""
+
+    data_buffer: simpy.Store = field(init=False)
+    """Buffer holding incoming bursts; each entry is one full burst."""
+
+    bus: simpy.Resource = field(init=False)
+    """Serialises concurrent writes from different input ports."""
+
+    nrx: simpy.Container = field(init=False)
+    """Number of words pending in the RX queue."""
+
+    ntx: simpy.Container = field(init=False)
+    """Number of words pending in the TX (overflow) queue."""
+
+    type_name = 'crossbar_if_output'
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.data_buffer = simpy.Store(self.env)
+        self.bus = simpy.Resource(self.env, capacity=1)
+        capacity = self.queue_size if self.queue_size is not None else float('inf')
+        self.nrx = simpy.Container(self.env, init=0, capacity=capacity)
+        self.ntx = simpy.Container(self.env, init=0)
+
+    def run_proc(self) -> ProcessGen:
+        """Continually processes incoming data bursts and invokes :attr:`rx_proc`."""
+        while True:
+            words = yield self.data_buffer.get()
+            nwords = words.shape[0]
+
+            btx = min(nwords, self.ntx.level)
+            if btx > 0:
+                yield self.ntx.get(btx)
+
+            brx = nwords - btx
+            if brx > 0:
+                if self.nrx.level < brx:
+                    raise RuntimeError(
+                        f"Not enough words in RX queue to read {nwords} words. "
+                        f"RX queue level: {self.nrx.level}, TX queue level: {self.ntx.level}"
+                    )
+                yield self.nrx.get(brx)
+
+            if self.rx_proc is not None:
+                yield self.env.process(self.rx_proc(words))

--- a/tests/hw/test_crossbar_interface.py
+++ b/tests/hw/test_crossbar_interface.py
@@ -1,3 +1,9 @@
+"""
+CrossBarIF-specific tests: routing behaviour and topology validation.
+
+Timing / data-correctness tests shared with StreamIF are in test_interface.py
+(parameterised over both StreamScenario and CrossBarScenario11).
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -11,19 +17,18 @@ from pysilicon.hw.interface import (
     CrossBarIF,
     CrossBarIFInput,
     CrossBarIFOutput,
-    StreamIFSlave,
     Words,
 )
 from pysilicon.simulation.simulation import Simulation
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Multi-port routing harness
 # ---------------------------------------------------------------------------
 
 class CrossBarScenario:
     """
-    Test harness for a single CrossBarIF with configurable topology.
+    Test harness for a CrossBarIF with configurable topology.
 
     Parameters
     ----------
@@ -36,7 +41,7 @@ class CrossBarScenario:
     rx_processing_delay : float
         SimPy time each output spends processing one burst.
     clk_freq : float
-        Clock frequency in Hz (used as simulated time = words / freq).
+        Clock frequency in Hz.
     """
 
     def __init__(
@@ -119,7 +124,6 @@ class CrossBarScenario:
 
             self.env.process(_proc())
 
-        # Run the crossbar output loops
         for out in self.outputs:
             self.env.process(out.run_proc())
 
@@ -131,7 +135,7 @@ class CrossBarScenario:
 
 
 # ---------------------------------------------------------------------------
-# Data-correctness tests
+# Routing tests
 # ---------------------------------------------------------------------------
 
 def test_identity_routing_2x2():
@@ -145,7 +149,6 @@ def test_identity_routing_2x2():
 
     assert len(sc.received[0]) == 1
     npt.assert_array_equal(sc.received[0][0], pkts0[0])
-
     assert len(sc.received[1]) == 1
     npt.assert_array_equal(sc.received[1][0], pkts1[0])
 
@@ -182,18 +185,15 @@ def test_route_fn_based_on_data():
 
     assert len(sc.received[0]) == 1
     npt.assert_array_equal(sc.received[0][0], even_pkt)
-
     assert len(sc.received[1]) == 1
     npt.assert_array_equal(sc.received[1][0], odd_pkt)
 
 
 def test_multiple_packets_single_path():
-    """Multiple bursts on a single 1x1 path are all delivered in order."""
+    """Multiple bursts on a single 1×1 path are all delivered in order."""
     sc = CrossBarScenario(nports_in=1, nports_out=1)
 
-    packets = [
-        np.array([i, i + 1], dtype=np.uint32) for i in range(0, 10, 2)
-    ]
+    packets = [np.array([i, i + 1], dtype=np.uint32) for i in range(0, 10, 2)]
     sc.run({0: packets})
 
     assert len(sc.received[0]) == len(packets)
@@ -202,92 +202,7 @@ def test_multiple_packets_single_path():
 
 
 # ---------------------------------------------------------------------------
-# Timing tests  (clock freq = 1 Hz so cycles == seconds)
-# ---------------------------------------------------------------------------
-
-def test_timing_single_input_no_backpressure():
-    """
-    Single path, three packets with a gap.  Write-end time equals nwords
-    (with freq=1 and latency_init=0).
-    """
-    sc = CrossBarScenario(nports_in=1, nports_out=1, clk_freq=1.0)
-
-    packets = [
-        np.array([1, 2, 3], dtype=np.uint32),   # 3 words  -> t=3
-        np.array([10, 11], dtype=np.uint32),     # 2 words  -> t=3+1(gap)+2=6
-        np.array([99], dtype=np.uint32),          # 1 word   -> t=6+1+1=8
-    ]
-    tx_gap = 1.0
-    write_end_times: list[float] = []
-
-    def _proc():
-        for pkt in packets:
-            yield sc.env.process(sc.inputs[0].write(pkt))
-            write_end_times.append(sc.env.now)
-            yield sc.env.timeout(tx_gap)
-
-    done = sc.env.event()
-
-    def _outer():
-        yield from _proc()
-        done.succeed()
-
-    sc.env.process(_outer())
-    for out in sc.outputs:
-        sc.env.process(out.run_proc())
-    sc.env.run(until=done)
-
-    assert write_end_times == pytest.approx([3.0, 6.0, 8.0])
-    assert sc.rx_start_times[0] == pytest.approx([3.0, 6.0, 8.0])
-
-
-def test_timing_backpressure():
-    """
-    Bounded queue forces the sender to stall when the receiver is slow.
-    Mirrors the shallow-queue test from test_interface.py.
-    """
-    sc = CrossBarScenario(
-        nports_in=1,
-        nports_out=1,
-        queue_sizes=[2],
-        rx_processing_delay=5.0,
-        clk_freq=1.0,
-    )
-
-    packets = [
-        np.array([1, 2], dtype=np.uint32),
-        np.array([3, 4], dtype=np.uint32),
-        np.array([5, 6], dtype=np.uint32),
-    ]
-    write_end_times: list[float] = []
-
-    def _proc():
-        for pkt in packets:
-            yield sc.env.process(sc.inputs[0].write(pkt))
-            write_end_times.append(sc.env.now)
-
-    all_rx_done = sc.env.event()
-
-    def _rx_monitor():
-        while len(sc.rx_end_times[0]) < len(packets):
-            yield sc.env.timeout(0.1)
-        all_rx_done.succeed()
-
-    sc.env.process(_proc())
-    for out in sc.outputs:
-        sc.env.process(out.run_proc())
-    sc.env.process(_rx_monitor())
-    sc.env.run(until=all_rx_done)
-
-    assert write_end_times == pytest.approx([2.0, 4.0, 7.0])
-    assert sc.rx_start_times[0] == pytest.approx([2.0, 7.0, 12.0])
-    assert sc.rx_end_times[0] == pytest.approx([7.0, 12.0, 17.0])
-    assert sc.outputs[0].nrx.level == 0
-    assert sc.outputs[0].ntx.level == 0
-
-
-# ---------------------------------------------------------------------------
-# Validation / error tests
+# CrossBarIF-specific validation tests
 # ---------------------------------------------------------------------------
 
 def test_invalid_nports_in():

--- a/tests/hw/test_crossbar_interface.py
+++ b/tests/hw/test_crossbar_interface.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pysilicon.hw.clock import Clock
+from pysilicon.hw.interface import (
+    CrossBarIF,
+    CrossBarIFInput,
+    CrossBarIFOutput,
+    StreamIFSlave,
+    Words,
+)
+from pysilicon.simulation.simulation import Simulation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class CrossBarScenario:
+    """
+    Test harness for a single CrossBarIF with configurable topology.
+
+    Parameters
+    ----------
+    nports_in, nports_out : int
+        Crossbar dimensions.
+    queue_sizes : list[int | None]
+        Per-output queue size (None = unbounded).
+    route_fn : callable | None
+        Routing function; None uses the default modulo routing.
+    rx_processing_delay : float
+        SimPy time each output spends processing one burst.
+    clk_freq : float
+        Clock frequency in Hz (used as simulated time = words / freq).
+    """
+
+    def __init__(
+        self,
+        nports_in: int = 2,
+        nports_out: int = 2,
+        queue_sizes: list[int | None] | None = None,
+        route_fn=None,
+        rx_processing_delay: float = 0.0,
+        clk_freq: float = 1.0,
+    ) -> None:
+        self.sim = Simulation()
+        self.env = self.sim.env
+        self.clk = Clock(freq=clk_freq)
+
+        if queue_sizes is None:
+            queue_sizes = [None] * nports_out
+
+        self.xbar = CrossBarIF(
+            sim=self.sim,
+            clk=self.clk,
+            nports_in=nports_in,
+            nports_out=nports_out,
+            route_fn=route_fn,
+        )
+        self.inputs = [
+            CrossBarIFInput(sim=self.sim, bitwidth=32) for _ in range(nports_in)
+        ]
+        self.outputs = [
+            CrossBarIFOutput(
+                sim=self.sim,
+                bitwidth=32,
+                queue_size=queue_sizes[j],
+                rx_proc=self._make_rx_proc(j, rx_processing_delay),
+            )
+            for j in range(nports_out)
+        ]
+
+        for i, inp in enumerate(self.inputs):
+            self.xbar.bind(f"in_{i}", inp)
+        for j, out in enumerate(self.outputs):
+            self.xbar.bind(f"out_{j}", out)
+
+        self.received: list[list[np.ndarray]] = [[] for _ in range(nports_out)]
+        self.rx_start_times: list[list[float]] = [[] for _ in range(nports_out)]
+        self.rx_end_times: list[list[float]] = [[] for _ in range(nports_out)]
+
+    def _make_rx_proc(self, port_out: int, delay: float):
+        def rx_proc(words: Words):
+            self.rx_start_times[port_out].append(self.env.now)
+            self.received[port_out].append(np.array(words, copy=True))
+            yield self.env.timeout(delay)
+            self.rx_end_times[port_out].append(self.env.now)
+
+        return rx_proc
+
+    def send_proc(self, port_in: int, packets: list[np.ndarray], tx_gap: float = 0.0):
+        def _proc():
+            for packet in packets:
+                yield self.env.process(self.inputs[port_in].write(packet))
+                if tx_gap > 0:
+                    yield self.env.timeout(tx_gap)
+
+        return _proc
+
+    def run(
+        self,
+        senders: dict[int, list[np.ndarray]],
+        tx_gap: float = 0.0,
+        until: float | None = None,
+    ) -> None:
+        all_done = []
+        for port_in, packets in senders.items():
+            done = self.env.event()
+            all_done.append(done)
+
+            def _proc(packets=packets, port_in=port_in, done=done):
+                yield from self.send_proc(port_in, packets, tx_gap)()
+                done.succeed()
+
+            self.env.process(_proc())
+
+        # Run the crossbar output loops
+        for out in self.outputs:
+            self.env.process(out.run_proc())
+
+        target = (
+            self.env.all_of(all_done) if until is None
+            else self.env.timeout(until)
+        )
+        self.env.run(until=target)
+
+
+# ---------------------------------------------------------------------------
+# Data-correctness tests
+# ---------------------------------------------------------------------------
+
+def test_identity_routing_2x2():
+    """Default modulo routing: in_0 -> out_0, in_1 -> out_1."""
+    sc = CrossBarScenario(nports_in=2, nports_out=2)
+
+    pkts0 = [np.array([1, 2, 3], dtype=np.uint32)]
+    pkts1 = [np.array([4, 5], dtype=np.uint32)]
+
+    sc.run({0: pkts0, 1: pkts1})
+
+    assert len(sc.received[0]) == 1
+    npt.assert_array_equal(sc.received[0][0], pkts0[0])
+
+    assert len(sc.received[1]) == 1
+    npt.assert_array_equal(sc.received[1][0], pkts1[0])
+
+
+def test_custom_route_fn():
+    """Custom route_fn sends all traffic from both inputs to out_0."""
+    sc = CrossBarScenario(
+        nports_in=2,
+        nports_out=2,
+        route_fn=lambda words, port_in: 0,
+    )
+
+    pkts0 = [np.array([10, 11], dtype=np.uint32)]
+    pkts1 = [np.array([20, 21, 22], dtype=np.uint32)]
+
+    sc.run({0: pkts0, 1: pkts1})
+
+    assert len(sc.received[0]) == 2
+    assert len(sc.received[1]) == 0
+
+
+def test_route_fn_based_on_data():
+    """Route even first-word bursts to out_0, odd to out_1."""
+
+    def route(words: Words, port_in: int) -> int:
+        return int(words[0]) % 2
+
+    sc = CrossBarScenario(nports_in=1, nports_out=2, route_fn=route)
+
+    even_pkt = np.array([2, 3], dtype=np.uint32)
+    odd_pkt = np.array([7, 8, 9], dtype=np.uint32)
+
+    sc.run({0: [even_pkt, odd_pkt]})
+
+    assert len(sc.received[0]) == 1
+    npt.assert_array_equal(sc.received[0][0], even_pkt)
+
+    assert len(sc.received[1]) == 1
+    npt.assert_array_equal(sc.received[1][0], odd_pkt)
+
+
+def test_multiple_packets_single_path():
+    """Multiple bursts on a single 1x1 path are all delivered in order."""
+    sc = CrossBarScenario(nports_in=1, nports_out=1)
+
+    packets = [
+        np.array([i, i + 1], dtype=np.uint32) for i in range(0, 10, 2)
+    ]
+    sc.run({0: packets})
+
+    assert len(sc.received[0]) == len(packets)
+    for rx, tx in zip(sc.received[0], packets, strict=True):
+        npt.assert_array_equal(rx, tx)
+
+
+# ---------------------------------------------------------------------------
+# Timing tests  (clock freq = 1 Hz so cycles == seconds)
+# ---------------------------------------------------------------------------
+
+def test_timing_single_input_no_backpressure():
+    """
+    Single path, three packets with a gap.  Write-end time equals nwords
+    (with freq=1 and latency_init=0).
+    """
+    sc = CrossBarScenario(nports_in=1, nports_out=1, clk_freq=1.0)
+
+    packets = [
+        np.array([1, 2, 3], dtype=np.uint32),   # 3 words  -> t=3
+        np.array([10, 11], dtype=np.uint32),     # 2 words  -> t=3+1(gap)+2=6
+        np.array([99], dtype=np.uint32),          # 1 word   -> t=6+1+1=8
+    ]
+    tx_gap = 1.0
+    write_end_times: list[float] = []
+
+    def _proc():
+        for pkt in packets:
+            yield sc.env.process(sc.inputs[0].write(pkt))
+            write_end_times.append(sc.env.now)
+            yield sc.env.timeout(tx_gap)
+
+    done = sc.env.event()
+
+    def _outer():
+        yield from _proc()
+        done.succeed()
+
+    sc.env.process(_outer())
+    for out in sc.outputs:
+        sc.env.process(out.run_proc())
+    sc.env.run(until=done)
+
+    assert write_end_times == pytest.approx([3.0, 6.0, 8.0])
+    assert sc.rx_start_times[0] == pytest.approx([3.0, 6.0, 8.0])
+
+
+def test_timing_backpressure():
+    """
+    Bounded queue forces the sender to stall when the receiver is slow.
+    Mirrors the shallow-queue test from test_interface.py.
+    """
+    sc = CrossBarScenario(
+        nports_in=1,
+        nports_out=1,
+        queue_sizes=[2],
+        rx_processing_delay=5.0,
+        clk_freq=1.0,
+    )
+
+    packets = [
+        np.array([1, 2], dtype=np.uint32),
+        np.array([3, 4], dtype=np.uint32),
+        np.array([5, 6], dtype=np.uint32),
+    ]
+    write_end_times: list[float] = []
+
+    def _proc():
+        for pkt in packets:
+            yield sc.env.process(sc.inputs[0].write(pkt))
+            write_end_times.append(sc.env.now)
+
+    all_rx_done = sc.env.event()
+
+    def _rx_monitor():
+        while len(sc.rx_end_times[0]) < len(packets):
+            yield sc.env.timeout(0.1)
+        all_rx_done.succeed()
+
+    sc.env.process(_proc())
+    for out in sc.outputs:
+        sc.env.process(out.run_proc())
+    sc.env.process(_rx_monitor())
+    sc.env.run(until=all_rx_done)
+
+    assert write_end_times == pytest.approx([2.0, 4.0, 7.0])
+    assert sc.rx_start_times[0] == pytest.approx([2.0, 7.0, 12.0])
+    assert sc.rx_end_times[0] == pytest.approx([7.0, 12.0, 17.0])
+    assert sc.outputs[0].nrx.level == 0
+    assert sc.outputs[0].ntx.level == 0
+
+
+# ---------------------------------------------------------------------------
+# Validation / error tests
+# ---------------------------------------------------------------------------
+
+def test_invalid_nports_in():
+    sim = Simulation()
+    with pytest.raises(ValueError, match="nports_in"):
+        CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=0, nports_out=2)
+
+
+def test_invalid_nports_out():
+    sim = Simulation()
+    with pytest.raises(ValueError, match="nports_out"):
+        CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=2, nports_out=0)
+
+
+def test_missing_clock():
+    sim = Simulation()
+    with pytest.raises(ValueError, match="clock"):
+        CrossBarIF(sim=sim, nports_in=2, nports_out=2)
+
+
+def test_bind_wrong_input_type():
+    sim = Simulation()
+    xbar = CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=1, nports_out=1)
+    wrong = CrossBarIFOutput(sim=sim, bitwidth=32)
+    with pytest.raises(TypeError):
+        xbar.bind("in_0", wrong)
+
+
+def test_bind_wrong_output_type():
+    sim = Simulation()
+    xbar = CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=1, nports_out=1)
+    wrong = CrossBarIFInput(sim=sim, bitwidth=32)
+    with pytest.raises(TypeError):
+        xbar.bind("out_0", wrong)
+
+
+def test_bind_invalid_ep_name():
+    sim = Simulation()
+    xbar = CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=1, nports_out=1)
+    ep = CrossBarIFInput(sim=sim, bitwidth=32)
+    with pytest.raises(KeyError):
+        xbar.bind("master", ep)
+
+
+def test_bind_out_of_range_input():
+    sim = Simulation()
+    xbar = CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=1, nports_out=1)
+    ep = CrossBarIFInput(sim=sim, bitwidth=32)
+    with pytest.raises(KeyError):
+        xbar.bind("in_5", ep)
+
+
+def test_bind_bitwidth_mismatch():
+    sim = Simulation()
+    xbar = CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=1, nports_out=1, bitwidth=32)
+    ep = CrossBarIFInput(sim=sim, bitwidth=64)
+    with pytest.raises(ValueError, match="bitwidth"):
+        xbar.bind("in_0", ep)
+
+
+def test_bind_already_bound():
+    sim = Simulation()
+    xbar = CrossBarIF(sim=sim, clk=Clock(freq=1), nports_in=1, nports_out=1)
+    ep1 = CrossBarIFInput(sim=sim, bitwidth=32)
+    ep2 = CrossBarIFInput(sim=sim, bitwidth=32)
+    xbar.bind("in_0", ep1)
+    with pytest.raises(ValueError):
+        xbar.bind("in_0", ep2)
+
+
+def test_write_without_binding():
+    """Writing from an unbound input endpoint should raise RuntimeError."""
+    sim = Simulation()
+    ep = CrossBarIFInput(sim=sim, bitwidth=32)
+    words = np.array([1, 2], dtype=np.uint32)
+
+    result: list[Exception] = []
+
+    def _proc():
+        try:
+            yield from ep.write(words)
+        except RuntimeError as exc:
+            result.append(exc)
+
+    sim.env.process(_proc())
+    sim.env.run()
+    assert len(result) == 1
+    assert "not bound" in str(result[0]).lower()

--- a/tests/hw/test_interface.py
+++ b/tests/hw/test_interface.py
@@ -5,15 +5,28 @@ from dataclasses import dataclass
 import numpy as np
 import numpy.testing as npt
 import pytest
-import simpy
 
 from pysilicon.hw.clock import Clock
-from pysilicon.hw.interface import StreamIF, StreamIFMaster, StreamIFSlave, Words
-from pysilicon.simulation.simobj import SimConfig
+from pysilicon.hw.interface import (
+    CrossBarIF,
+    CrossBarIFInput,
+    CrossBarIFOutput,
+    StreamIF,
+    StreamIFMaster,
+    StreamIFSlave,
+    StreamType,
+    TransferNotifyType,
+    Words,
+)
+from pysilicon.simulation.simulation import Simulation
 
+
+# ---------------------------------------------------------------------------
+# Shared timing test infrastructure
+# ---------------------------------------------------------------------------
 
 @dataclass(frozen=True)
-class StreamCase:
+class TransferCase:
     name: str
     packets: tuple[tuple[int, ...], ...]
     tx_gap: float
@@ -25,55 +38,120 @@ class StreamCase:
 
 
 class StreamScenario:
-    def __init__(self, case: StreamCase) -> None:
+    """1 master + 1 slave StreamIF scenario for timing / data tests."""
+
+    def __init__(self, case: TransferCase) -> None:
         self.case = case
-        self.env = simpy.Environment()
-        self.sim_config = SimConfig(env=self.env)
-        self.iface = StreamIF(sim_config=self.sim_config, clk=Clock(freq=1))
-        self.master = StreamIFMaster(sim_config=self.sim_config, bitwidth=32)
+        self.sim = Simulation()
+        self.iface = StreamIF(sim=self.sim, clk=Clock(freq=1))
+        self.master = StreamIFMaster(sim=self.sim, bitwidth=32)
         self.slave = StreamIFSlave(
-            sim_config=self.sim_config,
+            sim=self.sim,
             bitwidth=32,
             queue_size=case.queue_size,
             rx_proc=self.rx_proc,
         )
         self.iface.bind("master", self.master)
         self.iface.bind("slave", self.slave)
-        self.env.process(self.slave.run_proc())
 
-        self.packets = [np.array(packet, dtype=np.uint32) for packet in case.packets]
-        self.write_start_times: list[float] = []
+        self.packets = [np.array(p, dtype=np.uint32) for p in case.packets]
         self.write_end_times: list[float] = []
         self.rx_start_times: list[float] = []
         self.rx_end_times: list[float] = []
         self.received_packets: list[np.ndarray] = []
-        self.master_done = self.env.event()
-        self.rx_done = self.env.event()
-
-    def master_proc(self):
-        for packet in self.packets:
-            self.write_start_times.append(self.env.now)
-            yield self.env.process(self.master.write(packet))
-            self.write_end_times.append(self.env.now)
-            yield self.env.timeout(self.case.tx_gap)
-        self.master_done.succeed()
 
     def rx_proc(self, words: Words):
-        self.rx_start_times.append(self.env.now)
+        self.rx_start_times.append(self.sim.env.now)
         self.received_packets.append(np.array(words, copy=True))
-        yield self.env.timeout(self.case.rx_processing_delay)
-        self.rx_end_times.append(self.env.now)
-        if len(self.rx_end_times) == len(self.packets) and not self.rx_done.triggered:
-            self.rx_done.succeed()
+        yield self.sim.env.timeout(self.case.rx_processing_delay)
+        self.rx_end_times.append(self.sim.env.now)
 
     def run(self) -> None:
-        self.env.process(self.master_proc())
-        self.env.run(until=simpy.events.AllOf(self.env, [self.master_done, self.rx_done]))
+        env = self.sim.env
+        master_done = env.event()
+        rx_done = env.event()
+
+        def master_proc():
+            for packet in self.packets:
+                yield env.process(self.master.write(packet))
+                self.write_end_times.append(env.now)
+                yield env.timeout(self.case.tx_gap)
+            master_done.succeed()
+
+        def rx_monitor():
+            while len(self.rx_end_times) < len(self.packets):
+                yield env.timeout(0.1)
+            rx_done.succeed()
+
+        env.process(self.slave.run_proc())
+        env.process(master_proc())
+        env.process(rx_monitor())
+        env.run(until=env.all_of([master_done, rx_done]))
+
+    @property
+    def rx_ep(self):
+        return self.slave
 
 
-STREAM_CASES = [
+class CrossBarScenario11:
+    """1×1 CrossBarIF scenario — same timing semantics as StreamScenario."""
+
+    def __init__(self, case: TransferCase) -> None:
+        self.case = case
+        self.sim = Simulation()
+        self.xbar = CrossBarIF(sim=self.sim, clk=Clock(freq=1), nports_in=1, nports_out=1)
+        self.inp = CrossBarIFInput(sim=self.sim, bitwidth=32)
+        self.out = CrossBarIFOutput(
+            sim=self.sim,
+            bitwidth=32,
+            queue_size=case.queue_size,
+            rx_proc=self.rx_proc,
+        )
+        self.xbar.bind("in_0", self.inp)
+        self.xbar.bind("out_0", self.out)
+
+        self.packets = [np.array(p, dtype=np.uint32) for p in case.packets]
+        self.write_end_times: list[float] = []
+        self.rx_start_times: list[float] = []
+        self.rx_end_times: list[float] = []
+        self.received_packets: list[np.ndarray] = []
+
+    def rx_proc(self, words: Words):
+        self.rx_start_times.append(self.sim.env.now)
+        self.received_packets.append(np.array(words, copy=True))
+        yield self.sim.env.timeout(self.case.rx_processing_delay)
+        self.rx_end_times.append(self.sim.env.now)
+
+    def run(self) -> None:
+        env = self.sim.env
+        master_done = env.event()
+        rx_done = env.event()
+
+        def sender_proc():
+            for packet in self.packets:
+                yield env.process(self.inp.write(packet))
+                self.write_end_times.append(env.now)
+                yield env.timeout(self.case.tx_gap)
+            master_done.succeed()
+
+        def rx_monitor():
+            while len(self.rx_end_times) < len(self.packets):
+                yield env.timeout(0.1)
+            rx_done.succeed()
+
+        env.process(self.out.run_proc())
+        env.process(sender_proc())
+        env.process(rx_monitor())
+        env.run(until=env.all_of([master_done, rx_done]))
+
+    @property
+    def rx_ep(self):
+        return self.out
+
+
+TRANSFER_CASES = [
     pytest.param(
-        StreamCase(
+        TransferCase(
             name="spaced_packets_no_backpressure",
             packets=((10, 11, 12), (20, 21), (30,)),
             tx_gap=1.0,
@@ -83,10 +161,10 @@ STREAM_CASES = [
             expected_rx_start=(3.0, 6.0, 8.0),
             expected_rx_end=(3.0, 6.0, 8.0),
         ),
-        id="spaced-packets-no-backpressure",
+        id="no-backpressure",
     ),
     pytest.param(
-        StreamCase(
+        TransferCase(
             name="deep_queue_absorbs_receiver_delay",
             packets=((1, 2), (3, 4), (5, 6)),
             tx_gap=0.0,
@@ -96,10 +174,10 @@ STREAM_CASES = [
             expected_rx_start=(2.0, 7.0, 12.0),
             expected_rx_end=(7.0, 12.0, 17.0),
         ),
-        id="deep-queue-absorbs-receiver-delay",
+        id="deep-queue",
     ),
     pytest.param(
-        StreamCase(
+        TransferCase(
             name="shallow_queue_forces_backpressure",
             packets=((1, 2), (3, 4), (5, 6)),
             tx_gap=0.0,
@@ -109,22 +187,125 @@ STREAM_CASES = [
             expected_rx_start=(2.0, 7.0, 12.0),
             expected_rx_end=(7.0, 12.0, 17.0),
         ),
-        id="shallow-queue-forces-backpressure",
+        id="shallow-queue-backpressure",
     ),
 ]
 
+SCENARIO_CLASSES = [
+    pytest.param(StreamScenario, id="stream"),
+    pytest.param(CrossBarScenario11, id="crossbar-1x1"),
+]
 
-@pytest.mark.parametrize("case", STREAM_CASES)
-def test_stream_interface_timing_cases(case: StreamCase) -> None:
-    scenario = StreamScenario(case)
 
-    scenario.run()
+@pytest.mark.parametrize("scenario_cls", SCENARIO_CLASSES)
+@pytest.mark.parametrize("case", TRANSFER_CASES)
+def test_timing(case: TransferCase, scenario_cls) -> None:
+    sc = scenario_cls(case)
+    sc.run()
 
-    assert len(scenario.write_start_times) == len(case.packets)
-    assert scenario.write_end_times == list(case.expected_write_end)
-    assert scenario.rx_start_times == list(case.expected_rx_start)
-    assert scenario.rx_end_times == list(case.expected_rx_end)
-    assert scenario.slave.nrx.level == 0
-    assert scenario.slave.ntx.level == 0
-    for received, expected in zip(scenario.received_packets, scenario.packets, strict=True):
+    assert sc.write_end_times == pytest.approx(list(case.expected_write_end))
+    assert sc.rx_start_times == pytest.approx(list(case.expected_rx_start))
+    assert sc.rx_end_times == pytest.approx(list(case.expected_rx_end))
+    assert sc.rx_ep.nrx.level == 0
+    assert sc.rx_ep.ntx.level == 0
+    for received, expected in zip(sc.received_packets, case.packets, strict=True):
         npt.assert_array_equal(received, expected)
+
+
+# ---------------------------------------------------------------------------
+# StreamIF-specific validation tests
+# ---------------------------------------------------------------------------
+
+def test_stream_missing_clock():
+    sim = Simulation()
+    with pytest.raises(ValueError, match="clock"):
+        StreamIF(sim=sim)
+
+
+def test_stream_bind_wrong_slave_type():
+    sim = Simulation()
+    iface = StreamIF(sim=sim, clk=Clock(freq=1))
+    wrong = StreamIFMaster(sim=sim, bitwidth=32)
+    with pytest.raises(TypeError):
+        iface.bind("slave", wrong)
+
+
+def test_stream_bind_wrong_master_type():
+    sim = Simulation()
+    iface = StreamIF(sim=sim, clk=Clock(freq=1))
+    wrong = StreamIFSlave(sim=sim, bitwidth=32)
+    with pytest.raises(TypeError):
+        iface.bind("master", wrong)
+
+
+def test_stream_bind_invalid_ep_name():
+    sim = Simulation()
+    iface = StreamIF(sim=sim, clk=Clock(freq=1))
+    ep = StreamIFMaster(sim=sim, bitwidth=32)
+    with pytest.raises(KeyError):
+        iface.bind("in_0", ep)
+
+
+def test_stream_bind_bitwidth_mismatch():
+    sim = Simulation()
+    iface = StreamIF(sim=sim, clk=Clock(freq=1), bitwidth=32)
+    ep = StreamIFSlave(sim=sim, bitwidth=64)
+    with pytest.raises(ValueError, match="bitwidth"):
+        iface.bind("slave", ep)
+
+
+def test_stream_bind_stream_type_mismatch():
+    sim = Simulation()
+    iface = StreamIF(sim=sim, clk=Clock(freq=1), stream_type=StreamType.axi4)
+    ep = StreamIFSlave(sim=sim, bitwidth=32, stream_type=StreamType.hls)
+    with pytest.raises(ValueError, match="stream type"):
+        iface.bind("slave", ep)
+
+
+def test_stream_bind_notify_type_mismatch():
+    sim = Simulation()
+    iface = StreamIF(
+        sim=sim, clk=Clock(freq=1), notify_type=TransferNotifyType.end_only
+    )
+    ep = StreamIFSlave(sim=sim, bitwidth=32, notify_type=TransferNotifyType.begin_end)
+    with pytest.raises(ValueError, match="notify type"):
+        iface.bind("slave", ep)
+
+
+def test_stream_write_without_slave():
+    sim = Simulation()
+    iface = StreamIF(sim=sim, clk=Clock(freq=1))
+    master = StreamIFMaster(sim=sim, bitwidth=32)
+    iface.bind("master", master)
+
+    result: list[Exception] = []
+
+    def _proc():
+        try:
+            yield from iface.write(np.array([1, 2], dtype=np.uint32))
+        except RuntimeError as exc:
+            result.append(exc)
+
+    sim.env.process(_proc())
+    sim.env.run()
+    assert len(result) == 1
+    assert "slave" in str(result[0]).lower()
+
+
+def test_stream_master_write_without_binding():
+    sim = Simulation()
+    master = StreamIFMaster(sim=sim, bitwidth=32)
+    words = np.array([1, 2], dtype=np.uint32)
+
+    result: list[Exception] = []
+
+    def _proc():
+        try:
+            yield from master.write(words)
+        except RuntimeError as exc:
+            result.append(exc)
+
+    sim.env.process(_proc())
+    sim.env.run()
+    assert len(result) == 1
+    assert "not bound" in str(result[0]).lower()


### PR DESCRIPTION
Implements a crossbar interface with N input ports and M output ports. Transfers arriving at any input are routed to exactly one output port via a configurable route_fn; default is modulo routing (port_in % nports_out).

- CrossBarIF: main interface; validates topology, models transfer latency
- CrossBarIFInput: upstream master endpoint (analogous to StreamIFMaster)
- CrossBarIFOutput: downstream slave endpoint (analogous to StreamIFSlave); has run_proc, rx_proc callback, and bounded/unbounded RX queue support
- examples/interface/crossbar_demo.py: 2×2 demo with data-value-based routing
- tests/hw/test_crossbar_interface.py: data-correctness, timing, and validation tests

Closes #19