### PR TITLE
hwcodegen: lower inline regmap.get + rename param-shadowing locals

### DIFF
--- a/examples/interface/vitis_regmap_simp_fun/simp_fun.py
+++ b/examples/interface/vitis_regmap_simp_fun/simp_fun.py
@@ -94,19 +94,13 @@ class SimpFunComponent(HwComponent):
     def on_start(self) -> ProcessGen[None]:
         # ap_done is auto-managed by VitisRegMapMMIFSlave: cleared on ap_start,
         # set when on_start returns. The kernel only writes its result.
-        #
-        # The codegen recognises ``<name> = self.regmap.get("<name>")`` as
-        # "this register is already a kernel parameter named <name>" and
-        # emits a comment instead of a redundant read.  Naming the compute
-        # result ``result`` (not ``y``) avoids shadowing the ``y`` kernel
-        # parameter so the subsequent ``set("y", result)`` lowers cleanly to
-        # ``y = result;`` rather than the no-op ``y = y;``.
         self._log("kernel_busy", 1)
-        x = self.regmap.get("x")
-        a = self.regmap.get("a")
-        b = self.regmap.get("b")
-        result = self.compute(x, a, b)
-        self.regmap.set("y", result)
+        y = self.compute(
+            self.regmap.get("x"),
+            self.regmap.get("a"),
+            self.regmap.get("b"),
+        )
+        self.regmap.set("y", y)
         self._log("kernel_done", 1)
 
     @synthesizable

--- a/pysilicon/build/hwcodegen.py
+++ b/pysilicon/build/hwcodegen.py
@@ -658,15 +658,49 @@ class HwStmtExtractor:
             self._require_synthesizable(method, node)
             assert method is not None
             inputs = self._resolve_call_args(node.value)
-            outputs = self._make_output_vars(node.targets)
+            target_names = self._extract_names(node.targets)
+            outputs = self._make_output_vars_with_rename(
+                target_names, method=method,
+            )
             stmt = self._make_call_stmt(method, inputs, outputs)
-            for v in outputs:
+            for orig_name, v in zip(target_names, outputs):
                 v.producer = stmt
-                self._scope[v.name] = v
+                self._scope[orig_name] = v
             return stmt
         raise SynthesisError(
             f"Non-synthesizable assignment at line {node.lineno}"
         )
+
+    def _make_output_vars_with_rename(
+        self,
+        target_names: list[str],
+        method: object,
+    ) -> list[HwVar]:
+        """Build output ``HwVar``s for an assignment, renaming any local
+        that would shadow a kernel parameter declared by the regmap.
+
+        A local named after a regmap field aliases the kernel-signature
+        parameter in C++. Without rename, ``y = compute(...)`` followed
+        by ``self.regmap.set("y", y)`` lowers to ``ap_int<32> y = ...;
+        y = y;`` — a self-assignment that discards the computed value.
+
+        Same-name ``<name> = self.regmap.get("<name>")`` is the existing
+        idiom recognized by ``_emit_regmap_get`` (it elides into a
+        comment), so we leave that case alone — the parameter is in
+        scope, no local is actually declared.
+        """
+        from pysilicon.hw.regmap import RegMapGetStmt
+        is_regmap_get = (
+            getattr(method, '_stmt_class', None) is RegMapGetStmt
+        )
+        rm_fields = self._regmap_field_names()
+        outputs: list[HwVar] = []
+        for n in target_names:
+            emit_name = n
+            if n in rm_fields and not is_regmap_get:
+                emit_name = f"_{n}_local"
+            outputs.append(HwVar(name=emit_name, typ=None))
+        return outputs
 
     def _visit_ann_assign(self, node: ast.AnnAssign) -> HwStmt:
         # x: T = yield from self.ep.method(...)
@@ -856,9 +890,47 @@ class HwStmtExtractor:
             elif isinstance(arg, ast.Attribute):
                 obj = self._resolve_obj(arg)
                 result.append(obj if obj is not None else arg)
+            elif isinstance(arg, ast.Call):
+                hw_var = self._try_inline_regmap_get(arg)
+                result.append(hw_var if hw_var is not None else arg)
             else:
                 result.append(arg)
         return result
