### PR TITLE
AXI-MM queue: MemComponent backing, streaming/typed write/get, SPSC demo

### DIFF
--- a/examples/interface/aximm_queue_demo.py
+++ b/examples/interface/aximm_queue_demo.py
@@ -1,0 +1,179 @@
+"""
+aximm_queue_demo.py — SPSC ring buffer over an AXI-MM crossbar.
+
+A producer and a consumer, each its own master on a crossbar, share a single
+memory-backed FIFO (:class:`~pysilicon.hw.aximm_queue.AXIMMQueue`).  The ring's
+storage and its head/tail pointers all live in one ``MemComponent`` region; the
+two sides coordinate purely through memory (decision 1), with no shared Python
+object.  The queue capacity is deliberately small, so the producer blocks on a
+full ring and the consumer's draining is what lets it make progress — the
+backpressure that proves the blocking ``write``/``get`` (decision 8).
+
+Topology
+--------
+  Producer (master_0) ──┐
+                        ├── AXIMMCrossBarIF ──── ring region (slave_0, FULL)
+  Consumer (master_1) ──┘                        in one MemComponent (s_mm)
+
+      ring region (AXIMMQueueLayout @ base, capacity slots):
+        word 0 : head      (consumer-owned)
+        word 1 : tail      (producer-owned)
+        word 2 : capacity
+        word 3 : reserved
+        data   : capacity slots × elem_words words
+
+Scenario
+--------
+  1. The producer ``write``s ``np.arange(N)`` into a ``capacity``-slot ring,
+     blocking whenever the ring fills.
+  2. The consumer ``get``s all ``N`` words, blocking whenever the ring is empty.
+  3. The harness asserts the consumer received the producer's exact sequence,
+     in order, with no loss or duplication, and prints a timing summary.
+
+Run standalone::
+
+    python -m examples.interface.aximm_queue_demo
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from pysilicon.hw.aximm_queue import AXIMMQueue, AXIMMQueueLayout
+from pysilicon.hw.clock import Clock
+from pysilicon.hw.memif import (
+    AXIMMCrossBarIF,
+    MMIFMaster,
+    assign_address_ranges,
+)
+from pysilicon.hw.memory import MemComponent
+from pysilicon.simulation.simobj import ProcessGen, SimObj
+from pysilicon.simulation.simulation import Simulation
+
+
+# ---------------------------------------------------------------------------
+# Producer / consumer masters
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Producer(SimObj):
+    """Enqueues a known sequence, blocking when the ring is full."""
+
+    layout: AXIMMQueueLayout | None = None
+    data: np.ndarray | None = None
+    poll_interval: float = 1.0
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.master_ep = MMIFMaster(sim=self.sim, bitwidth=self.layout.mem_bw)
+        self.queue = AXIMMQueue(master=self.master_ep, layout=self.layout)
+        self.done_time: float = 0.0
+
+    def run_proc(self) -> ProcessGen[None]:
+        # The producer owns setup: zero head/tail once before either side runs.
+        yield from self.queue.reset()
+        t0 = self.now
+        yield from self.queue.write(self.data, poll_interval=self.poll_interval)
+        self.done_time = self.now
+        print(f"[Producer] wrote {len(self.data)} words into a "
+              f"{self.layout.capacity}-slot ring, done at t={self.now:.3f} "
+              f"(dt={self.now - t0:.3f})")
+
+
+@dataclass
+class Consumer(SimObj):
+    """Dequeues ``count`` words, blocking when the ring is empty."""
+
+    layout: AXIMMQueueLayout | None = None
+    count: int = 0
+    poll_interval: float = 1.0
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.master_ep = MMIFMaster(sim=self.sim, bitwidth=self.layout.mem_bw)
+        self.queue = AXIMMQueue(master=self.master_ep, layout=self.layout)
+        self.received: np.ndarray | None = None
+        self.done_time: float = 0.0
+
+    def run_proc(self) -> ProcessGen[None]:
+        t0 = self.now
+        got = yield from self.queue.get(count=self.count, poll_interval=self.poll_interval)
+        self.received = np.array(got)
+        self.done_time = self.now
+        print(f"[Consumer] received {len(self.received)} words, done at "
+              f"t={self.now:.3f} (dt={self.now - t0:.3f})")
+
+
+# ---------------------------------------------------------------------------
+# Demo harness
+# ---------------------------------------------------------------------------
+
+class AXIMMQueueDemo:
+    """Wires the producer, consumer, crossbar and ring memory, then runs."""
+
+    BASE_ADDR = 0x1000
+    CAPACITY = 8          # usable depth 7 — small enough to force backpressure
+    N = 64                # words to stream through it
+    MEM_BW = 32
+
+    def __init__(self) -> None:
+        self.sim = Simulation()
+        self.clk = Clock(freq=100.0)   # 100 Hz → 1 cycle = 0.01 s
+
+        self.layout = AXIMMQueueLayout(
+            base_addr=self.BASE_ADDR, capacity=self.CAPACITY, mem_bw=self.MEM_BW
+        )
+        # External shared memory (decision 9): inline=False + one alloc places the
+        # ring at byte 0, where the crossbar (global − base) delivers it.
+        total_words = self.layout.total_bytes // self.layout.word_bytes
+        self.mem = MemComponent(
+            sim=self.sim, word_size=self.MEM_BW, inline=False, clk=self.clk,
+            latency_init=2.0, latency_per_word=1.0,
+        )
+        self.mem.alloc(total_words)
+
+        self.data = np.arange(self.N, dtype=np.uint32)
+        self.producer = Producer(sim=self.sim, layout=self.layout, data=self.data)
+        self.consumer = Consumer(sim=self.sim, layout=self.layout, count=self.N)
+
+        self.xbar = AXIMMCrossBarIF(
+            sim=self.sim, clk=self.clk,
+            nports_master=2, nports_slave=1, bitwidth=self.MEM_BW,
+            latency_init=2.0, latency_read_return=2.0,
+        )
+        self.xbar.bind("master_0", self.producer.master_ep)
+        self.xbar.bind("master_1", self.consumer.master_ep)
+        self.xbar.bind("slave_0", self.mem.s_mm)
+        assign_address_ranges(
+            [self.mem.s_mm], [(self.layout.base_addr, self.layout.total_bytes)]
+        )
+
+    def run_and_check(self) -> np.ndarray:
+        print("=== AXI-MM memory-backed queue demo ===")
+        print(f"ring: base=0x{self.BASE_ADDR:04x}, capacity={self.CAPACITY} "
+              f"(usable {self.CAPACITY - 1}), streaming N={self.N} words\n")
+
+        self.sim.run_sim()
+
+        received = self.consumer.received
+        assert received is not None, "consumer never produced a result"
+        assert np.array_equal(received, self.data), (
+            f"FIFO mismatch:\n  expected {self.data}\n  got      {received}"
+        )
+
+        print(f"\nProducer finished at t={self.producer.done_time:.3f}, "
+              f"consumer at t={self.consumer.done_time:.3f}, "
+              f"sim end t={self.sim.env.now:.3f}.")
+        print("All checks passed: consumer received the producer's exact "
+              "sequence, in order.")
+        return received
+
+
+def run_and_check() -> np.ndarray:
+    """Module-level entry point: build the demo and run its self-check."""
+    return AXIMMQueueDemo().run_and_check()
+
+
+if __name__ == "__main__":
+    run_and_check()

--- a/pysilicon/hw/aximm_queue.py
+++ b/pysilicon/hw/aximm_queue.py
@@ -25,23 +25,20 @@ This module exposes two classes:
 ``AXIMMQueueLayout``
     The memory map.  Owns all address math given ``mem_bw``, ``capacity`` and
     ``elem_words``.
-``MMMemory``
-    A reusable word-addressed RAM ``SimObj`` backing an MM slave (a cleaned-up,
-    generalized version of the ``MemBank`` defined locally in
-    ``examples/interface/aximm_demo.py``).  Lives here (rather than in
-    ``memif.py``) so the queue's dependency on a concrete memory model stays
-    local; any MM slave with read/write callbacks works — ``MMMemory`` is just
-    the convenient default.
+``AXIMMQueue``
+    The proxy a master uses to ``write``/``get`` the ring.  Storage-agnostic —
+    it only issues ``MMIFMaster`` transactions — so it works over any MM slave;
+    :class:`~pysilicon.hw.memory.MemComponent` is the canonical backing store.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import ClassVar
 
 import numpy as np
 
-from pysilicon.hw.memif import MMIFMaster, MMIFSlave, Words
-from pysilicon.simulation.simobj import ProcessGen, SimObj
+from pysilicon.hw.memif import MMIFMaster, Words
+from pysilicon.simulation.simobj import ProcessGen
 
 
 # ---------------------------------------------------------------------------
@@ -128,69 +125,6 @@ class AXIMMQueueLayout:
     def total_bytes(self) -> int:
         """Size of the whole region, for ``assign_address_ranges``."""
         return self.control_bytes + self.capacity * self.elem_words * self.word_bytes
-
-
-# ---------------------------------------------------------------------------
-# Reusable memory slave
-# ---------------------------------------------------------------------------
-
-@dataclass
-class MMMemory(SimObj):
-    """Word-addressed RAM backing an MM slave (generalized aximm_demo MemBank).
-
-    Backed by a dict keyed by byte address.  In the FULL protocol the slave
-    callback receives the whole burst at the starting ``local_addr`` and is
-    responsible for striding words within it; the stride per word is
-    ``bitwidth // 8`` bytes, never a hard-coded 4.
-
-    Parameters
-    ----------
-    bitwidth : int
-        Data word width in bits.  Must match the queue layout's ``mem_bw`` and
-        the interconnect ``bitwidth``.
-    access_latency : float
-        Simulated read access time (seconds).  Writes are non-blocking.
-    """
-
-    bitwidth: int = 32
-    access_latency: float = 0.0
-
-    slave_ep: MMIFSlave = field(init=False)
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self._mem: dict[int, int] = {}
-        self.slave_ep = MMIFSlave(
-            sim=self.sim,
-            bitwidth=self.bitwidth,
-            rx_write_proc=self.rx_write,
-            rx_read_proc=self.rx_read,
-        )
-
-    @property
-    def _word_bytes(self) -> int:
-        return self.bitwidth // 8
-
-    def rx_write(self, words: Words, local_addr: int) -> ProcessGen[None]:
-        word_bytes = self._word_bytes
-        for i, w in enumerate(words):
-            self._mem[local_addr + i * word_bytes] = int(w)
-        yield self.timeout(0)   # write is non-blocking for the caller
-
-    def rx_read(self, nwords: int, local_addr: int) -> ProcessGen[Words]:
-        if self.access_latency > 0:
-            yield self.timeout(self.access_latency)
-        else:
-            yield self.timeout(0)
-        word_bytes = self._word_bytes
-        dtype = np.uint32 if self.bitwidth <= 32 else np.uint64
-        return np.array(
-            [self._mem.get(local_addr + i * word_bytes, 0) for i in range(nwords)],
-            dtype=dtype,
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -354,22 +288,28 @@ class AXIMMQueue:
     def write(
         self, words: Words, poll_interval: float = DEFAULT_POLL_INTERVAL
     ) -> ProcessGen[None]:
-        """Enqueue *words* as one atomic batch, blocking until it fits.
+        """Enqueue *words*, blocking until the whole array is in (decision 8).
 
-        The batch is enqueued all-or-nothing, so it must fit in the usable depth
-        (``capacity - 1`` slots); a producer that wants to stream more than that
-        chunks the data into multiple ``write`` calls.  Polls :meth:`try_write`,
-        sleeping *poll_interval* simulation seconds between attempts; the loop is
-        cancelled by simulation end like any other SimObj process.
+        Accepts an array of *any* size: it is streamed through in pieces of at
+        most the usable depth (``capacity - 1`` slots), blocking as the consumer
+        drains, until every word is enqueued.  This mirrors :meth:`get`, which
+        already collects across multiple :meth:`try_get` calls — there is no size
+        guard and no error for a batch larger than the queue.  Polls
+        :meth:`try_write`, sleeping *poll_interval* simulation seconds when the
+        queue is full; the loop is cancelled by simulation end like any other
+        SimObj process.  The atomic single-shot enqueue stays available as
+        :meth:`try_write`.
         """
