### PR TITLE
hwcodegen: drop is_vitis_auto fields from write_status_json

### DIFF
--- a/examples/interface/vitis_regmap_simp_fun/simp_fun.py
+++ b/examples/interface/vitis_regmap_simp_fun/simp_fun.py
@@ -195,16 +195,9 @@ class SimpFunTBHls(HwTestbench):
         dut.regmap.read_uint32_file("b", self.data_dir + "/b.bin")
         dut.run()
 
-        # NOTE: ap_done is auto-managed by VitisRegMapMMIFSlave on the Python
-        # side, but on the Vitis C++ side it is part of the AXI-Lite slave's
-        # standard control register and is NOT a C++ function argument the
-        # testbench can dereference. The generated TB cannot read it as a
-        # local variable, so we omit it here. Functional agreement on `y`
-        # plus the kernel returning normally (which is what makes the host
-        # poll loop exit) together establish completion.
         dut.regmap.write_status_json(
             self.data_dir + "/regmap_status.json",
-            fields=["y"],
+            fields=["ap_done", "y"],
         )
 
 

--- a/examples/interface/vitis_regmap_simp_fun/simp_fun_build.py
+++ b/examples/interface/vitis_regmap_simp_fun/simp_fun_build.py
@@ -96,11 +96,8 @@ class PySimStep(BuildStep):
         sim_dir = config.root_dir / "results" / "sim"
         sim_dir.mkdir(parents=True, exist_ok=True)
         S32(result.y).write_uint32_file(sim_dir / "y.bin")
-        # See note in simp_fun.py SimpFunTBHls.main on why ap_done is omitted
-        # from the regmap_status.json shape: the C++ TB cannot reach it as a
-        # local variable. The two-flow comparison is on `y` only.
         (sim_dir / "regmap_status.json").write_text(
-            json.dumps({"y": int(result.y)}, indent=2),
+            json.dumps({"ap_done": int(result.ap_done), "y": int(result.y)}, indent=2),
             encoding="utf-8",
         )
         summary_path = write_sim_summary(config.root_dir / "results" / "sim_summary.json", result)

--- a/pysilicon/build/hwcodegen.py
+++ b/pysilicon/build/hwcodegen.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import ast
 import inspect
+import logging
 import textwrap
+
+_log = logging.getLogger(__name__)
 
 from pysilicon.hw.hwstmt import (
     CaseStmt,
@@ -490,12 +493,65 @@ class HwStmtExtractor:
                         f"(line {parent.lineno})"
                     )
                 names.append(elt.value)
+            names = self._filter_vitis_auto_fields(dut_local, names)
             return TbStatusJsonStmt(
                 dut_local=dut_local,
                 path=call.args[0],
                 field_names=names,
             )
         return None
