### PR TITLE
hwgen: skip streamutils_hls.h include for regmap-only kernels

### DIFF
--- a/examples/interface/vitis_regmap_simp_fun/simp_fun_build.py
+++ b/examples/interface/vitis_regmap_simp_fun/simp_fun_build.py
@@ -12,7 +12,6 @@ import numpy as np
 from pysilicon.build.build import BuildConfig, BuildDag, BuildStep, SourceStep
 from pysilicon.build.cosim_steps import ExtractCosimTimingStep, ValidateTimingStep
 from pysilicon.build.hwcodegen_steps import HlsCodegenStep
-from pysilicon.build.streamutils import StreamUtilsStep
 from pysilicon.build.verify_steps import FunctionalVerifyStep
 from pysilicon.toolchain import toolchain
 
@@ -144,31 +143,10 @@ class ExtractPyTimingStep(BuildStep):
 
 
 @dataclass(kw_only=True)
-class HlsGenIncludeStep(BuildStep):
-    description = "Generate the streamutils support headers needed for the Vitis flow."
-    consumes    = ["simp_fun_source"]
-    params      = {}
-    include_dir: str = "include"
-
-    @property
-    def produces(self) -> dict:  # type: ignore[override]
-        return {"include_dir": Path(self.include_dir)}
-
-    def run(self, config: BuildConfig, **_) -> dict:
-        inner_dag = BuildDag()
-        inner_dag.add(StreamUtilsStep(output_dir=self.include_dir))
-        inner_results = inner_dag.run(config)
-        failed = [n for n, r in inner_results.items() if not r.success]
-        if failed:
-            raise RuntimeError(f"Code generation failed: {failed}")
-        return {"include_dir": config.root_dir / self.include_dir}
-
-
-@dataclass(kw_only=True)
 class CSimStep(BuildStep):
     description = "Invoke Vitis HLS C-simulation."
     consumes = ["simp_fun_cpp", "simp_fun_compute_impl", "simp_fun_tb", "run_tcl",
-                "include_dir", "data_dir"]
+                "data_dir"]
     produces = {"csim_data_dir": "data_dir"}
     params = {"live_output": False, "clk_freq": 100e6}
 
@@ -198,7 +176,7 @@ class CSimStep(BuildStep):
 class CSynthStep(BuildStep):
     description = "Run Vitis HLS C-synthesis and RTL co-simulation."
     consumes = ["simp_fun_cpp", "simp_fun_compute_impl", "simp_fun_tb", "run_tcl",
-                "include_dir", "csim_data_dir"]
+                "csim_data_dir"]
     produces = {"report_dir": Path("pysilicon_simp_fun_proj/solution1")}
     params = {"live_output": False, "clk_freq": 100e6}
 
@@ -279,7 +257,6 @@ def build_simp_fun_dag() -> BuildDag:
     dag.add(BuildInputsStep(name="build_inputs"))
     dag.add(PySimStep(name="py_sim"))
     dag.add(ExtractPyTimingStep(name="extract_py_timing"))