-        nslots = len(words) // self.layout.elem_words
-        if nslots > self.layout.capacity - 1:
-            raise ValueError(
-                f"write: batch of {nslots} slots can never fit in usable depth "
-                f"{self.layout.capacity - 1}; chunk the data into smaller writes"
-            )
-        while not (yield from self.try_write(words)):
-            yield self.master.timeout(poll_interval)
+        ew = self.layout.elem_words
+        chunk_words = (self.layout.capacity - 1) * ew   # max words per attempt
+        n = len(words)
+        off = 0
+        while off < n:
+            piece = words[off:off + chunk_words]
+            if (yield from self.try_write(piece)):
+                off += len(piece)
+            else:
+                yield self.master.timeout(poll_interval)
 
     def get(
         self, nslots: int, poll_interval: float = DEFAULT_POLL_INTERVAL
@@ -390,4 +330,8 @@ class AXIMMQueue:
             else:
                 out.append(chunk)
                 collected += len(chunk) // ew
+        if not out:
+            # nslots == 0 (or nothing collected): return an empty array rather
+            # than indexing out[0] on an empty list.
+            return np.empty(0, dtype=self._dtype)
         return np.concatenate(out) if len(out) > 1 else out[0]

--- a/pysilicon/hw/aximm_queue.py
+++ b/pysilicon/hw/aximm_queue.py
@@ -33,7 +33,7 @@ This module exposes two classes:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 
@@ -282,23 +282,31 @@ class AXIMMQueue:
         return np.concatenate(chunks) if len(chunks) > 1 else chunks[0]
 
     # ------------------------------------------------------------------
-    # Blocking public API (decision 8) — poll the try_* primitives.
+    # Blocking public API (decisions 6 & 8) — poll the try_* primitives.
     # ------------------------------------------------------------------
 
-    def write(
-        self, words: Words, poll_interval: float = DEFAULT_POLL_INTERVAL
-    ) -> ProcessGen[None]:
-        """Enqueue *words*, blocking until the whole array is in (decision 8).
+    def _check_schema_elem_words(self, schema_type: type) -> int:
+        """Validate a schema's word footprint matches the layout's elem_words.
 
-        Accepts an array of *any* size: it is streamed through in pieces of at
-        most the usable depth (``capacity - 1`` slots), blocking as the consumer
-        drains, until every word is enqueued.  This mirrors :meth:`get`, which
-        already collects across multiple :meth:`try_get` calls — there is no size
-        guard and no error for a batch larger than the queue.  Polls
-        :meth:`try_write`, sleeping *poll_interval* simulation seconds when the
-        queue is full; the loop is cancelled by simulation end like any other
-        SimObj process.  The atomic single-shot enqueue stays available as
-        :meth:`try_write`.
+        Typed access only makes sense when one element occupies exactly one slot
+        (``elem_words`` words); otherwise the slot addressing and the schema
+        disagree and every transfer would be misaligned (decision 11, applied to
+        the typed layer).
+        """
+        nwpe = schema_type.nwords_per_inst(self.layout.mem_bw)
+        if nwpe != self.layout.elem_words:
+            raise ValueError(
+                f"{schema_type.__name__} occupies {nwpe} words per element at "
+                f"mem_bw={self.layout.mem_bw}, but the layout's elem_words is "
+                f"{self.layout.elem_words}"
+            )
+        return nwpe
+
+    def _write_raw(self, words: Words, poll_interval: float) -> ProcessGen[None]:
+        """Stream *words* into the ring in pieces of at most the usable depth.
+
+        Blocks as the consumer drains; mirrors :meth:`_get_raw_slots`.  There is
+        no size guard — an array larger than the queue is fed through in chunks.
         """
         ew = self.layout.elem_words
         chunk_words = (self.layout.capacity - 1) * ew   # max words per attempt
@@ -311,15 +319,8 @@ class AXIMMQueue:
             else:
                 yield self.master.timeout(poll_interval)
 
-    def get(
-        self, nslots: int, poll_interval: float = DEFAULT_POLL_INTERVAL
-    ) -> ProcessGen[Words]:
-        """Dequeue exactly *nslots* slots, blocking until they are available.
-
-        Polls :meth:`try_get`, sleeping *poll_interval* simulation seconds when
-        the queue is empty; the loop is cancelled by simulation end like any
-        other SimObj process.
-        """
+    def _get_raw_slots(self, nslots: int, poll_interval: float) -> ProcessGen[Words]:
+        """Dequeue exactly *nslots* slots (blocking), returning the raw words."""
         ew = self.layout.elem_words
         out: list[Words] = []
         collected = 0
@@ -335,3 +336,82 @@ class AXIMMQueue:
             # than indexing out[0] on an empty list.
             return np.empty(0, dtype=self._dtype)
         return np.concatenate(out) if len(out) > 1 else out[0]
+
+    def write(
+        self,
+        data: Any,
+        element_type: type | None = None,
+        *,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+    ) -> ProcessGen[None]:
+        """Enqueue *data*, blocking until the whole batch is in (decision 8).
+
+        With ``element_type=None`` *data* is a raw word array.  With
+        *element_type* given, *data* is an array / iterable of elements that is
+        serialized (``elem_words`` words each) before enqueue — the layout's
+        ``elem_words`` must equal ``element_type.nwords_per_inst(mem_bw)``.
+
+        Either way the words are streamed through in pieces of at most the usable
+        depth (``capacity - 1`` slots), blocking as the consumer drains, until
+        every word is enqueued; there is no size guard.  The atomic single-shot
+        enqueue stays available as :meth:`try_write`.
+        """
+        if element_type is None:
+            words = data
+        else:
+            self._check_schema_elem_words(element_type)
+            from pysilicon.hw.arrayutils import write_array
+            words = write_array(data, elem_type=element_type, word_bw=self.layout.mem_bw)
+        yield from self._write_raw(words, poll_interval)
+
+    def get(
+        self,
+        schema_type: type | None = None,
+        count: int | None = None,
+        *,
+        nwords_max: int | None = None,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+    ) -> ProcessGen[Any]:
+        """Dequeue from the ring, blocking until the data is available.
+
+        Reuses the stream queue's signature exactly (decision 6;
+        :meth:`~pysilicon.hw.interface.StreamIFSlave.get`).
+
+        Raw path (``schema_type=None``) returns a NumPy word array; pass exactly
+        one of *count* (number of slots) or *nwords_max* (number of words, a
+        multiple of ``elem_words``) to say how much to dequeue.
+
+        Typed path (*schema_type* given) sets the element footprint from
+        ``schema_type.nwords_per_inst(mem_bw)`` (which must equal the layout's
+        ``elem_words``), dequeues, and deserializes: with *count* it returns a
+        ``count``-element :class:`~pysilicon.hw.dataschema.DataArray` (mirroring
+        ``StreamIFSlave.get``); without *count*, a single deserialized instance
+        (one slot).
+        """
+        ew = self.layout.elem_words
+        if schema_type is None:
+            if count is not None and nwords_max is not None:
+                raise ValueError("get: pass at most one of count / nwords_max")
+            if count is not None:
+                nslots = int(count)
+            elif nwords_max is not None:
+                if int(nwords_max) % ew != 0:
+                    raise ValueError(
+                        f"get: nwords_max={nwords_max} is not a multiple of "
+                        f"elem_words={ew}"
+                    )
+                nslots = int(nwords_max) // ew
+            else:
+                raise ValueError("get: raw path requires count or nwords_max")
+            return (yield from self._get_raw_slots(nslots, poll_interval))
+
+        # Typed path.
+        self._check_schema_elem_words(schema_type)
+        nslots = int(count) if count is not None else 1
+        raw = yield from self._get_raw_slots(nslots, poll_interval)
+        if count is not None:
+            from pysilicon.hw.arrayutils import read_array
+            return read_array(
+                raw, elem_type=schema_type, word_bw=self.layout.mem_bw, shape=int(count)
+            )
+        return schema_type().deserialize(raw, word_bw=self.layout.mem_bw)

--- a/tests/examples/test_aximm_queue_demo.py
+++ b/tests/examples/test_aximm_queue_demo.py
@@ -1,0 +1,18 @@
+"""Test that the aximm_queue_demo harness runs and self-checks."""
+from __future__ import annotations
+
+import numpy as np
+
+from examples.interface.aximm_queue_demo import AXIMMQueueDemo, run_and_check
+
+
+def test_aximm_queue_demo_passes():
+    demo = AXIMMQueueDemo()
+    received = demo.run_and_check()
+    # The consumer received the producer's exact sequence, in FIFO order.
+    np.testing.assert_array_equal(received, np.arange(demo.N, dtype=np.uint32))
+
+
+def test_run_and_check_entry_point():
+    received = run_and_check()
+    assert len(received) > 0

--- a/tests/hw/test_aximm_queue.py
+++ b/tests/hw/test_aximm_queue.py
@@ -17,12 +17,16 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
+import inspect
+
 from pysilicon.hw.aximm_queue import (
     AXIMMQueue,
     AXIMMQueueLayout,
     _split,
 )
 from pysilicon.hw.clock import Clock
+from pysilicon.hw.dataschema import DataList, IntField
+from pysilicon.hw.interface import StreamIFSlave
 from pysilicon.hw.memif import (
     AXIMMCrossBarIF,
     DirectMMIF,
@@ -31,6 +35,18 @@ from pysilicon.hw.memif import (
 )
 from pysilicon.hw.memory import MemComponent
 from pysilicon.simulation.simulation import Simulation
+
+
+# A 2-field struct used by the typed-access tests; each field is one 32-bit
+# word, so a Pair occupies elem_words == 2 at mem_bw == 32.
+_U32 = IntField.specialize(bitwidth=32, signed=False)
+
+
+class Pair(DataList):
+    elements = {
+        "a": {"schema": _U32, "description": "first word"},
+        "b": {"schema": _U32, "description": "second word"},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -318,7 +334,7 @@ class TestBlocking:
         def proc():
             yield from q.reset()
             yield from q.write(np.array([1, 2, 3], dtype=np.uint32))
-            got = yield from q.get(3)
+            got = yield from q.get(count=3)
             result["got"] = np.array(got)
 
         sim.env.process(proc())
@@ -332,7 +348,7 @@ class TestBlocking:
 
         def proc():
             yield from q.reset()
-            got = yield from q.get(0)
+            got = yield from q.get(count=0)
             result["got"] = np.array(got)
 
         sim.env.process(proc())
@@ -361,7 +377,7 @@ class TestConcurrentSPSC:
                 yield from pq.write(data[i:i + 4], poll_interval=1.0)
 
         def consumer():
-            got = yield from cq.get(N, poll_interval=1.0)
+            got = yield from cq.get(count=N, poll_interval=1.0)
             result["got"] = np.array(got)
 
         sim.env.process(producer())
@@ -388,7 +404,7 @@ class TestConcurrentSPSC:
                 yield from pq.write(data[i:i + 5], poll_interval=0.5)
 
         def consumer():
-            got = yield from cq.get(N, poll_interval=0.5)
+            got = yield from cq.get(count=N, poll_interval=0.5)
             result["got"] = np.array(got)
 
         sim.env.process(producer())
@@ -414,10 +430,149 @@ class TestConcurrentSPSC:
             yield from pq.write(data, poll_interval=1.0)
 
         def consumer():
-            got = yield from cq.get(N, poll_interval=1.0)
+            got = yield from cq.get(count=N, poll_interval=1.0)
             result["got"] = np.array(got)
 
         sim.env.process(producer())
         sim.env.process(consumer())
         sim.env.run()
         npt.assert_array_equal(result["got"], data)
+
+
+# ---------------------------------------------------------------------------
+# Multi-word slots (elem_words > 1), raw words
+# ---------------------------------------------------------------------------
+
+class TestMultiWordSlots:
+    def test_elem_words_4_wrap_and_fifo(self):
+        """A 4-word-per-slot ring preserves FIFO and integrity across the wrap.
+
+        capacity 4 (usable 3); repeatedly write 3 slots / get 3 slots forces the
+        slot pointers past the end so the wrap split (decision 10) is exercised
+        with multi-word slots.
+        """
+        sim, q = _make_queue_direct(capacity=4, elem_words=4)
+        out = []
+
+        def proc():
+            yield from q.reset()
+            nxt = 0
+            for _ in range(8):
+                words = np.arange(nxt, nxt + 3 * 4, dtype=np.uint32)  # 3 slots
+                ok = yield from q.try_write(words)
+                assert ok
+                got = yield from q.try_get(3)
+                out.append(np.array(got))
+                nxt += 3 * 4
+
+        sim.env.process(proc())
+        sim.env.run()
+        npt.assert_array_equal(np.concatenate(out), np.arange(8 * 3 * 4))
+
+    def test_blocking_get_raw_by_nwords_max(self):
+        """The raw path also accepts nwords_max (a word cap), like the stream."""
+        sim, q = _make_queue_direct(capacity=8, elem_words=2)
+        result = {}
+
+        def proc():
+            yield from q.reset()
+            yield from q.write(np.arange(6, dtype=np.uint32))  # 3 slots
+            got = yield from q.get(nwords_max=6)               # 6 words = 3 slots
+            result["got"] = np.array(got)
+
+        sim.env.process(proc())
+        sim.env.run()
+        npt.assert_array_equal(result["got"], np.arange(6))
+
+
+# ---------------------------------------------------------------------------
+# Typed write/get (stream signature, decision 6)
+# ---------------------------------------------------------------------------
+
+class TestTyped:
+    def test_typed_roundtrip_count(self):
+        """write(element_type=Pair) then get(Pair, count=N) round-trips fields."""
+        sim, q = _make_queue_direct(capacity=8, elem_words=2)   # Pair = 2 words
+        pairs = [Pair(a=i, b=i + 100) for i in range(5)]
+        result = {}
+
+        def proc():
+            yield from q.reset()
+            yield from q.write(pairs, Pair)
+            got = yield from q.get(Pair, count=5)
+            # The count path returns a DataArray; .val is a list of dict rows.
+            result["pairs"] = [(int(r["a"]), int(r["b"])) for r in got.val]
+
+        sim.env.process(proc())
+        sim.env.run()
+        assert result["pairs"] == [(i, i + 100) for i in range(5)]
+
+    def test_typed_single_instance(self):
+        """get(Pair) with no count returns one deserialized Pair instance."""
+        sim, q = _make_queue_direct(capacity=8, elem_words=2)
+        result = {}
+
+        def proc():
+            yield from q.reset()
+            yield from q.write([Pair(a=7, b=9)], Pair)
+            got = yield from q.get(Pair)
+            result["pair"] = (int(got.a), int(got.b))
+
+        sim.env.process(proc())
+        sim.env.run()
+        assert result["pair"] == (7, 9)
+
+    def test_typed_wrap_around(self):
+        """Typed access survives the ring wrap (multi-word slots)."""
+        sim, q = _make_queue_direct(capacity=4, elem_words=2)   # usable 3 slots
+        out = []
+
+        def proc():
+            yield from q.reset()
+            nxt = 0
+            for _ in range(6):
+                batch = [Pair(a=nxt + j, b=nxt + j + 1000) for j in range(3)]
+                yield from q.write(batch, Pair)
+                got = yield from q.get(Pair, count=3)
+                out.extend((int(r["a"]), int(r["b"])) for r in got.val)
+                nxt += 3
+
+        sim.env.process(proc())
+        sim.env.run()
+        expected = [(n, n + 1000) for n in range(6 * 3)]
+        assert out == expected
+
+    def test_get_signature_matches_stream(self):
+        """The dequeue signature reuses StreamIFSlave.get exactly (decision 6)."""
+        q_params = inspect.signature(AXIMMQueue.get).parameters
+        s_params = inspect.signature(StreamIFSlave.get).parameters
+        # Every stream parameter (schema_type, count, nwords_max) is present with
+        # the same kind on the queue; the queue only adds poll_interval.
+        for name in ("schema_type", "count", "nwords_max"):
+            assert name in q_params, f"queue get is missing {name}"
+            assert q_params[name].kind == s_params[name].kind
+        assert set(s_params) - {"self"} <= set(q_params)
+        assert "poll_interval" in q_params
+
+    def test_typed_elem_words_mismatch_raises(self):
+        """Typed access against a layout whose elem_words disagrees with the
+        schema raises a clear error (decision 11, typed layer)."""
+        sim, q = _make_queue_direct(capacity=8, elem_words=1)   # Pair needs 2
+
+        def write_proc():
+            yield from q.reset()
+            yield from q.write([Pair(a=1, b=2)], Pair)
+
+        sim.env.process(write_proc())
+        with pytest.raises(ValueError, match="elem_words"):
+            sim.env.run()
+
+        sim2, q2 = _make_queue_direct(capacity=8, elem_words=1)
+
+        def get_proc():
+            yield from q2.reset()
+            yield from q2.get(Pair, count=1)
+
+        sim2.env.process(get_proc())
+        with pytest.raises(ValueError, match="elem_words"):
+            sim2.env.run()

--- a/tests/hw/test_aximm_queue.py
+++ b/tests/hw/test_aximm_queue.py
@@ -1,10 +1,15 @@
 """
 Unit tests for pysilicon/hw/aximm_queue.py.
 