+
+    def _filter_vitis_auto_fields(
+        self,
+        dut_local: str,
+        field_names: list[str],
+    ) -> list[str]:
+        """Drop ``is_vitis_auto`` fields from a ``write_status_json`` list.
+
+        Vitis HLS auto-generates ``ap_start``/``ap_done`` inside the
+        ``s_axilite`` control register — they are not C++ kernel
+        parameters, so the generated TB cannot read them as locals.
+        The Python side records them naturally; matching the symmetric
+        Python shape just means listing them here too. This filter lets
+        users write the idiomatic symmetric list and lowers it to the
+        subset the C++ TB can actually emit.
+        """
+        regmap = self._dut_regmap_or_none(dut_local)
+        if regmap is None:
+            return field_names
+        kept: list[str] = []
+        skipped: list[str] = []
+        for n in field_names:
+            fld = regmap._fields.get(n)
+            if fld is not None and getattr(fld, 'is_vitis_auto', False):
+                skipped.append(n)
+            else:
+                kept.append(n)
+        if skipped:
+            _log.debug(
+                "write_status_json on '%s': dropped is_vitis_auto fields %s "
+                "(no C++ local in the generated TB)",
+                dut_local, skipped,
+            )
+        return kept
+
+    def _dut_regmap_or_none(self, dut_local: str):
+        """Return the ``VitisRegMap`` of the DUT bound to ``dut_local``, or
+        ``None`` if the DUT has no regmap.
+
+        The DUT class is held in ``self._duts`` as the class itself; this
+        helper instantiates it lazily with ``name``/``sim`` placeholders
+        so we can inspect the regmap's field declarations at parse time.
+        """
+        cls = self._duts.get(dut_local)
+        if cls is None or not isinstance(cls, type):
+            return None
+        from pysilicon.simulation.simulation import Simulation
+        try:
+            comp = cls(name="_codegen", sim=Simulation())
+        except Exception:
+            return None
+        return getattr(comp, 'regmap', None)
 
     def _extract_count_kwarg(
         self,

--- a/tests/build/test_hw_testbench.py
+++ b/tests/build/test_hw_testbench.py
@@ -455,3 +455,135 @@ def test_phase4_count_kwarg_required_for_array_ops():
     tb = _MissingCountTB(name='tb', sim=Simulation())
     with pytest.raises(SynthesisError, match="requires count"):
         extract_testbench(tb)
+
+
+# ---------------------------------------------------------------------------
+# write_status_json silently drops is_vitis_auto fields
+# ---------------------------------------------------------------------------
+#
+# Vitis HLS auto-generates ap_start/ap_done inside the s_axilite control
+# register — they are not C++ kernel parameters and the generated TB
+# cannot read them as locals. Listing them in fields=[...] should be a
+# no-op (a user writing the symmetric shape on both flows is idiomatic;
+# requiring them to manually exclude is a foot-gun).
+
+def _make_regmap_auto_dut_class():
+    """Build a tiny regmap-only DUT class with one user field, used by the
+    is_vitis_auto-filter tests. Defined as a factory because dataclass
+    needs a module-level home to resolve ClassVar annotations under
+    ``from __future__ import annotations``; we put it on the module
+    namespace below.
+    """
+    return _RegmapAutoDut
+
+
+from dataclasses import dataclass as _dc
+from typing import ClassVar as _CV
+
+from pysilicon.hw.dataschema import IntField as _IntField
+from pysilicon.hw.hw_component import HwComponent as _HwComp
+from pysilicon.hw.regmap import (
+    RegAccess as _RA,
+    RegField as _RF,
+    VitisRegMap as _VRM,
+    VitisRegMapMMIFSlave as _VRMS,
+)
+from pysilicon.simulation.simobj import ProcessGen as _PG
+
+_S32_TB = _IntField.specialize(bitwidth=32, signed=True)
+
+
+@_dc
+class _RegmapAutoDut(_HwComp):
+    cpp_kernel_name: _CV[str | None] = "rmauto"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.regmap = _VRM({
+            "y": _RF(_S32_TB, _RA.R, description="user field"),
+        })
+        self.s_lite = _VRMS(
+            name=f"{self.name}_s_lite", sim=self.sim, bitwidth=32,
+            regmap=self.regmap, on_start=self.on_start,
+        )
+        self.add_endpoint(self.s_lite)
+
+    def on_start(self) -> _PG[None]:
+        self.regmap.set("y", 0)
+
+
+@pytest.mark.phase4
+def test_write_status_json_drops_is_vitis_auto_fields():
+    """``fields=["ap_done", "ap_start", "y"]`` lowers to a TB that only
+    references the user field ``y``. The auto-managed ap_* bits are not
+    C++ locals on the Vitis side, so listing them in the symmetric
+    Python/C++ shape is fine — the parse pass silently filters them.
+    """
+    from pysilicon.build.hwgen import tb_files_to_str
+
+    @dataclass
+    class _AutoFilterTB(HwTestbench):
+        cpp_kernel_name: ClassVar[str | None] = "rmauto"
+
+        def main(self) -> None:
+            dut = _RegmapAutoDut()
+            dut.run()
+            dut.regmap.write_status_json(
+                self.data_dir + "/regmap_status.json",
+                fields=["ap_done", "ap_start", "y"],
+            )
+
+    files = tb_files_to_str(_AutoFilterTB, output_dir="gen")
+    body = files["rmauto_tb.cpp"]
+
+    # The user field IS emitted.
+    assert r'\"y\": " << (int)y' in body
+    # The auto-managed bits are NOT emitted as locals — they would not
+    # compile against the Vitis-generated kernel signature.
+    assert "ap_done" not in body
+    assert "ap_start" not in body
+
+
+@pytest.mark.phase4
+def test_write_status_json_filter_emits_debug_log():
+    """Surfacing the dropped fields via a debug log keeps the silent
+    filter discoverable for anyone reading the trace.
+    """
+    import logging
+
+    from pysilicon.build.hwgen import tb_files_to_str
+
+    @dataclass
+    class _LogFilterTB(HwTestbench):
+        cpp_kernel_name: ClassVar[str | None] = "rmauto"
+
+        def main(self) -> None:
+            dut = _RegmapAutoDut()
+            dut.run()
+            dut.regmap.write_status_json(
+                self.data_dir + "/regmap_status.json",
+                fields=["ap_done", "y"],
+            )
+
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger("pysilicon.build.hwcodegen")
+    handler = _Capture(level=logging.DEBUG)
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        tb_files_to_str(_LogFilterTB, output_dir="gen")
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+    matches = [r for r in records if "ap_done" in r.getMessage()]
+    assert matches, (
+        "expected at least one debug log mentioning the dropped ap_done "
+        f"field; got: {[r.getMessage() for r in records]}"
+    )


### PR DESCRIPTION
## Summary
- Phase 2 of [plans/regmap_codegen_fixes_plan.md](../blob/regmap-codegen-fixes-phase-2/plans/regmap_codegen_fixes_plan.md).
- ``HwStmtExtractor._make_regmap_call_stmt`` silently filters ``is_vitis_auto`` fields out of ``write_status_json(fields=[...])`` at parse time, with a debug-level log line so the drop is discoverable. Vitis HLS auto-generates ``ap_start`` / ``ap_done`` inside the s_axilite control register — they are not C++ kernel parameters, so the generated TB cannot read them as locals.
- Two unit tests in ``tests/build/test_hw_testbench.py``: the filter drop, and the debug log emission.
- ``vitis_regmap_simp_fun`` restores the symmetric ``fields=[\"ap_done\", \"y\"]`` shape on the TB side and ``{\"ap_done\", \"y\"}`` on the Python JSON shape. ``compare_fields`` stays at ``[\"y\"]`` since that's the field both flows can agree on (the C++ side filters ``ap_done``).

Implementation choice: silent filter (option a from the plan) over loud SynthesisError (option b). Silent matches the principle that the framework accepts idiomatic Python.

Targets [Phase 1](#38) (stacked PR). Retarget to ``main`` after Phase 1 merges.

## Test plan
- [ ] ``pytest tests/build/test_hw_testbench.py``
- [ ] ``pytest tests/examples/test_vitis_regmap_simp_fun.py -m 'not vitis'``
- [ ] Locally (with Vitis): bundled with the Phase 3 whole-plan gate, ``cd examples/interface/vitis_regmap_simp_fun && python simp_fun_build.py --through validate_csim --force``

🤖 Generated with [Claude Code](https://claude.com/claude-code)