+
+    def _try_inline_regmap_get(self, call_node: ast.Call) -> HwVar | None:
+        """Recognize ``self.regmap.get("<name>")`` as a sub-expression and
+        lower it to a ``HwVar`` named after the field.
+
+        The kernel signature already declares a parameter named after each
+        non-vitis-auto regmap field, so emitting ``<name>`` as the call
+        argument resolves to the right C++ scalar (or array) directly —
+        no temp local, no AST repr leak.
+        """
+        from pysilicon.hw.regmap import RegMapGetStmt
+        method = self._resolve_method(call_node.func)
+        if method is None:
+            return None
+        if getattr(method, '_stmt_class', None) is not RegMapGetStmt:
+            return None
+        if len(call_node.args) != 1 or call_node.keywords:
+            return None
+        name_node = call_node.args[0]
+        if not (isinstance(name_node, ast.Constant)
+                and isinstance(name_node.value, str)):
+            return None
+        field_name = name_node.value
+        regmap = getattr(self._comp, 'regmap', None)
+        if regmap is None or field_name not in regmap._fields:
+            return None
+        return HwVar(name=field_name, typ=regmap._fields[field_name].schema)
+
+    def _regmap_field_names(self) -> set[str]:
+        """Return the set of regmap field names declared on the component,
+        or an empty set when the component has no regmap."""
+        regmap = getattr(self._comp, 'regmap', None)
+        if regmap is None:
+            return set()
+        return set(regmap._fields.keys())
 
     def _make_output_vars(self, targets: list[ast.expr]) -> list[HwVar]:
         names = self._extract_names(targets)

--- a/tests/hw/test_hwgen.py
+++ b/tests/hw/test_hwgen.py
@@ -1556,3 +1556,102 @@ def test_header_includes_streamutils_for_stream_using_component():
     hpp = header_to_cpp(type(comp))
     assert '#include "include/streamutils_hls.h"' in hpp
 
+
+# ---------------------------------------------------------------------------
+# Inline regmap.get(...) + local-shadows-regmap-field fix
+# ---------------------------------------------------------------------------
+
+from pysilicon.hw.synth import synthesizable as _synth2
+
+_S32_PH3 = _IntField.specialize(bitwidth=32, signed=True)
+
+
+@_dataclass
+class _InlineGetComp(HwComponent):
+    """``on_start`` reads regmap fields inline as a call argument, and
+    assigns the compute result into a local whose name matches the
+    output regmap field. Both patterns must lower cleanly to C++.
+    """
+
+    cpp_kernel_name: ClassVar[str | None] = "inline_get"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.regmap = _VitisRegMap({
+            "x": _RegField(_S32_PH3, _RegAccess.RW),
+            "a": _RegField(_S32_PH3, _RegAccess.RW),
+            "b": _RegField(_S32_PH3, _RegAccess.RW),
+            "y": _RegField(_S32_PH3, _RegAccess.R),
+        })
+        self.s_lite = _VitisRegMapMMIFSlave(
+            name=f'{self.name}_s_lite', sim=self.sim, bitwidth=32,
+            regmap=self.regmap, on_start=self.on_start,
+        )
+        self.add_endpoint(self.s_lite)
+
+    def on_start(self) -> _ProcessGen[None]:
+        y = self.compute(
+            self.regmap.get("x"),
+            self.regmap.get("a"),
+            self.regmap.get("b"),
+        )
+        self.regmap.set("y", y)
+
+    @_synth2
+    def compute(self, x: _S32_PH3, a: _S32_PH3, b: _S32_PH3) -> _S32_PH3:
+        return x
+
+
+def test_inline_regmap_get_lowers_to_kernel_param_name():
+    """``self.regmap.get("x")`` as a call argument lowers to the kernel
+    parameter ``x``, not raw AST repr text.
+    """
+    from pysilicon.build.hwgen import kernel_to_cpp
+
+    cpp = kernel_to_cpp(_InlineGetComp)
+    # The compute call should reference the kernel parameter names.
+    assert "compute(x, a, b)" in cpp, (
+        "expected inline regmap.get(...) to lower to bare param names:\n"
+        + cpp
+    )
+    # The bug symptom — ast.dump text — must not appear anywhere.
+    assert "Call(func=" not in cpp
+    assert "Attribute(value=" not in cpp
+
+
+def test_local_shadowing_regmap_field_does_not_self_assign():
+    """``y = compute(...); self.regmap.set("y", y)`` must not lower to the
+    no-op ``y = y;``. The local that aliases the kernel parameter is
+    either renamed at codegen time (option a) or extraction raises a
+    clear error (option b).
+    """
+    from pysilicon.build.hwcodegen import SynthesisError
+    from pysilicon.build.hwgen import kernel_to_cpp
+
+    try:
+        cpp = kernel_to_cpp(_InlineGetComp)
+    except SynthesisError as exc:
+        # Option (b) fallback: a clear error pointing at the shadowing.
+        msg = str(exc).lower()
+        assert "y" in msg and ("shadow" in msg or "rename" in msg), (
+            f"SynthesisError did not explain the shadowing issue: {exc}"
+        )
+        return
+
+    # Option (a) success path: the assignment is no longer a self-assign.
+    assert "y = y;" not in cpp, (
+        "regmap.set('y', y) emitted as self-assignment; the compute "
+        "result is being lost:\n" + cpp
+    )
+    # The compute result must flow into the kernel-parameter ``y`` via
+    # SOME renamed local.
+    assert "compute(x, a, b)" in cpp
+    # Final assignment line of the form ``y = <something_not_y>;`` must
+    # exist so the parameter gets the compute result.
+    import re
+    final_assigns = re.findall(r"^\s*y\s*=\s*([A-Za-z_]\w*)\s*;", cpp, re.M)
+    assert any(rhs != "y" for rhs in final_assigns), (
+        "no ``y = <local>;`` assignment found that propagates the compute "
+        "result:\n" + cpp
+    )
+