-Phase 1 coverage
-----------------
+Coverage
+--------
 AXIMMQueueLayout  — address math across mem_bw and elem_words, validation
-MMMemory          — burst round-trip over a DirectMMIF
+AXIMMQueue        — try_write/try_get core, blocking write/get, concurrent SPSC
+
+The ring is backed by a real ``MemComponent`` (decision 9): ``inline=False`` plus
+a single ``alloc`` puts the backing segment at byte 0, which is exactly where
+both the DirectMMIF (pass-through, base_addr=0) and crossbar (global − base)
+paths deliver their local addresses.
 """
 from __future__ import annotations
 
@@ -15,7 +20,6 @@ import pytest
 from pysilicon.hw.aximm_queue import (
     AXIMMQueue,
     AXIMMQueueLayout,
-    MMMemory,
     _split,
 )
 from pysilicon.hw.clock import Clock
@@ -25,6 +29,7 @@ from pysilicon.hw.memif import (
     MMIFMaster,
     assign_address_ranges,
 )
+from pysilicon.hw.memory import MemComponent
 from pysilicon.simulation.simulation import Simulation
 
 
@@ -32,19 +37,55 @@ from pysilicon.simulation.simulation import Simulation
 # Shared helpers
 # ---------------------------------------------------------------------------
 
+def _make_mem(sim, layout, clk):
+    """A ``MemComponent`` backing *layout*'s ring region.
+
+    ``inline=False`` + one ``alloc`` of the region's word count places the
+    segment at byte 0; the slave then accepts the local addresses ``[0,
+    total_bytes)`` that both interconnects deliver.
+    """
+    total_words = layout.total_bytes // layout.word_bytes
+    mem = MemComponent(sim=sim, word_size=layout.mem_bw, inline=False, clk=clk)
+    mem.alloc(total_words)
+    return mem
+
+
 def _make_queue_direct(capacity, *, elem_words=1, mem_bw=32, base_addr=0x0):
-    """One AXIMMQueue over a DirectMMIF + MMMemory; returns (sim, queue)."""
+    """One AXIMMQueue over a DirectMMIF + MemComponent; returns (sim, queue)."""
     sim = Simulation()
     clk = Clock(freq=1.0)
-    mem = MMMemory(sim=sim, bitwidth=mem_bw)
-    master = MMIFMaster(sim=sim, bitwidth=mem_bw)
-    direct = DirectMMIF(sim=sim, clk=clk)
-    direct.bind("master", master)
-    direct.bind("slave", mem.slave_ep)
     layout = AXIMMQueueLayout(
         base_addr=base_addr, capacity=capacity, elem_words=elem_words, mem_bw=mem_bw
     )
+    mem = _make_mem(sim, layout, clk)
+    master = MMIFMaster(sim=sim, bitwidth=mem_bw)
+    direct = DirectMMIF(sim=sim, clk=clk)
+    direct.bind("master", master)
+    direct.bind("slave", mem.s_mm)
     return sim, AXIMMQueue(master=master, layout=layout)
+
+
+def _make_spsc_crossbar(sim, layout, clk, *, latency_init=0.0, latency_read_return=0.0):
+    """Producer/consumer AXIMMQueues over a 2-master crossbar + MemComponent.
+
+    Returns ``(producer_queue, consumer_queue)`` sharing one ring region.
+    """
+    mem = _make_mem(sim, layout, clk)
+    xbar = AXIMMCrossBarIF(
+        sim=sim, clk=clk,
+        nports_master=2, nports_slave=1, bitwidth=layout.mem_bw,
+        latency_init=latency_init, latency_read_return=latency_read_return,
+    )
+    prod_master = MMIFMaster(sim=sim, bitwidth=layout.mem_bw)
+    cons_master = MMIFMaster(sim=sim, bitwidth=layout.mem_bw)
+    xbar.bind("master_0", prod_master)
+    xbar.bind("master_1", cons_master)
+    xbar.bind("slave_0", mem.s_mm)
+    assign_address_ranges([mem.s_mm], [(layout.base_addr, layout.total_bytes)])
+    return (
+        AXIMMQueue(master=prod_master, layout=layout),
+        AXIMMQueue(master=cons_master, layout=layout),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -103,72 +144,6 @@ class TestAXIMMQueueLayout:
             AXIMMQueueLayout(base_addr=0, capacity=4, elem_words=0)
         with pytest.raises(ValueError, match="mem_bw"):
             AXIMMQueueLayout(base_addr=0, capacity=4, mem_bw=128)
-
-
-# ---------------------------------------------------------------------------
-# MMMemory
-# ---------------------------------------------------------------------------
-
-class TestMMMemory:
-    def _make(self, bitwidth=32):
-        sim = Simulation()
-        clk = Clock(freq=1.0)
-        mem = MMMemory(sim=sim, bitwidth=bitwidth)
-        master = MMIFMaster(sim=sim, bitwidth=bitwidth)
-        direct = DirectMMIF(sim=sim, clk=clk)
-        direct.bind("master", master)
-        direct.bind("slave", mem.slave_ep)
-        return sim, master, mem
-
-    def test_burst_round_trip(self):
-        sim, master, mem = self._make()
-        data = np.arange(6, dtype=np.uint32) + 100
-        result = []
-
-        def proc():
-            yield from master.write(data, 0x0)
-            got = yield from master.read(6, 0x0)
-            result.append(got)
-
-        sim.env.process(proc())
-        sim.env.run()
-        npt.assert_array_equal(result[0], data)
-
-    def test_byte_stride_keys(self):
-        """Words are stored at byte addresses spaced by bitwidth // 8."""
-        sim, master, mem = self._make(bitwidth=32)
-
-        def proc():
-            yield from master.write(np.array([7, 8, 9], dtype=np.uint32), 0x10)
-
-        sim.env.process(proc())
-        sim.env.run()
-        assert mem._mem[0x10] == 7
-        assert mem._mem[0x14] == 8
-        assert mem._mem[0x18] == 9
-
-    def test_unwritten_reads_zero(self):
-        sim, master, mem = self._make()
-        result = []
-
-        def proc():
-            got = yield from master.read(3, 0x200)
-            result.append(got)
-
-        sim.env.process(proc())
-        sim.env.run()
-        npt.assert_array_equal(result[0], [0, 0, 0])
-
-    def test_64bit_stride(self):
-        sim, master, mem = self._make(bitwidth=64)
-
-        def proc():
-            yield from master.write(np.array([1, 2], dtype=np.uint64), 0x0)
-
-        sim.env.process(proc())
-        sim.env.run()
-        assert mem._mem[0x0] == 1
-        assert mem._mem[0x8] == 2   # stride 8 bytes for 64-bit
 
 
 # ---------------------------------------------------------------------------