-    dag.add(HlsGenIncludeStep(name="gen_include"))
 
     dag.add(HlsCodegenStep(
         name="gen_kernel",

--- a/pysilicon/build/hwgen.py
+++ b/pysilicon/build/hwgen.py
@@ -852,7 +852,8 @@ def header_to_cpp(
     tree = extract_kernel(default_comp)
     schemas = _collect_schemas(tree, default_comp)
     lines = ['#pragma once', '']
-    lines.append('#include "include/streamutils_hls.h"')
+    if _discover_stream_endpoints(default_comp):
+        lines.append('#include "include/streamutils_hls.h"')
     for s in schemas:
         lines.append(f'#include "include/{_snake_case(s.cpp_class_name())}.h"')  # type: ignore[attr-defined]
     for path in _collect_utility_includes(schemas):

--- a/tests/hw/test_hwgen.py
+++ b/tests/hw/test_hwgen.py
@@ -1504,3 +1504,55 @@ def test_header_utility_include_deduped():
     paths = _collect_utility_includes([Float32A, Float32A])
     assert paths == ["include/float32_array_utils.h"]
 
+
+# ---------------------------------------------------------------------------
+# Conditional streamutils_hls.h include (regmap-only vs stream-using)
+# ---------------------------------------------------------------------------
+
+def test_header_omits_streamutils_for_regmap_only_component():
+    """A regmap-only component (no StreamIF endpoints) must not include
+    streamutils_hls.h. The user shouldn't have to register a step to produce
+    a header their kernel doesn't use.
+    """
+    from pysilicon.build.hwgen import header_to_cpp
+
+    S32 = _IntField.specialize(bitwidth=32, signed=True)
+
+    @_dataclass
+    class _RegMapOnly(HwComponent):
+        cpp_kernel_name: ClassVar[str | None] = "rmonly"
+
+        def __post_init__(self) -> None:
+            super().__post_init__()
+            self.regmap = _VitisRegMap({
+                "x": _RegField(S32, _RegAccess.RW),
+                "y": _RegField(S32, _RegAccess.R),
+            })
+            self.s_lite = _VitisRegMapMMIFSlave(
+                name=f'{self.name}_s_lite', sim=self.sim, bitwidth=32,
+                regmap=self.regmap, on_start=self.on_start,
+            )
+            self.add_endpoint(self.s_lite)
+
+        def on_start(self) -> _ProcessGen[None]:
+            x = self.regmap.get("x")
+            self.regmap.set("y", x)
+
+    comp = _RegMapOnly(name="rmonly", sim=Simulation())
+    hpp = header_to_cpp(type(comp))
+    assert 'streamutils_hls.h' not in hpp, (
+        "regmap-only kernels must not emit the streamutils include:\n" + hpp
+    )
+
+
+def test_header_includes_streamutils_for_stream_using_component():
+    """A component with StreamIF endpoints (poly's shape) still gets the
+    streamutils_hls.h include — guards against regressing the fix.
+    """
+    from pysilicon.build.hwgen import header_to_cpp
+    from tests.hw.test_resolve import DemoComponent
+
+    comp = DemoComponent(name="demo", sim=Simulation())
+    hpp = header_to_cpp(type(comp))
+    assert '#include "include/streamutils_hls.h"' in hpp
+


### PR DESCRIPTION
## Summary
- Phase 1 of [plans/regmap_codegen_fixes_plan.md](../blob/regmap-codegen-fixes-phase-1/plans/regmap_codegen_fixes_plan.md).
- ``header_to_cpp`` no longer emits ``#include \"include/streamutils_hls.h\"`` when the component has no ``StreamIF`` endpoints. Gated on ``_discover_stream_endpoints(default_comp)``.
- Two unit tests in ``tests/hw/test_hwgen.py``: regmap-only kernel skips the include; stream-using kernel keeps it.
- ``vitis_regmap_simp_fun`` example loses its ``HlsGenIncludeStep`` boilerplate and the ``include_dir`` artifact wiring on CSimStep / CSynthStep — the framework no longer demands a stream-utility header for a regmap-only kernel.

Targets the prereq branch [regmap-poll-end-and-simp-fun-fixes](#37) (stacked PR). Retarget to ``main`` after #37 merges.

## Test plan
- [ ] ``pytest tests/hw/test_hwgen.py tests/hw/test_regmap.py``
- [ ] ``pytest tests/examples/test_poly_demo.py -m 'not vitis'``
- [ ] ``pytest tests/examples/test_vitis_regmap_simp_fun.py -m 'not vitis'``
- [ ] Locally (with Vitis): bundled with the Phase 3 whole-plan gate, ``cd examples/interface/vitis_regmap_simp_fun && python simp_fun_build.py --through generate_timing_diagram --force``

🤖 Generated with [Claude Code](https://claude.com/claude-code)