### PR DESCRIPTION
## Summary
- Phase 3 of [plans/regmap_codegen_fixes_plan.md](../blob/regmap-codegen-fixes-phase-3/plans/regmap_codegen_fixes_plan.md).
- Fix 3a: ``self.regmap.get(\"<name>\")`` used as a call argument now lowers to a ``HwVar`` named after the field (which the kernel signature already declares as a parameter), not to ``ast.dump`` text. Implemented in ``HwStmtExtractor._try_inline_regmap_get`` and threaded through ``_resolve_call_args``.
- Fix 3b: ``y = compute(...); self.regmap.set(\"y\", y)`` no longer lowers to ``y = y;``. When an assignment target shadows a regmap field name (and the RHS is not a same-name ``regmap.get``), ``_visit_assign`` renames the C++ local to ``_<name>_local`` while keeping the original Python name in scope. The set then lowers to ``y = _y_local;`` cleanly. Same-name ``x = self.regmap.get(\"x\")`` idiom is unchanged — ``_emit_regmap_get`` still elides it to a comment.
- Two unit tests in ``tests/hw/test_hwgen.py`` cover both lowerings.
- ``vitis_regmap_simp_fun`` ``on_start`` reverts to the idiomatic form: inline ``regmap.get`` as call args, ``y`` as the local name.

Implementation choice: option (a) rename at codegen time, per plan recommendation. Option (b) extraction-time SynthesisError was not required.

Targets [Phase 2](#39) (stacked PR). Retarget to ``main`` after Phase 2 merges. This PR completes the plan; the whole-plan Vitis verification gate runs after all three phases land.

## Test plan
- [ ] ``pytest tests/hw/test_hwgen.py``
- [ ] ``pytest tests/examples/test_vitis_regmap_simp_fun.py -m 'not vitis'``
- [ ] ``pytest tests/examples/test_poly_demo.py -m 'not vitis'``
- [ ] Whole-plan gate (with Vitis): ``cd examples/interface/vitis_regmap_simp_fun && python simp_fun_build.py --through generate_timing_diagram --force`` reports ``timing_verdict.pass=true`` with ``delta ≤ tolerance``.
- [ ] Poly Vitis regression: ``pytest -m vitis tests/examples/test_poly_demo.py``

🤖 Generated with [Claude Code](https://claude.com/claude-code)