@@ -336,17 +311,6 @@ class TestAXIMMQueueCore:
 # ---------------------------------------------------------------------------
 
 class TestBlocking:
-    def test_write_too_large_raises(self):
-        sim, q = _make_queue_direct(capacity=8)   # usable depth 7
-
-        def proc():
-            yield from q.reset()
-            yield from q.write(np.arange(8, dtype=np.uint32))   # 8 > 7
-
-        sim.env.process(proc())
-        with pytest.raises(ValueError, match="never fit"):
-            sim.env.run()
-
     def test_blocking_write_get_single_process(self):
         sim, q = _make_queue_direct(capacity=4)   # usable depth 3
         result = {}
@@ -361,6 +325,20 @@ class TestBlocking:
         sim.env.run()
         npt.assert_array_equal(result["got"], [1, 2, 3])
 
+    def test_get_zero_returns_empty(self):
+        """get(0) returns an empty array without indexing an empty list."""
+        sim, q = _make_queue_direct(capacity=4)
+        result = {}
+
+        def proc():
+            yield from q.reset()
+            got = yield from q.get(0)
+            result["got"] = np.array(got)
+
+        sim.env.process(proc())
+        sim.env.run()
+        assert len(result["got"]) == 0
+
 
 class TestConcurrentSPSC:
     def test_producer_consumer_crossbar(self):
@@ -370,22 +348,9 @@ class TestConcurrentSPSC:
         clk = Clock(freq=1.0)
         N = 100
         layout = AXIMMQueueLayout(base_addr=0x1000, capacity=8, mem_bw=32)
-
-        mem = MMMemory(sim=sim, bitwidth=32)
-        xbar = AXIMMCrossBarIF(
-            sim=sim, clk=clk,
-            nports_master=2, nports_slave=1, bitwidth=32,
-            latency_init=1.0, latency_read_return=1.0,
+        pq, cq = _make_spsc_crossbar(
+            sim, layout, clk, latency_init=1.0, latency_read_return=1.0
         )
-        prod_master = MMIFMaster(sim=sim, bitwidth=32)
-        cons_master = MMIFMaster(sim=sim, bitwidth=32)
-        xbar.bind("master_0", prod_master)
-        xbar.bind("master_1", cons_master)
-        xbar.bind("slave_0", mem.slave_ep)
-        assign_address_ranges([mem.slave_ep], [(layout.base_addr, layout.total_bytes)])
-
-        pq = AXIMMQueue(master=prod_master, layout=layout)
-        cq = AXIMMQueue(master=cons_master, layout=layout)
 
         data = np.arange(N, dtype=np.uint32)
         result = {}
@@ -412,20 +377,7 @@ class TestConcurrentSPSC:
         clk = Clock(freq=1.0)
         N = 30
         layout = AXIMMQueueLayout(base_addr=0x0, capacity=6, mem_bw=32)
-
-        mem = MMMemory(sim=sim, bitwidth=32)
-        xbar = AXIMMCrossBarIF(
-            sim=sim, clk=clk, nports_master=2, nports_slave=1, bitwidth=32,
-        )
-        prod_master = MMIFMaster(sim=sim, bitwidth=32)
-        cons_master = MMIFMaster(sim=sim, bitwidth=32)
-        xbar.bind("master_0", prod_master)
-        xbar.bind("master_1", cons_master)
-        xbar.bind("slave_0", mem.slave_ep)
-        assign_address_ranges([mem.slave_ep], [(layout.base_addr, layout.total_bytes)])
-
-        pq = AXIMMQueue(master=prod_master, layout=layout)
-        cq = AXIMMQueue(master=cons_master, layout=layout)
+        pq, cq = _make_spsc_crossbar(sim, layout, clk)
         data = np.arange(N, dtype=np.uint32) + 1000
         result = {}
 
@@ -437,6 +389,32 @@ class TestConcurrentSPSC:
 
         def consumer():
             got = yield from cq.get(N, poll_interval=0.5)
+            result["got"] = np.array(got)
+
+        sim.env.process(producer())
+        sim.env.process(consumer())
+        sim.env.run()
+        npt.assert_array_equal(result["got"], data)
+
+    def test_write_larger_than_depth_streams(self):
+        """A single ``write`` of an array far larger than the usable depth
+        streams through, blocking as the consumer drains — the case the old
+        all-or-nothing ``write`` raised on (decision 8)."""
+        sim = Simulation()
+        clk = Clock(freq=1.0)
+        N = 1000
+        layout = AXIMMQueueLayout(base_addr=0x0, capacity=8, mem_bw=32)  # usable 7
+        pq, cq = _make_spsc_crossbar(sim, layout, clk)
+        data = np.arange(N, dtype=np.uint32)
+        result = {}
+
+        def producer():
+            yield from pq.reset()
+            # One write call for the whole 1000-word array (>> usable depth 7).
+            yield from pq.write(data, poll_interval=1.0)
+
+        def consumer():
+            got = yield from cq.get(N, poll_interval=1.0)
             result["got"] = np.array(got)
 
         sim.env.process(producer())


### PR DESCRIPTION
Finishes the AXI-MM memory-backed ring buffer (plans/aximm_queue.md, Phases 3.5/4/6 on top of the already-merged Phases 1-3).

- **3.5** — back the ring with the real `MemComponent` (s_mm) instead of the throwaway `MMMemory`; `write` streams/chunks an array of any size (no more raise-if-too-large); fix `get(0)` to return empty.
- **4** — multi-word slots (`elem_words > 1`) + typed `write`/`get` matching `StreamIFSlave.get`'s exact signature, with a clear error on schema/layout footprint mismatch.
- **6** — standalone self-checking `aximm_queue_demo`: producer + consumer over an AXI-MM crossbar sharing one MemComponent ring, blocking on backpressure through an 8-slot ring.

Pure simulation (no Vitis). Independently verified: non-vitis suite 775 passed / 1 pre-existing unrelated failure (test_dataschema_poly poly.hpp, fails on main too). Optional Phases 5 (pointer caching) and 7 (docs) skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)