### PR TITLE
docs(shared_mem): histogram walkthrough + committed-figure workflow

### DIFF
--- a/docs/examples/shared_mem/aximm.md
+++ b/docs/examples/shared_mem/aximm.md
@@ -1,0 +1,169 @@
+---
+title: Understanding AXI Memory-Mapped
+parent: Shared Memory (histogram)
+nav_order: 1
+has_children: false
+---
+
+# Understanding AXI Memory-Mapped
+
+This is the first PySilicon example whose **data lives in memory** rather than on
+the control bus or a stream. The accelerator is handed *pointers* — byte
+addresses into a shared DRAM — reads its inputs from there over an AXI4
+memory-mapped (`m_axi`) master, and writes its outputs back the same way. It
+exists to introduce one idea: how a kernel moves bulk data to and from shared
+memory, and why that is a different interface from the control registers
+([regmap](../regmap/)) and the data streams ([stream_inband](../stream_inband/))
+of the earlier examples.
+
+## The data plane: AXI memory-mapped
+
+When an accelerator processes more than a handful of scalars — an array of
+samples, an image, a model's weights — that data is too big to pass through
+control registers and often does not arrive as a neat stream. Instead it sits in
+**shared DRAM** that both the host CPU and the FPGA kernel can address. The host
+writes the input buffers, hands the kernel their addresses, and reads the output
+buffers back afterwards. The kernel reaches into that memory directly.
+
+**AXI memory-mapped** (`m_axi` in Vitis HLS) is the AXI family member for exactly
+this. Unlike AXI-Lite — which reads or writes one 32-bit register at a time — an
+`m_axi` master issues **burst transfers**: it presents a base address and a
+length, and the memory streams back (or accepts) many consecutive words in one
+transaction. Bursting is what makes it bandwidth-efficient; a 37-element read is
+a couple of bus transactions, not 37 round-trips. The kernel sees memory as a
+flat, byte-addressed pointer (`ap_uint<32>* m_mem` in the generated C++), and the
+tool turns its array accesses into AXI read/write bursts.
+
+The three AXI interfaces divide up cleanly, and this example is where the third
+one finally appears:
+
+| Interface | Role | Access pattern | Introduced in |
+| --------- | ---- | -------------- | ------------- |
+| **AXI-Lite** | control plane — scalar args, start/done | one register at a time | [regmap](../regmap/) |
+| **AXI-Stream** | streaming data — flows through, no addresses | sequential, with `TLAST` | [stream_inband](../stream_inband/) |
+| **AXI memory-mapped** | bulk data in shared DRAM | random-access bursts at byte addresses | **this example** |
+
+## The shared-memory architecture
+
+A memory-mapped accelerator still needs a control plane: someone has to tell it
+*which* buffers to process, *how many* elements, and *where* to put the result —
+and the kernel has to report when it is done and whether it succeeded. This
+example keeps that control on a **dedicated AXI4-Stream**: the host pushes one
+**command** descriptor in on the input stream and reads one **response** back on
+the output stream, while all the bulk data moves over `m_axi`.
+
+> **Why split control from data?** The command is a few small fields; the data is
+> kilobytes. Putting the command on its own narrow stream keeps it cheap and
+> ordered (one command in, one response out, like a function call), while the
+> wide `m_axi` master is reserved for the high-bandwidth payload. The kernel's
+> control protocol is Vitis's `ap_ctrl_hs` handshake — the same start/done
+> contract the [regmap](../regmap/) example drove through registers, here driven
+> by the arrival of a command word.
+
+This is the **shared-memory pattern**: control over a stream, payload in memory
+addressed by pointers carried in the command. (A *memory-backed* control queue —
+where the commands themselves live in DRAM — is the separate, later `mem_queue`
+example; here the command path is a plain stream.)
+
+## The example: a histogram accelerator
+
+The vehicle is a **histogram**. Given `ndata` floating-point samples and a set of
+bin edges, it counts how many samples fall into each of `nbins` bins. That is a
+natural fit for shared memory: the samples and edges are arrays the host stages
+in DRAM, and the counts are an array the kernel writes back.
+
+Everything the kernel needs to find its data is packed into the **command
+descriptor** it reads off the input stream:
+
+```python
+# examples/shared_mem/hist_demo.py — HistCmd
+class HistCmd(DataList):
+    """Command descriptor for the histogram accelerator."""
+    elements = {
+        "tx_id":          {"schema": TxIdField},   # correlate command & response
+        "data_addr":      {"schema": AddrField},   # base address of the input samples
+        "bin_edges_addr": {"schema": AddrField},   # base address of the nbins-1 edges
+        "ndata":          {"schema": NdataField},  # number of samples
+        "nbins":          {"schema": NbinField},   # number of bins
+        "cnt_addr":       {"schema": AddrField},   # base address of the output counts
+    }
+```
+
+Three of those fields are **addresses** (`data_addr`, `bin_edges_addr`,
+`cnt_addr`) and two are **sizes** (`ndata`, `nbins`). The kernel reads the two
+input buffers, computes the histogram, and writes the counts buffer — three
+separate regions in the one shared memory, at independent addresses the command
+chose.
+
+## Byte addresses, words, and the allocator
+
+The command's addresses are **byte addresses** — the same currency a CPU pointer
+uses. Inside the kernel, memory is a pointer to 32-bit **words** (`ap_uint<32>*`),
+so a byte address is divided by the word size (4 bytes) to index it. The
+generated kernel does exactly this with a helper,
+`memmgr::byte_addr_to_word_index<32>(...)`, before each burst — the
+[code generation](codegen.md) page shows the lowered C++.
+
+Who decides the addresses? On the simulation and testbench side, a small
+**allocator** (`MemMgr` / the SimPy `MemComponent`) hands out non-overlapping
+regions in declaration order. The histogram needs three: `data`, then
+`bin_edges`, then `counts`. The allocator places them back-to-back and reports
+each region's base byte address, which the host stamps into the command. The
+kernel never allocates — it only follows the pointers it is given. This mirrors
+how a real host driver would `malloc` (or pin) the buffers and pass their
+addresses to the accelerator.
+
+## The execution model
+
+One histogram transaction is a fixed sequence:
+
+1. **Stage the inputs.** The host writes the `data` samples and the `bin_edges`
+   into their allocated regions in shared memory.
+2. **Issue the command.** The host pushes one `HistCmd` (the three addresses +
+   the two sizes + a transaction id) onto the input stream.
+3. **Validate.** The kernel checks the sizes and address alignment; if anything
+   is out of range it selects a `HistError` and skips straight to the response —
+   no memory is touched.
+4. **Read.** The kernel bursts `ndata` samples from `data_addr` and `nbins-1`
+   edges from `bin_edges_addr` over `m_axi`.
+5. **Compute.** It bins the samples (the count of edges each sample meets or
+   exceeds) into `nbins` counts.
+6. **Write.** It bursts the `nbins` counts back to `cnt_addr`.
+7. **Respond.** It emits one `HistResp` (the echoed `tx_id` + the status) on the
+   output stream.
+8. **Read the result.** The host reads the counts back from `cnt_addr`.
+
+Steps 3–7 are the kernel; steps 1–2 and 8 are the host. The validation in step 3
+is what makes the response carry a **status** rather than just data — the host
+learns *why* a transaction failed (bad `ndata`, bad `nbins`, a misaligned
+address) without the kernel ever reading garbage memory.
+
+### What the Python model abstracts away
+
+In the simulation you do not hand-assemble bursts or compute word indices. The
+kernel issues typed array operations against its memory master, and the framework
+lowers them to the right AXI bursts:
+
+```python
+# examples/shared_mem/hist.py — HistAccel.run_proc (excerpt)
+data = yield from self.m_mem.read_array(
+    Float32, cmd.ndata, cmd.data_addr, max_count=self.max_ndata)
+edges = yield from self.m_mem.read_array(
+    Float32, cmd.nbins - 1, cmd.bin_edges_addr, max_count=self.max_nbins)
+...
+yield from self.m_mem.write_array(
+    counts, Uint32Field, cmd.cnt_addr, cmd.nbins, max_count=self.max_nbins)
+```
+
+The **same** `read_array` / `write_array` calls drive the SimPy simulation, and
+the **same** Python source is lowered to the Vitis HLS kernel's `m_axi` bursts —
+so the buffer layout and the access pattern can never drift between the model and
+the hardware.
+
+---
+
+The rest of this example follows the same accelerator through the full PySilicon
+flow: [the Python model](python.md), [running it in SimPy](pysim.md),
+[generating the Vitis kernel](codegen.md),
+[validating the RTL](rtlsim.md), and
+[viewing the timing and burst diagrams](timing.md).

--- a/docs/examples/shared_mem/codegen.md
+++ b/docs/examples/shared_mem/codegen.md
@@ -1,0 +1,214 @@
+---
+title: Vitis HLS Code Generation
+parent: Shared Memory (histogram)
+nav_order: 4
+has_children: false
+---
+
+# Vitis HLS Code Generation
+
+The same `HistAccel` Python class that ran in SimPy is the source the Vitis HLS
+kernel is generated from. PySilicon emits everything mechanical — the `m_axi`
+function signature, the interface pragmas, the multi-buffer burst calls, the
+validation-status plumbing — and leaves only the datapath hooks as hand-written
+C++. This page walks the generated kernel, the generated testbench, and the seam
+between generated and hand-written code.
+
+## Running the generation
+
+For the histogram example the generation is a small helper,
+`generate_vitis_sources`, in
+[`shared_mem_build.py`](../../../examples/shared_mem/shared_mem_build.py). It
+writes the support headers, then lowers the kernel and the testbench:
+
+```python
+# examples/shared_mem/shared_mem_build.py — generate_vitis_sources
+(gen / "hist.cpp").write_text(kernel_to_cpp(HistAccel))
+(gen / "hist.hpp").write_text(header_to_cpp(HistAccel))
+for fname, content in tb_files_to_str(HistTBHls).items():
+    (gen / fname).write_text(content)          # gen/hist_tb.cpp
+```
+
+`kernel_to_cpp(HistAccel)` lowers the `run_proc` body; `tb_files_to_str(HistTBHls)`
+lowers the testbench's `main()`. Both come from the **same Python source** you
+already simulated — there is no second description of the kernel to keep in sync.
+
+After it runs, `gen/` holds three framework-owned files, and three hand-written
+hook files sit next to the Python source:
+
+| File | Owner | Lifecycle |
+| ---- | ----- | --------- |
+| `gen/hist.hpp` | framework | rewritten each run |
+| `gen/hist.cpp` | framework | rewritten each run |
+| `gen/hist_tb.cpp` | framework | rewritten each run |
+| `hist_validate_impl.cpp` | user | committed — the validation logic |
+| `hist_compute_impl.cpp` | user | committed — the binning datapath |
+| `hist_respond_impl.tpp` | user | committed — the response write |
+
+`gen/` is `.gitignored` — generated files are never committed; the hooks **are**
+committed because they hold logic no codegen pass reproduces.
+
+## The kernel signature and pragmas
+
+The generated top-level function is where the three Python ports become the three
+AXI interfaces:
+
+```cpp
+// gen/hist.cpp
+void hist(
+    hls::stream<streamutils::axi4s_word<32>>& s_in,
+    hls::stream<streamutils::axi4s_word<32>>& m_out,
+    ap_uint<32>* m_mem
+) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE m_axi port=m_mem offset=slave bundle=gmem depth=m_mem_depth
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+```
+
+- **`s_in` / `m_out`** become AXI4-Stream ports (`axis`) — the command in, the
+  response out.
+- **`m_mem`** becomes the AXI memory-mapped master: a plain `ap_uint<32>*` with an
+  `m_axi` pragma. `offset=slave` means the base address is itself programmed over
+  the control interface; `bundle=gmem` puts all of this kernel's memory traffic on
+  one shared port.
+- **`depth=m_mem_depth`** sizes the interface for co-simulation. That constant is
+  the **sum of the buffer maxima** — the worst-case number of words the kernel
+  could touch:
+
+  ```cpp
+  // gen/hist.hpp
+  static const int m_mem_depth = max_ndata + max_nbins + max_nbins;
+  ```
+
+  i.e. `data` (`max_ndata`) + `edges` (`max_nbins`) + `counts` (`max_nbins`).
+  The `max_ndata` / `max_nbins` HwParams from the Python model drive this directly.
+- **`ap_ctrl_hs`** is the start/done handshake — the same control contract as the
+  [regmap example](../regmap/), here implicit on the kernel rather than exposed as
+  registers.
+
+## The body: validate, then multi-buffer bursts
+
+The lowered `run_proc` reads exactly like the Python it came from:
+
+```cpp
+// gen/hist.cpp
+HistCmd cmd;
+cmd.read_axi4_stream<32>(s_in);
+ap_uint<8> status = hist_impl::validate(cmd);
+if (status != (ap_uint<8>)static_cast<unsigned int>(HistError::NO_ERROR)) {
+    hist_impl::respond(m_out, cmd.tx_id, status);
+    return;
+}
+static float data[max_ndata];
+float32_array_utils::read_array<32>(m_mem + memmgr::byte_addr_to_word_index<32>(cmd.data_addr), data, cmd.ndata);
+static float edges[max_nbins];
+float32_array_utils::read_array<32>(m_mem + memmgr::byte_addr_to_word_index<32>(cmd.bin_edges_addr), edges, cmd.nbins - 1);
+static ap_uint<32> counts[32];
+hist_impl::compute(data, edges, cmd.ndata, cmd.nbins, counts);
+uint32_array_utils::write_array<32>(counts, m_mem + memmgr::byte_addr_to_word_index<32>(cmd.cnt_addr), cmd.nbins);
+hist_impl::respond(m_out, cmd.tx_id, status);
+```
+
+The pieces this example exists to exercise:
+
+1. **Multi-buffer, multi-type lowering.** Three `read_array`/`write_array` calls
+   target the **one** `m_mem` pointer at three different command addresses, with
+   **two** element types — `float32_array_utils::read_array` for `data` and
+   `edges`, `uint32_array_utils::write_array` for `counts`. Each Python
+   `read_array(Float32, ...)` / `write_array(Uint32Field, ...)` chose its
+   array-utils namespace from the schema's element type.
+2. **Byte address → word index.** Every burst wraps the command's byte address in
+   `memmgr::byte_addr_to_word_index<32>(...)` before indexing the word pointer —
+   the same conversion the SimPy `DirectMMIF` did.
+3. **The runtime count is the Python expression, verbatim.** `cmd.ndata` and
+   `cmd.nbins - 1` are lowered straight from the model's `read_array` arguments —
+   including the `nbins - 1` edge count, a no-op burst when `nbins == 1`.
+4. **Compute returns an array via an out-parameter.** HLS cannot return an array
+   by value, so the generator declares the `static ap_uint<32> counts[...]` buffer
+   in the kernel and passes it to `hist_impl::compute(..., counts)` — the Python
+   `compute` "returns" the counts; the C++ fills them in place.
+5. **Validation is a status, checked once.** `validate` returns an `ap_uint<8>`;
+   the `!=` against `NO_ERROR` is the one branch, and on failure the kernel
+   responds and returns before touching memory.
+
+The header also declares the three hooks the body calls into:
+
+```cpp
+// gen/hist.hpp
+namespace hist_impl {
+    ap_uint<8> validate(HistCmd cmd);
+    template <int out_bw>
+    void respond(hls::stream<streamutils::axi4s_word<out_bw>>& m_out, int tx_id, ap_uint<8> status);
+    void compute(float data[1024], float edges[32], int ndata, int nbins, ap_uint<32> out[32]);
+}
+```
+
+## The hand-written datapath
+
+The hooks supply the bodies. `hist_compute_impl.cpp` is the binning datapath — the
+loop that turns samples into counts:
+
+```cpp
+// examples/shared_mem/hist_compute_impl.cpp — hist_impl::compute
+for (int i = 0; i < ndata; ++i) {
+#pragma HLS LOOP_TRIPCOUNT min=1 max=max_ndata
+    float sample = data[i];
+    int bin = 0;
+hist_search:
+    for (int b = 0; b < nbins - 1; ++b) {
+#pragma HLS LOOP_TRIPCOUNT min=1 max=max_nbins
+#pragma HLS PIPELINE II=1
+        if (sample >= edges[b]) bin = b + 1;
+    }
+    out[bin] = out[bin] + 1;
+}
+```
+
+This is the same rule as the Python golden — the bin is the number of edges a
+sample meets or exceeds — written once, by hand, with the HLS pragmas that make it
+synthesize well. `hist_validate_impl.cpp` and `hist_respond_impl.tpp` similarly
+hold the bounds/alignment checks and the response write. They are committed; the
+generated `gen/` files that call them are not. (See
+[`CODEGEN_NOTES.md`](../../../examples/shared_mem/CODEGEN_NOTES.md) for the full
+generated-vs-hand-written breakdown.)
+
+## The generated testbench
+
+`tb_files_to_str(HistTBHls)` lowers the testbench `main()` into `gen/hist_tb.cpp`.
+It allocates the three regions in the same order the SimPy controller did, and —
+because a runtime count can be `0` (`nbins-1` edges when `nbins == 1`, or an
+invalid size) — it **clamps every allocation to at least one word**:
+
+```cpp
+// gen/hist_tb.cpp (one of three regions)
+const int _cmd_data_addr_nwords = float32_array_utils::get_nwords<32>(cmd.ndata);
+const int _cmd_data_addr_widx = mem_mgr.alloc(_cmd_data_addr_nwords > 0 ? _cmd_data_addr_nwords : 1);
+cmd.data_addr = _cmd_data_addr_widx * (32 / 8);
+float32_array_utils::write_array<32>(data, mem + _cmd_data_addr_widx, cmd.ndata);
+```
+
+A 0-word region is meaningless and the allocator rejects it, so the testbench
+reserves one word it never uses — the same `max(nedges, 1)` clamp the SimPy
+controller applied. The generated TB writes the kernel's response and counts back
+out as `.bin` files, which the [C and RTL simulation](rtlsim.md) flow checks
+against the golden.
+
+## Running the codegen
+
+The generation needs no Vitis — it is pure Python:
+
+```bash
+cd examples/shared_mem
+python -c "from shared_mem_build import generate_vitis_sources; generate_vitis_sources('.')"
+ls gen/        # hist.cpp  hist.hpp  hist_tb.cpp
+```
+
+After it lands, inspect `gen/hist.cpp` and confirm the three hook `.cpp`/`.tpp`
+files exist in the example directory.
+
+## Next
+
+- [C and RTL simulation](rtlsim.md) — compiling the generated kernel + testbench
+  with Vitis HLS, the four-case C-sim coverage, C-synthesis, RTL co-simulation,
+  and the multi-buffer burst extraction.

--- a/docs/examples/shared_mem/images/burst_diagram.svg
+++ b/docs/examples/shared_mem/images/burst_diagram.svg
@@ -1,0 +1,1211 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="559.628125pt" height="204.018375pt" viewBox="0 0 559.628125 204.018375" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 204.018375 
+L 559.628125 204.018375 
+L 559.628125 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 68.584375 166.462125 
+L 542.884375 166.462125 
+L 542.884375 22.318125 
+L 68.584375 22.318125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 77.884375 166.462125 
+L 77.884375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="md2f1dec9ba" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="77.884375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(74.703125 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 136.009375 166.462125 
+L 136.009375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="136.009375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 25 -->
+      <g transform="translate(129.646875 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 194.134375 166.462125 
+L 194.134375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="194.134375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 50 -->
+      <g transform="translate(187.771875 181.060563) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 252.259375 166.462125 
+L 252.259375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="252.259375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 75 -->
+      <g transform="translate(245.896875 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 310.384375 166.462125 
+L 310.384375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="310.384375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 100 -->
+      <g transform="translate(300.840625 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 368.509375 166.462125 
+L 368.509375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="368.509375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 125 -->
+      <g transform="translate(358.965625 181.060563) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 426.634375 166.462125 
+L 426.634375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="426.634375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 150 -->
+      <g transform="translate(417.090625 181.060563) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 484.759375 166.462125 
+L 484.759375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="484.759375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 175 -->
+      <g transform="translate(475.215625 181.060563) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 542.884375 166.462125 
+L 542.884375 22.318125 
+" clip-path="url(#pcfc2ee2dc1)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="542.884375" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 200 -->
+      <g transform="translate(533.340625 181.060563) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_10">
+     <!-- byte address into the gmem bundle -->
+     <g transform="translate(216.051563 194.738687) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-62"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(122.65625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(161.865234 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(223.388672 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(255.175781 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(316.455078 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(379.931641 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(443.408203 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(482.271484 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(543.794922 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(595.894531 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(647.994141 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(679.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(707.564453 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(770.943359 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(810.152344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(871.333984 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(903.121094 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(942.330078 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1005.708984 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1067.232422 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1099.019531 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1162.496094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1259.908203 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1321.431641 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1418.84375 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(1450.630859 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1514.107422 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1577.486328 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1640.865234 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1704.341797 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1732.125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_19"/>
+     <g id="text_11">
+      <!-- m_axi read -->
+      <g transform="translate(9.825 65.429344) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(97.412109 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-78" transform="translate(208.691406 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(267.871094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(295.654297 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(327.441406 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(366.304688 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(427.828125 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(489.107422 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_20"/>
+     <g id="text_12">
+      <!-- m_axi write -->
+      <g transform="translate(7.2 130.949344) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(97.412109 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(147.412109 0)"/>
+       <use xlink:href="#DejaVuSans-78" transform="translate(208.691406 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(267.871094 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(295.654297 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(327.441406 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(409.228516 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(450.341797 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(478.125 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(517.333984 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 68.584375 166.462125 
+L 542.884375 166.462125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 77.884375 81.286125 
+L 226.684375 81.286125 
+L 226.684375 41.974125 
+L 77.884375 41.974125 
+z
+" clip-path="url(#pcfc2ee2dc1)" style="fill: #4c78a8; stroke: #ffffff; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 226.684375 81.286125 
+L 375.484375 81.286125 
+L 375.484375 41.974125 
+L 226.684375 41.974125 
+z
+" clip-path="url(#pcfc2ee2dc1)" style="fill: #4c78a8; stroke: #ffffff; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 375.484375 81.286125 
+L 421.984375 81.286125 
+L 421.984375 41.974125 
+L 375.484375 41.974125 
+z
+" clip-path="url(#pcfc2ee2dc1)" style="fill: #4c78a8; stroke: #ffffff; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 421.984375 81.286125 
+L 468.484375 81.286125 
+L 468.484375 41.974125 
+L 421.984375 41.974125 
+z
+" clip-path="url(#pcfc2ee2dc1)" style="fill: #54a24b; stroke: #ffffff; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 468.484375 146.806125 
+L 524.284375 146.806125 
+L 524.284375 107.494125 
+L 468.484375 107.494125 
+z
+" clip-path="url(#pcfc2ee2dc1)" style="fill: #e45756; stroke: #ffffff; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_13">
+    <!-- Multi-buffer AXI-MM burst layout (ndata=37, nbins=6) -->
+    <g transform="translate(142.975 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 403 4666 
+L 1081 4666 
+L 2241 2931 
+L 3406 4666 
+L 4084 4666 
+L 2584 2425 
+L 4184 0 
+L 3506 0 
+L 2194 1984 
+L 872 0 
+L 191 0 
+L 1856 2491 
+L 403 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4d"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(86.279297 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(149.658203 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(177.441406 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(216.650391 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(244.433594 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(280.517578 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(343.994141 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(407.373047 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(442.578125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(477.783203 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(539.306641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(580.419922 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(612.207031 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(680.615234 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(749.121094 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(778.613281 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(814.697266 0)"/>
+     <use xlink:href="#DejaVuSans-4d" transform="translate(900.976562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(987.255859 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1019.042969 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1082.519531 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1145.898438 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1187.011719 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1239.111328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1278.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1310.107422 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1337.890625 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(1399.169922 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1458.349609 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1519.53125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1582.910156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1622.119141 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1653.90625 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1692.919922 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1756.298828 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1819.775391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1881.054688 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1920.263672 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1981.542969 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2065.332031 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2128.955078 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2192.578125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2224.365234 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2256.152344 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2319.53125 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2383.007812 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2410.791016 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2474.169922 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2526.269531 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2610.058594 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2673.681641 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- data -->
+    <g style="fill: #ffffff" transform="translate(143.274375 59.3585) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-64"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(124.755859 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(163.964844 0)"/>
+    </g>
+    <!-- 16w -->
+    <g style="fill: #ffffff" transform="translate(143.923125 68.31675) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- data -->
+    <g style="fill: #ffffff" transform="translate(292.074375 59.3585) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-64"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(124.755859 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(163.964844 0)"/>
+    </g>
+    <!-- 16w -->
+    <g style="fill: #ffffff" transform="translate(292.723125 68.31675) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(127.246094 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- data -->
+    <g style="fill: #ffffff" transform="translate(389.724375 59.3585) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-64"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(124.755859 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(163.964844 0)"/>
+    </g>
+    <!-- 5w -->
+    <g style="fill: #ffffff" transform="translate(392.918125 68.31675) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- bin_edges -->
+    <g style="fill: #ffffff" transform="translate(424.96375 59.24725) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-62"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(91.259766 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(154.638672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(204.638672 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(266.162109 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(329.638672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(393.115234 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(454.638672 0)"/>
+    </g>
+    <!-- 5w -->
+    <g style="fill: #ffffff" transform="translate(439.418125 68.428) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- counts -->
+    <g style="fill: #ffffff" transform="translate(483.015625 124.8785) scale(0.08 -0.08)">
+     <defs>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-63"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(116.162109 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(179.541016 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(242.919922 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(282.128906 0)"/>
+    </g>
+    <!-- 6w -->
+    <g style="fill: #ffffff" transform="translate(490.568125 133.83675) scale(0.08 -0.08)">
+     <use xlink:href="#DejaVuSans-36"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pcfc2ee2dc1">
+   <rect x="68.584375" y="22.318125" width="474.3" height="144.144"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/examples/shared_mem/images/timing_diagram.svg
+++ b/docs/examples/shared_mem/images/timing_diagram.svg
@@ -1,0 +1,1275 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="564.720116pt" height="204.018375pt" viewBox="0 0 564.720116 204.018375" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 204.018375 
+L 564.720116 204.018375 
+L 564.720116 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 7.2 166.462125 
+L 481.5 166.462125 
+L 481.5 22.318125 
+L 7.2 22.318125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 49.413386 166.462125 
+L 49.413386 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="md2f1dec9ba" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="49.413386" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 1000 -->
+      <g transform="translate(36.688386 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 118.053039 166.462125 
+L 118.053039 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="118.053039" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2000 -->
+      <g transform="translate(105.328039 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 186.692692 166.462125 
+L 186.692692 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="186.692692" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 3000 -->
+      <g transform="translate(173.967692 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 255.332344 166.462125 
+L 255.332344 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="255.332344" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4000 -->
+      <g transform="translate(242.607344 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 323.971997 166.462125 
+L 323.971997 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="323.971997" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 5000 -->
+      <g transform="translate(311.246997 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 392.61165 166.462125 
+L 392.61165 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="392.61165" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 6000 -->
+      <g transform="translate(379.88665 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 461.251302 166.462125 
+L 461.251302 22.318125 
+" clip-path="url(#p06c4d08db2)" style="fill: none; stroke: #dddddd; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#md2f1dec9ba" x="461.251302" y="166.462125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 7000 -->
+      <g transform="translate(448.526302 181.060563) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- time [ns]   (clk period = 10 ns) -->
+     <g transform="translate(167.476562 194.738687) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863 
+L 1875 4863 
+L 1875 4416 
+L 1125 4416 
+L 1125 -397 
+L 1875 -397 
+L 1875 -844 
+L 550 -844 
+L 550 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863 
+L 1947 -844 
+L 622 -844 
+L 622 -397 
+L 1369 -397 
+L 1369 4416 
+L 622 4416 
+L 622 4863 
+L 1947 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(296.728516 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(360.107422 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(412.207031 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(451.220703 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(483.007812 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(514.794922 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(546.582031 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(585.595703 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(640.576172 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(668.359375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(726.269531 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(758.056641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(821.533203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(883.056641 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(924.169922 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(951.953125 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1013.134766 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1076.611328 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(1108.398438 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1192.1875 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(1223.974609 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(1287.597656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1351.220703 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1383.007812 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1446.386719 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1498.486328 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2"/>
+   <g id="patch_3">
+    <path d="M 7.2 166.462125 
+L 481.5 166.462125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 8.572793 47.266125 
+L 9.25919 47.266125 
+L 9.25919 30.634125 
+L 8.572793 30.634125 
+z
+" clip-path="url(#p06c4d08db2)" style="fill: #b279a2; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 9.25919 74.986125 
+L 46.324602 74.986125 
+L 46.324602 58.354125 
+L 9.25919 58.354125 
+z
+" clip-path="url(#p06c4d08db2)" style="fill: #4c78a8; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 46.324602 102.706125 
+L 462.967294 102.706125 
+L 462.967294 86.074125 
+L 46.324602 86.074125 
+z
+" clip-path="url(#p06c4d08db2)" style="fill: #9d9d9d; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 462.967294 130.426125 
+L 466.399276 130.426125 
+L 466.399276 113.794125 
+L 462.967294 113.794125 
+z
+" clip-path="url(#p06c4d08db2)" style="fill: #e45756; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 466.399276 158.146125 
+L 467.085673 158.146125 
+L 467.085673 141.514125 
+L 466.399276 141.514125 
+z
+" clip-path="url(#p06c4d08db2)" style="fill: #b279a2; stroke: #ffffff; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_9">
+    <!-- Histogram transaction timeline (ndata=37, nbins=6, from RTL cosim) -->
+    <g transform="translate(35.764688 16.318125) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-48" d="M 628 4666 
+L 1259 4666 
+L 1259 2753 
+L 3553 2753 
+L 3553 4666 
+L 4184 4666 
+L 4184 0 
+L 3553 0 
+L 3553 2222 
+L 1259 2222 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-48"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(75.195312 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(102.978516 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(155.078125 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(194.287109 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(255.46875 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(318.945312 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(360.058594 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(421.337891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(518.75 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(550.537109 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(589.746094 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(630.859375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(692.138672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(755.517578 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(807.617188 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(868.896484 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(923.876953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(963.085938 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(990.869141 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1052.050781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1115.429688 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1147.216797 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1186.425781 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1214.208984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1311.621094 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1373.144531 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1400.927734 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1428.710938 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1492.089844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1553.613281 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1585.400391 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1624.414062 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1687.792969 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1751.269531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1812.548828 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1851.757812 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(1913.037109 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(1996.826172 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2060.449219 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2124.072266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2155.859375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2187.646484 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2251.025391 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2314.501953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2342.285156 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2405.664062 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2457.763672 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2541.552734 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2605.175781 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2636.962891 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(2668.75 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2703.955078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2742.818359 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2804 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2901.412109 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2933.199219 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(2995.431641 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(3056.515625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3112.228516 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3144.015625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3198.996094 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3260.177734 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3312.277344 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3340.060547 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3437.472656 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- command in  (1 cyc) -->
+    <g transform="translate(9.945586 41.295594) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-63"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(213.574219 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(310.986328 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(372.265625 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(435.644531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(499.121094 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(530.908203 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(558.691406 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(622.070312 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(653.857422 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(685.644531 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(724.658203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(788.28125 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(820.068359 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(875.048828 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(934.228516 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(989.208984 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- read data + edges  (54 cyc) -->
+    <g transform="translate(47.010999 69.015594) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-2b" d="M 2944 4013 
+L 2944 2272 
+L 4684 2272 
+L 4684 1741 
+L 2944 1741 
+L 2944 0 
+L 2419 0 
+L 2419 1741 
+L 678 1741 
+L 678 2272 
+L 2419 2272 
+L 2419 4013 
+L 2944 4013 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-72"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(38.863281 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(100.386719 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(161.666016 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(225.142578 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(256.929688 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(320.40625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(381.685547 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(420.894531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(482.173828 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(513.960938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(597.75 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(629.537109 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(691.060547 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(754.537109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(818.013672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(879.537109 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(931.636719 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(963.423828 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(995.210938 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(1034.224609 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(1097.847656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1161.470703 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1193.257812 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(1248.238281 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1307.417969 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1362.398438 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- compute  (607 cyc) -->
+    <g transform="translate(463.65369 96.735594) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-63"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(116.162109 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(213.574219 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(277.050781 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(340.429688 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(379.638672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(441.162109 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(472.949219 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(504.736328 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(543.75 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(607.373047 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(670.996094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(734.619141 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(766.40625 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(821.386719 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(880.566406 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(935.546875 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- write counts  (5 cyc) -->
+    <g transform="translate(467.085673 124.455594) scale(0.085 -0.085)">
+     <defs>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-77"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(81.787109 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(122.900391 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(150.683594 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(189.892578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(251.416016 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(283.203125 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(338.183594 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(399.365234 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(462.744141 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(526.123047 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(565.332031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(617.431641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(649.21875 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(681.005859 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(720.019531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(783.642578 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(815.429688 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(870.410156 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(929.589844 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(984.570312 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- response out  (1 cyc) -->
+    <g transform="translate(467.772069 152.175594) scale(0.085 -0.085)">
+     <use xlink:href="#DejaVuSans-72"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(38.863281 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(100.386719 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(152.486328 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(215.962891 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(277.144531 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(340.523438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(392.623047 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(454.146484 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(485.933594 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(547.115234 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(610.494141 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(649.703125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(681.490234 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(713.277344 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(752.291016 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(815.914062 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(847.701172 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(902.681641 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(961.861328 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1016.841797 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p06c4d08db2">
+   <rect x="7.2" y="22.318125" width="474.3" height="144.144"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/examples/shared_mem/index.md
+++ b/docs/examples/shared_mem/index.md
@@ -2,7 +2,7 @@
 title: Shared Memory (histogram)
 parent: Examples
 nav_order: 4
-has_children: false
+has_children: true
 ---
 
 # Shared Memory (histogram)
@@ -32,3 +32,20 @@ Like the other full examples it walks all five stages — Python model → SimPy
 simulation → code generation → C and RTL simulation → timing extraction — with
 the kernel and testbench generated from the Python `HistAccel` component. It is
 the reference design for AXI-MM (`m_axi`) codegen.
+
+## Walkthrough
+
+1. [Understanding AXI Memory-Mapped](aximm.md) — what `m_axi` is (burst
+   transfers, byte-addressed pointers into shared DRAM), and the shared-memory
+   architecture: bulk data in memory, command/response on a dedicated stream.
+2. [Python model](python.md) — the `HistAccel` component, the `HistCmd` /
+   `HistResp` / `HistError` schemas, and the `MMIFMaster` (`read_array` /
+   `write_array`) interface.
+3. [Python simulation](pysim.md) — the SimPy harness (`HistController` +
+   `MemComponent`) and parity against the numpy golden.
+4. [Code generation](codegen.md) — lowering `HistAccel` / `HistTBHls` to the
+   multi-buffer m_axi Vitis HLS kernel and testbench.
+5. [C and RTL simulation](rtlsim.md) — the four-case C-sim coverage, C-synthesis,
+   RTL co-simulation, and multi-buffer burst extraction.
+6. [Viewing timing and bursts](timing.md) — the committed timing/burst figures
+   and the workflow for refreshing them.

--- a/docs/examples/shared_mem/pysim.md
+++ b/docs/examples/shared_mem/pysim.md
@@ -1,0 +1,187 @@
+---
+title: Python Simulation
+parent: Shared Memory (histogram)
+nav_order: 3
+has_children: false
+---
+
+# Python simulation
+
+Python simulation is fast and easy to debug, so we run the histogram in SimPy
+before ever invoking Vitis. This page shows the simulation harness — the host
+controller that drives one transaction, the `MemComponent` that stands in for
+shared DRAM, and how the kernel-produced counts are checked against the numpy
+golden. The harness is `run_sim()` in
+[`examples/shared_mem/hist.py`](../../../examples/shared_mem/hist.py).
+
+## What a SimPy run needs
+
+Unlike the [regmap example](../regmap/pysim.md), where the host talks to the
+kernel over a single AXI-Lite link, the histogram has **two** participants on
+**three** interfaces: a host/controller that issues the command and stages the
+data, the accelerator, and a shared memory both reach. The harness instantiates
+all three and wires them together:
+
+```python
+# examples/shared_mem/hist.py — run_sim
+def run_sim(data, bin_edges, nbins, *, clk_freq=1e9, tx_id=7, addr_misalign=0):
+    sim = Simulation()
+    clk = Clock(freq=clk_freq)
+    mem   = MemComponent(name="mem", sim=sim, inline=False, clk=clk)
+    accel = HistAccel(name="hist_accel", sim=sim, clk=clk)
+    ctrl  = HistController(name="hist_ctrl", sim=sim, mem=mem,
+                           data=data, bin_edges=bin_edges, nbins=nbins, tx_id=tx_id,
+                           addr_misalign=addr_misalign)
+    connect(sim, ctrl, accel, mem, clk)
+    sim.run_sim()
+
+    expected = golden_counts(data, bin_edges, nbins)
+    return HistResult(counts=ctrl.counts, expected=expected, status=ctrl.resp.status)
+```
+
+Three SimObjs share one `Simulation` and one `Clock`:
+
+- **`MemComponent`** is the shared memory — a SimPy model of a byte-addressed
+  word memory behind an AXI-MM **slave** endpoint. It is where the `data`,
+  `bin_edges`, and `counts` buffers live; both the controller (to stage inputs
+  and read results) and the accelerator (to do the work) reach it over `m_axi`.
+  `inline=False` makes it its own scheduled process rather than a passive object,
+  so its accesses take simulated time on the clock.
+- **`HistAccel`** is the [accelerator](python.md) under test.
+- **`HistController`** is the host stand-in — the SimObj that plays the CPU
+  driver.
+
+## The controller — one transaction, end to end
+
+`HistController.run_proc` is the host-side sequence the [concept page](aximm.md)
+laid out: allocate the three regions, stage the inputs, issue the command, await
+the response, read the counts back.
+
+```python
+# examples/shared_mem/hist.py — HistController.run_proc
+# Allocate the three regions, in order (data, edges, counts).
+data_nwords  = get_nwords(Float32, word_bw=self.mem.word_size, shape=ndata)
+edge_nwords  = get_nwords(Float32, word_bw=self.mem.word_size, shape=max(nedges, 1))
+count_nwords = get_nwords(Uint32Field, word_bw=self.mem.word_size, shape=nbins)
+self.data_addr  = self.mem.alloc(data_nwords)
+self.edge_addr  = self.mem.alloc(edge_nwords)
+self.count_addr = self.mem.alloc(count_nwords)
+
+# Populate the input buffers (TB-side memory access).
+yield from self.mem.m_mm.write_array(self.data, Float32, self.data_addr, word_bw=bw)
+if nedges > 0:
+    yield from self.mem.m_mm.write_array(self.bin_edges, Float32, self.edge_addr, word_bw=bw)
+
+# Issue the command and await the response.
+cmd = HistCmd(tx_id=self.tx_id,
+              data_addr=self.data_addr + self.addr_misalign,
+              bin_edges_addr=self.edge_addr, ndata=ndata, nbins=nbins,
+              cnt_addr=self.count_addr)
+yield from self.m_cmd.write(cmd)
+
+resp_words = yield from self.s_resp.get()
+self.resp = HistResp().deserialize(resp_words, word_bw=bw)
+
+# Read the kernel-produced counts back.
+out = yield from self.mem.m_mm.read_array(Uint32Field, nbins, self.count_addr, word_bw=bw)
+self.counts = np.asarray(out, dtype=np.uint32)
+```
+
+The details that matter:
+
+1. **Allocation order is the contract.** The controller allocs `data`, then
+   `edges`, then `counts` — the same order the [testbench](codegen.md) will, so
+   the three regions land at the same byte addresses on both sides. `MemComponent`
+   hands out non-overlapping regions; the controller stamps the returned addresses
+   into the command.
+2. **The edges alloc is clamped to `max(nedges, 1)`.** When `nbins == 1` there are
+   zero edges, but a memory region still needs a valid base address — so the
+   controller reserves one word it never writes. (The generated testbench does the
+   same clamp; see [`CODEGEN_NOTES.md`](../../../examples/shared_mem/CODEGEN_NOTES.md).)
+3. **`addr_misalign` is a test hook.** Adding a byte offset to `data_addr` lets a
+   test drive the kernel's `ADDRESS_ERROR` path without any other change — the
+   command now points one byte off a word boundary.
+
+## Wiring it together
+
+`connect()` builds the three links — two `StreamIF`s for the command/response
+control and one `DirectMMIF` for the shared memory — and binds each port to its
+peer:
+
+```python
+# examples/shared_mem/hist.py — connect
+def connect(sim, ctrl, accel, mem, clk):
+    in_stream  = StreamIF(sim=sim, clk=clk)
+    out_stream = StreamIF(sim=sim, clk=clk)
+    mem_link   = DirectMMIF(sim=sim, clk=clk, byte_addressable=True)
+    in_stream.bind( "master", ctrl.m_cmd);   in_stream.bind( "slave", accel.s_in)
+    out_stream.bind("master", accel.m_out);  out_stream.bind("slave", ctrl.s_resp)
+    mem_link.bind(  "master", accel.m_mem);  mem_link.bind(  "slave", mem.s_mm)
+```
+
+`DirectMMIF(byte_addressable=True)` is the in-process AXI-MM link: it carries the
+accelerator's `read_array` / `write_array` bursts to the memory's slave endpoint,
+converting the command's **byte** addresses to word indices exactly as real
+hardware does. The controller reaches the same memory through its own `mem.m_mm`
+master — so in the model, host and kernel genuinely share one memory, addressed
+identically.
+
+## Parity against the golden
+
+The point of the SimPy run is to confirm the accelerator's logic before
+synthesis. `run_sim` returns a `HistResult` carrying both the observed counts and
+the numpy golden, and `passed` is the conjunction of *status is `NO_ERROR`* and
+*counts match*:
+
+```python
+# examples/shared_mem/hist.py
+@dataclass
+class HistResult:
+    counts: npt.NDArray[np.uint32]
+    expected: npt.NDArray[np.uint32]
+    status: HistError
+
+    @property
+    def passed(self) -> bool:
+        return (self.status == HistError.NO_ERROR
+                and np.array_equal(self.counts, self.expected))
+```
+
+The golden is `golden_counts` — `bin = #{edges <= sample}`, then count per bin —
+the same routine the `compute` hook uses, so the model is checked against a
+second, independent numpy implementation of the binning rule.
+
+The parity tests in
+[`tests/examples/test_hist_sim.py`](../../../tests/examples/test_hist_sim.py)
+sweep several `(ndata, nbins)` vectors and the three failure modes:
+
+```python
+res = run_sim(ht.data, ht.bin_edges, nbins=nbins, tx_id=seed)
+assert res.status == HistError.NO_ERROR
+np.testing.assert_array_equal(res.counts, ht.counts)   # vs the HistogramAccel golden
+```
+
+Plus one test each for `INVALID_NDATA` (`ndata` out of range), `INVALID_NBINS`
+(`nbins` out of range), and `ADDRESS_ERROR` (driven by `addr_misalign=1`) — so the
+validation→status path is exercised in simulation, not just asserted in prose.
+
+## Timing in the SimPy run
+
+The SimPy simulation is **discrete-event on the clock**: every stream transfer and
+every memory burst advances simulated time, so a run is not just functional — it
+produces a transaction *timeline* (command in → reads → compute → write → response
+out). That timeline is a first, cheap estimate of how long a transaction takes.
+
+The simulation is cycle-*approximate*, though, not cycle-exact: the real burst
+latencies, the `m_axi` handshake overhead, and the pipeline fill only show up once
+the design is synthesized to RTL. The next page hands the generated kernel to
+Vitis to get those measured numbers, and the [timing page](timing.md) renders the
+RTL waveform and the multi-buffer burst layout that the SimPy model is
+approximating.
+
+## Next
+
+- [Code generation](codegen.md) — lowering `HistAccel` (and the testbench) to
+  Vitis HLS C++.
+- [C and RTL simulation](rtlsim.md) — running the Vitis flows against the
+  generated artifacts.

--- a/docs/examples/shared_mem/python.md
+++ b/docs/examples/shared_mem/python.md
@@ -1,0 +1,239 @@
+---
+title: Python model
+parent: Shared Memory (histogram)
+nav_order: 2
+has_children: false
+---
+
+# Python model
+
+This page builds the histogram accelerator as a PySilicon `HwComponent`. The
+[concept page](aximm.md) covered *why* the data lives in memory and the control
+on a stream; here we write the Python that says *how* — the command/response
+schemas, the kernel's three ports, and the `run_proc` body that validates,
+reads, computes, and writes back. Every excerpt is from
+[`examples/shared_mem/hist.py`](../../../examples/shared_mem/hist.py) and
+[`hist_demo.py`](../../../examples/shared_mem/hist_demo.py).
+
+## The command and response schemas
+
+The control plane is two small descriptors that ride the streams. A **command**
+goes in, a **response** comes back. Both are `DataList` schemas — ordered structs
+that serialize to the stream words — so the same field layout drives the SimPy
+model, the generated C++ struct, and the host.
+
+```python
+# examples/shared_mem/hist_demo.py
+TxIdField   = IntField.specialize(bitwidth=16, signed=False)
+NdataField  = IntField.specialize(bitwidth=32, signed=False)
+NbinField   = IntField.specialize(bitwidth=32, signed=False)
+Uint32Field = IntField.specialize(bitwidth=32, signed=False, include_dir=INCLUDE_DIR)
+Float32     = FloatField.specialize(bitwidth=32, include_dir=INCLUDE_DIR)
+AddrField   = MemAddr.specialize(bitwidth=MEM_AWIDTH)    # 64-bit byte address
+```
+
+The command carries the three buffer addresses and the two sizes; the response
+echoes the transaction id and reports a status:
+
+```python
+# examples/shared_mem/hist_demo.py
+class HistCmd(DataList):
+    elements = {
+        "tx_id":          {"schema": TxIdField},
+        "data_addr":      {"schema": AddrField},
+        "bin_edges_addr": {"schema": AddrField},
+        "ndata":          {"schema": NdataField},
+        "nbins":          {"schema": NbinField},
+        "cnt_addr":       {"schema": AddrField},
+    }
+
+class HistResp(DataList):
+    elements = {
+        "tx_id":  {"schema": TxIdField},
+        "status": {"schema": HistErrorField},
+    }
+```
+
+The status is a typed enum, not a bare integer — `HistError` names the four
+outcomes the host can distinguish:
+
+```python
+# examples/shared_mem/hist_demo.py
+class HistError(IntEnum):
+    NO_ERROR      = 0
+    INVALID_NDATA = 1
+    INVALID_NBINS = 2
+    ADDRESS_ERROR = 3
+
+HistErrorField = EnumField.specialize(enum_type=HistError)
+```
+
+`AddrField` is a [`MemAddr`](../../guide/interface/index.md) — a 64-bit field
+whose value is a **byte address** into the shared memory. That is the only thing
+that makes these buffers "shared": the command does not carry the data, it
+carries pointers to it.
+
+## The accelerator component
+
+`HistAccel` is the `HwComponent`. Its `cpp_kernel_name` / `cpp_namespace` name the
+generated kernel function and the hand-written-hook namespace; its **HwParams**
+are the compile-time configuration (interface widths and the buffer maxima); and
+its three **ports** are the two control streams and the one memory master.
+
+```python
+# examples/shared_mem/hist.py
+@dataclass
+class HistAccel(HwComponent):
+    cpp_kernel_name: ClassVar[str | None] = "hist"
+    cpp_namespace:   ClassVar[str | None] = "hist_impl"
+
+    in_bw:      HwParam[int] = STREAM_DWIDTH   # command-stream width  (32)
+    out_bw:     HwParam[int] = STREAM_DWIDTH   # response-stream width (32)
+    mem_bw:     HwParam[int] = MEM_DWIDTH      # m_axi data width      (32)
+    mem_awidth: HwParam[int] = MEM_AWIDTH      # m_axi address width   (64)
+    max_ndata:  HwParam[int] = MAX_NDATA       # 1024 — sample-buffer bound
+    max_nbins:  HwParam[int] = MAX_NBINS       # 32   — bin-buffer bound
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.s_in  = StreamIFSlave( name=f'{self.name}_s_in',  sim=self.sim, bitwidth=self.in_bw)
+        self.m_out = StreamIFMaster(name=f'{self.name}_m_out', sim=self.sim, bitwidth=self.out_bw)
+        self.m_mem = MMIFMaster(    name=f'{self.name}_m_mem', sim=self.sim, bitwidth=self.mem_bw)
+        for ep in (self.s_in, self.m_out, self.m_mem):
+            self.add_endpoint(ep)
+```
+
+Three ports, three roles:
+
+1. **`s_in`** — an `StreamIFSlave`. The kernel *receives* the `HistCmd` here; the
+   host is the stream master.
+2. **`m_out`** — an `StreamIFMaster`. The kernel *sends* the `HistResp` here.
+3. **`m_mem`** — an [`MMIFMaster`](../../guide/interface/index.md). This is the
+   AXI memory-mapped master, the new interface this example introduces. The
+   kernel issues array reads and writes through it; the bulk data flows here.
+
+The `max_ndata` / `max_nbins` HwParams are load-bearing for codegen: they become
+the compile-time array bounds in the generated kernel (`float data[max_ndata]`),
+the depth of the `m_axi` interface, and the upper limits the validation hook
+checks against. They are the one place the buffer sizes are declared.
+
+## The kernel body
+
+`run_proc` is the kernel — the body Vitis runs once per command under the
+`ap_ctrl_hs` handshake. It reads exactly as the [execution model](aximm.md)
+described: get the command, validate it, read the two inputs, compute, write the
+counts, respond.
+
+```python
+# examples/shared_mem/hist.py — HistAccel.run_proc
+def run_proc(self) -> ProcessGen[None]:
+    cmd: HistCmd = yield from self.s_in.get(HistCmd)
+
+    status = yield from self.validate(cmd)
+    if status != HistError.NO_ERROR:
+        yield from self.respond(self.m_out, cmd.tx_id, status)
+        return
+
+    data = yield from self.m_mem.read_array(
+        Float32, cmd.ndata, cmd.data_addr, max_count=self.max_ndata)
+    edges = yield from self.m_mem.read_array(
+        Float32, cmd.nbins - 1, cmd.bin_edges_addr, max_count=self.max_nbins)
+
+    counts = yield from self.compute(data, edges, cmd.ndata, cmd.nbins)
+    yield from self.m_mem.write_array(
+        counts, Uint32Field, cmd.cnt_addr, cmd.nbins, max_count=self.max_nbins)
+
+    # status is NO_ERROR on the success path — reuse it for the response.
+    yield from self.respond(self.m_out, cmd.tx_id, status)
+```
+
+A few things are doing real work here:
+
+1. **Validate first, touch memory never-if-invalid.** `validate` returns a
+   `HistError`; a non-`NO_ERROR` status takes the early-return path — respond and
+   stop, before a single `m_axi` access. A bad `data_addr` never gets
+   dereferenced.
+2. **The edges read is unconditional.** It reads `cmd.nbins - 1` edges — which is
+   `0` when `nbins == 1` (one bin, no interior edges). A zero-length burst is a
+   harmless no-op, so there is no `if (nbins > 1)` guard. That keeps the kernel
+   branch-free where the code generator can't lower a `>` comparison anyway (see
+   [`CODEGEN_NOTES.md`](../../../examples/shared_mem/CODEGEN_NOTES.md)).
+3. **Two element types, one master.** `data`/`edges` are read as `Float32`;
+   `counts` is written as `Uint32Field`. All three go through the same `m_mem`
+   port — the multi-type, multi-buffer traffic this example exists to exercise.
+
+## The `MMIFMaster` interface
+
+`m_mem.read_array` / `write_array` are the memory-mapped equivalent of the
+register `get`/`set` from the [regmap example](../regmap/python.md). Each call is
+one typed, addressed burst:
+
+```python
+read_array(self, elem_type, count, byte_addr, *, max_count) -> ProcessGen[array]
+write_array(self, values, elem_type, byte_addr, count, *, max_count) -> ProcessGen[None]
+```
+
+- **`elem_type`** — the schema (`Float32`, `Uint32Field`) the bytes are
+  interpreted as. The master converts to/from raw words; the model and the kernel
+  agree on the layout because they share the schema.
+- **`count`** — the runtime number of elements. It can be a command field
+  (`cmd.ndata`) or an expression (`cmd.nbins - 1`); the code generator lowers the
+  same expression into the C++ burst length.
+- **`byte_addr`** — the base byte address from the command. The master divides by
+  the word size to index the underlying word array; the model and kernel use the
+  same `byte_addr_to_word_index` convention.
+- **`max_count`** — the compile-time upper bound (`self.max_ndata` /
+  `self.max_nbins`). It sizes the on-chip buffer and the interface depth in the
+  generated kernel; at runtime the actual transfer is `count` elements.
+
+## The hand-written hooks
+
+Three methods are marked `@synthesizable`. That decorator tells the code
+generator the method is part of the kernel, but its **body is supplied by a
+hand-written C++ file** rather than lowered from Python — the seam through which
+the datapath stays human-owned. In simulation, the Python body runs; in the
+generated kernel, codegen emits a call to the hook.
+
+```python
+# examples/shared_mem/hist.py
+@synthesizable
+def validate(self, cmd: HistCmd) -> ProcessGen[HistError]:
+    ndata, nbins = int(cmd.ndata), int(cmd.nbins)
+    word_bytes = self.mem_bw // 8
+    if ndata <= 0 or ndata > self.max_ndata:
+        return HistError.INVALID_NDATA
+    if nbins <= 0 or nbins > self.max_nbins:
+        return HistError.INVALID_NBINS
+    if (int(cmd.data_addr) % word_bytes or int(cmd.bin_edges_addr) % word_bytes
+            or int(cmd.cnt_addr) % word_bytes):
+        return HistError.ADDRESS_ERROR
+    return HistError.NO_ERROR
+    yield  # unreachable — makes this a generator
+
+@synthesizable
+def compute(self, data, edges, ndata, nbins) -> ProcessGen[HistCountBuf]:
+    counts = golden_counts(np.asarray(data)[:int(ndata)], edges, int(nbins))
+    return counts
+    yield  # unreachable — makes this a generator
+```
+
+- **`validate`** is the bounds/alignment logic — it reads the `max_ndata` /
+  `max_nbins` HwParams to range-check the command and confirms every address is
+  word-aligned. Its hand-written counterpart is `hist_validate_impl.cpp`.
+- **`compute`** is the binning datapath — for each sample, the bin is the number
+  of edges it meets or exceeds (`np.searchsorted(..., "right")`). Its hand-written
+  counterpart is `hist_compute_impl.cpp`.
+- **`respond`** builds the `HistResp` and writes it on `m_out`; its counterpart is
+  `hist_respond_impl.tpp`.
+
+Why hand-write these? `validate` and `respond` are control glue that the
+generator emits *calls* to, and `compute` is the real algorithm — exactly the
+body a future AI-assisted codegen pass would fill, but for now a small,
+reviewable `.cpp` that lives next to the Python. The [code generation](codegen.md)
+page shows the generated kernel calling into them.
+
+## Next
+
+- [SimPy simulation](pysim.md) — running the model end-to-end against the numpy
+  golden, with a `MemComponent` standing in for shared DRAM.
+- [Code generation](codegen.md) — lowering `HistAccel` to the Vitis HLS kernel.

--- a/docs/examples/shared_mem/rtlsim.md
+++ b/docs/examples/shared_mem/rtlsim.md
@@ -1,0 +1,147 @@
+---
+title: C and RTL Simulation
+parent: Shared Memory (histogram)
+nav_order: 5
+has_children: false
+---
+
+# C and RTL Simulation
+
+This page picks up where [Code Generation](codegen.md) leaves off: the generated
+kernel and testbench are in `gen/`, the hand-written hooks sit next to them, and
+the support headers are written. From here Vitis HLS drives the design through:
+
+1. **C-simulation** — compile the generated kernel + testbench + hooks and run
+   them as a C++ program, checked bit-exact against the numpy golden, across four
+   coverage cases.
+2. **C-synthesis** — lower the kernel to RTL.
+3. **RTL co-simulation** — run the synthesized hardware in a simulator to get a
+   measured cycle count and a waveform.
+4. **Burst extraction** — pull the AXI-MM read/write bursts out of the cosim
+   waveform and confirm the multi-buffer layout.
+
+The payoff is twofold: the generated kernel produces the same histogram the
+Python model did, *and* the RTL waveform shows the three buffers moving over one
+`m_axi` port exactly as designed.
+
+## Two ways to run it
+
+The flow has the standard stages, named the same on both entry points:
+
+```python
+# examples/shared_mem/hist_demo.py
+STAGES = ("csim", "csynth", "cosim", "generate_vcd", "extract_bursts")
+```
+
+The **CLI** drives the whole pipeline through `HistTest.test_vitis`:
+
+```bash
+cd examples/shared_mem
+python hist_demo.py --through cosim                       # csim -> csynth -> cosim
+python hist_demo.py --through extract_bursts --trace_level port
+```
+
+The **pytest** path runs the same Vitis stages but as gated tests — the
+`-m vitis` marker so they only run where Vitis is installed:
+
+```bash
+pytest -m vitis tests/examples/test_hist_csim.py    # the four-case C-sim
+pytest -m vitis tests/examples/test_hist_cosim.py   # cosim + burst extraction
+```
+
+`run.tcl` is the Vitis driver both use; it compiles `gen/hist.cpp` +
+`gen/hist_tb.cpp` against the three hand-written hooks and runs the requested
+stage range.
+
+## C-sim functional verification — four cases
+
+The histogram's correctness is not one number; it is a small coverage set, because
+the interesting behavior is at the edges. `test_hist_csim.py` runs the generated
+kernel through C-sim on four vectors:
+
+```python
+# examples/shared_mem/shared_mem_build.py — CSIM_CASES
+CSIM_CASES = [
+    HistCase(ndata=37, nbins=1),    # one bin: the nbins-1 = 0 edges read is a no-op
+    HistCase(ndata=37, nbins=6),    # normal multi-bin binning
+    HistCase(ndata=200, nbins=12),  # more data, more bins
+    HistCase(ndata=0,  nbins=6),    # invalid: ndata == 0 -> INVALID_NDATA
+]
+```
+
+Each case writes its inputs (`cmd.bin`, `data_array.bin`, `edges_array.bin`),
+runs `run.tcl` through C-sim, then `HistCase.check_outputs` compares what the
+kernel wrote back:
+
+- For the three valid cases, it deserializes `counts_array.bin` and asserts it
+  equals `golden_counts(data, edges, nbins)` — bit-exact against the same numpy
+  golden the [SimPy run](pysim.md) used.
+- For the invalid case, it asserts the response `status` is `INVALID_NDATA` — the
+  validation→status path, confirmed in real compiled C++.
+
+The two edge cases earn their place: **`nbins == 1`** proves the unconditional
+`nbins-1 = 0` edges read is a genuine no-op in hardware (not a buffer underrun),
+and the **`ndata == 0`** case proves the kernel rejects bad input and responds
+with a status instead of dereferencing a buffer. A kernel that passed only the
+"normal" case could be hiding either bug.
+
+## C-synthesis and RTL co-simulation
+
+`--through cosim` continues past C-sim: `csynth` lowers the kernel to RTL, and
+`cosim` runs that RTL in a simulator driven by the same generated testbench. The
+cosim run does two things the C-sim cannot:
+
+- It produces a **measured cycle count** for one transaction — the real latency of
+  reading the buffers, binning, and writing back, including the `m_axi` burst
+  handshakes the SimPy model only approximated.
+- It writes a **waveform** (a VCD) of every interface signal, which is the raw
+  material for the burst and timing diagrams.
+
+Because the same generated testbench drives C-sim and cosim, a kernel that passes
+C-sim and then mismatches in cosim is a synthesis or interface issue, not a logic
+one — the functional check is already behind you.
+
+## Multi-buffer burst extraction
+
+This is the step unique to the shared-memory example. `test_hist_cosim.py` (and
+`--through extract_bursts`) re-runs the RTL to dump a port-level VCD, then
+`HistTest.extract_bursts` parses the `m_axi` signals into discrete read and write
+**bursts** and checks them against what the command should have produced:
+
+```python
+# examples/shared_mem/test flow
+ht = HistTest(example_dir=tmp_path, ndata=37, nbins=6)
+ht.simulate()
+vcd_path = ht.generate_vcd(trace_level="port")
+report = ht.extract_bursts(vcd_path=vcd_path)
+assert report["validated"]
+```
+
+For the `ndata=37, nbins=6` vector the report shows the multi-buffer pattern the
+whole example was built to demonstrate — **two read regions** (`data`,
+`bin_edges`) and **one write region** (`counts`), each at its allocated byte
+address, with `data`'s 37 words split into several bursts at the AXI maximum burst
+length. The extractor asserts the per-burst address-and-length layout matches the
+expected allocation, not merely that "some bursts happened."
+
+The [timing page](timing.md) renders this report — and the transaction
+waveform — as the two committed figures, and explains how to read them.
+
+## What a green run proves
+
+After a full `--through extract_bursts`:
+
+- **C-sim** — the generated kernel computes the same counts as the Python golden,
+  across the four coverage cases, and reports the right status on bad input.
+- **cosim** — the synthesized RTL reproduces that behavior with a measured cycle
+  count.
+- **burst extraction** — the `m_axi` traffic is exactly the three buffers, at the
+  right addresses, in the right order.
+
+Same source, same outputs, and a hardware waveform that proves the multi-buffer
+memory access pattern is what the Python model described.
+
+## Next
+
+- [Viewing timing and bursts](timing.md) — the committed timing/burst figures and
+  the workflow for refreshing them.

--- a/docs/examples/shared_mem/timing.md
+++ b/docs/examples/shared_mem/timing.md
@@ -1,0 +1,116 @@
+---
+title: Viewing Timing and Bursts
+parent: Shared Memory (histogram)
+nav_order: 6
+has_children: false
+---
+
+# Viewing Timing and Bursts
+
+The [RTL simulation](rtlsim.md) page produced a cosim waveform and a burst report.
+This page turns those into two pictures — the multi-buffer **burst layout** and
+the transaction **timeline** — and documents how the figures are committed and
+refreshed. Both are rendered by `shared_mem_figures.py` from the cosim burst
+report (`vcd/burst_info.json`), which is itself regenerable from the **committed**
+`vcd/dump.vcd` with no Vitis run.
+
+## The burst layout
+
+![Multi-buffer AXI-MM burst layout: data, bin_edges read bursts and the counts write burst at their byte addresses](images/burst_diagram.svg)
+
+This is the figure unique to the shared-memory example — the visual payoff of the
+multi-buffer m_axi story. It shows where, in the one `gmem` bundle, each buffer
+lives and how the `m_axi` master bursts it, for the `ndata=37, nbins=6` vector:
+
+- **`data` (read, 37 words from byte 0)** is split into **three bursts** —
+  `16 + 16 + 5` words. The `m_axi` interface has a maximum burst length (16 words
+  here), so a 37-word read becomes three back-to-back bursts rather than one
+  37-beat transfer. This splitting is automatic; the kernel just asked for 37
+  elements.
+- **`bin_edges` (read, 5 words from byte 148)** is one short burst, immediately
+  after the data region — `5` words because `nbins-1 = 5` edges define 6 bins.
+- **`counts` (write, 6 words from byte 168)** is the one write burst — `nbins = 6`
+  count words, after both input regions.
+
+Read the address axis left to right and you are reading the memory map the
+[command](aximm.md) chose: `data_addr = 0`, `bin_edges_addr = 148`,
+`cnt_addr = 168`, back-to-back because the allocator placed them in that order.
+Two element types (float reads, uint32 write), three buffers, one bundle — exactly
+what the example set out to exercise.
+
+## The transaction timeline
+
+![Histogram transaction timeline: command in, read data and edges, compute, write counts, response out, cycle-annotated](images/timing_diagram.svg)
+
+This is the same transaction over time, broken into phases and annotated with
+cycle counts (the clock period is 10 ns). It reads as the
+[execution model](aximm.md) did: command in → read the inputs → compute → write
+the counts → response out.
+
+The shape is worth noting: **compute dominates**. The two `m_axi` reads finish in
+tens of cycles, and the write is a handful more, but the binning loop over 37
+samples is hundreds of cycles — so the memory traffic is a small slice of the
+transaction. That is a real and useful reading: for this kernel the bottleneck is
+the datapath, not the bus, which is why the multi-buffer burst *efficiency* (the
+read splitting above) costs so little of the total. A heavier-data / lighter-
+compute kernel would show the opposite balance.
+
+The cosim timeline is what the [SimPy model](pysim.md) was approximating; here the
+phase boundaries and the burst latencies are measured from real synthesized RTL.
+
+## How the figures are committed
+
+The docs site cannot run Vitis or SimPy at build time, and committing a freshly
+generated figure on every run would churn binary blobs in git constantly. So the
+figures live in **three places**, with a deliberate promotion between them:
+
+| Location | Tracked? | Role |
+| -------- | -------- | ---- |
+| `examples/shared_mem/results/*.svg` | gitignored | generated each render — never committed |
+| `docs/examples/shared_mem/images/*.svg` | committed | the stable assets these pages embed |
+| `docs/examples/shared_mem/images/sync_status.json` | committed | provenance: each figure's source path + content hash |
+
+The render steps (`generate_burst_diagram`, `generate_timing_diagram`) write into
+`results/`; a separate **`SyncDocsFiguresStep`** copies them into `images/` on
+demand, driven by an explicit manifest (`results/... → docs/.../images/...`). The
+sync never copies by guesswork — the manifest is the reviewable mapping, and the
+copy is a normal `git diff` you choose to commit.
+
+## Refreshing the figures
+
+The whole workflow runs from `shared_mem_build.py`:
+
+```bash
+cd examples/shared_mem
+python shared_mem_build.py --through sync_docs_figures
+```
+
+That renders both SVGs from `vcd/burst_info.json` and syncs them into `images/`.
+If `burst_info.json` is missing, the render step regenerates it from the committed
+`vcd/dump.vcd` — so a routine figure refresh needs **no Vitis**, only matplotlib
+(already required by the example's timing utilities).
+
+To refresh against *new* hardware behavior — after changing the kernel, the
+buffer sizes, or the test vector — regenerate the cosim artifacts first, then sync:
+
+```bash
+python hist_demo.py --through extract_bursts --trace_level port  # new dump.vcd + burst_info.json (needs Vitis)
+python shared_mem_build.py --through sync_docs_figures           # re-render + sync
+git diff docs/examples/shared_mem/images/                        # review, then commit
+```
+
+Because the SVGs are rendered deterministically (a fixed `svg.hashsalt`, no
+embedded timestamp), a re-sync produces a **byte-identical** file when nothing
+changed — so the `git diff` is empty unless the hardware behavior actually moved.
+`sync_status.json` records each figure's source content hash at the last sync, a
+cheap staleness signal a docs lint can check without re-running anything.
+
+## Next
+
+This is the last page of the shared-memory walkthrough. For the broader
+references, see:
+
+- [Build System](../../guide/build/index.md) — the `BuildDag` / `BuildStep`
+  reference behind the figure workflow.
+- [Interfaces](../../guide/interface/index.md) — the AXI-MM / stream abstractions.
+- The [examples index](../) — the five-pattern progression this example sits in.

--- a/examples/shared_mem/shared_mem_build.py
+++ b/examples/shared_mem/shared_mem_build.py
@@ -149,3 +149,54 @@ CSIM_CASES = [
     HistCase(ndata=200, nbins=12),
     HistCase(ndata=0, nbins=6),    # INVALID_NDATA
 ]
+
+
+# ---------------------------------------------------------------------------
+# Committed-figure workflow (the docs timing/burst diagrams)
+# ---------------------------------------------------------------------------
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+
+
+def build_figures_dag():
+    """DAG that renders the two docs figures and syncs them into docs/images."""
+    from pysilicon.build.build import BuildDag
+    try:
+        from examples.shared_mem.shared_mem_figures import (
+            GenerateBurstDiagramStep, GenerateTimingDiagramStep, SyncDocsFiguresStep,
+        )
+    except ModuleNotFoundError:  # direct execution from the example dir
+        from shared_mem_figures import (  # type: ignore[no-redef]
+            GenerateBurstDiagramStep, GenerateTimingDiagramStep, SyncDocsFiguresStep,
+        )
+    dag = BuildDag()
+    dag.add(GenerateBurstDiagramStep(name="generate_burst_diagram"))
+    dag.add(GenerateTimingDiagramStep(name="generate_timing_diagram"))
+    dag.add(SyncDocsFiguresStep(name="sync_docs_figures"))
+    return dag
+
+
+def main() -> None:
+    import argparse
+
+    from pysilicon.build.build import BuildConfig
+
+    parser = argparse.ArgumentParser(
+        description="shared_mem figure workflow: render + sync the docs diagrams.")
+    parser.add_argument("--through", metavar="STEP", default="sync_docs_figures",
+                        help="Run the figure DAG up to and including this step.")
+    parser.add_argument("--list-steps", action="store_true",
+                        help="Print the figure step names and exit.")
+    parser.add_argument("--force", action="store_true", help="Force all steps to rebuild.")
+    args = parser.parse_args()
+
+    dag = build_figures_dag()
+    if args.list_steps:
+        for name in dag.step_names():
+            print(name)
+        return
+    dag.run(BuildConfig(root_dir=EXAMPLE_DIR), through=args.through, force=args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/shared_mem/shared_mem_figures.py
+++ b/examples/shared_mem/shared_mem_figures.py
@@ -1,0 +1,235 @@
+"""Committed-figure workflow for the ``shared_mem`` (histogram) example.
+
+Two figures document the multi-buffer m_axi story:
+
+* **burst_diagram.svg** — the AXI-MM burst *layout*: the ``data`` and ``bin_edges``
+  read bursts and the ``counts`` write burst at their byte addresses.
+* **timing_diagram.svg** — one transaction's *timeline*: the read phase, the
+  compute gap, and the write phase, cycle-annotated.
+
+Both are rendered deterministically from the cosim burst report
+(``vcd/burst_info.json``), which is itself regenerable from the **committed**
+``vcd/dump.vcd`` with no Vitis run.  The generated SVGs land in ``results/``
+(gitignored); :class:`SyncDocsFiguresStep` promotes them — on demand, via an
+explicit manifest — into ``docs/examples/shared_mem/images/`` as committed assets,
+so the docs figure only changes when you intend it to and the change is a
+reviewable ``git diff``.
+
+Run it with::
+
+    python shared_mem_build.py --through sync_docs_figures
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("svg")
+# Deterministic SVG: a stable hashsalt fixes the element ids matplotlib would
+# otherwise randomize, so a re-render only diffs when the figure truly changed.
+matplotlib.rcParams["svg.hashsalt"] = "shared_mem_figures"
+import matplotlib.pyplot as plt  # noqa: E402
+
+from pysilicon.build.build import BuildConfig, BuildStep  # noqa: E402
+
+BYTES_PER_WORD = 4  # 32-bit memory words
+
+# Source-in-code -> dest-in-docs.  The proxy never copies by guesswork; this is
+# the explicit, reviewable mapping a sync consults.
+FIGURE_MANIFEST = [
+    {"name": "burst_diagram",
+     "source": "results/burst_diagram.svg",
+     "dest": "docs/examples/shared_mem/images/burst_diagram.svg"},
+    {"name": "timing_diagram",
+     "source": "results/timing_diagram.svg",
+     "dest": "docs/examples/shared_mem/images/timing_diagram.svg"},
+]
+
+_REGION_COLORS = {"data": "#4C78A8", "bin_edges": "#54A24B", "counts": "#E45756"}
+
+
+def _save_svg(fig, path: Path) -> None:
+    """Write a deterministic SVG (no embedded timestamp)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # metadata Date=None omits the <dc:date> matplotlib embeds by default.
+    fig.savefig(path, format="svg", bbox_inches="tight", metadata={"Date": None})
+    plt.close(fig)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def ensure_burst_info(example_dir: Path, *, ndata: int = 37, nbins: int = 6) -> Path:
+    """Return ``vcd/burst_info.json``, regenerating it from the committed
+    ``vcd/dump.vcd`` if absent (cheap — no Vitis, just a VCD parse + the numpy
+    golden for the expected layout)."""
+    example_dir = Path(example_dir)
+    burst_info = example_dir / "vcd" / "burst_info.json"
+    if burst_info.exists():
+        return burst_info
+    dump_vcd = example_dir / "vcd" / "dump.vcd"
+    if not dump_vcd.exists():
+        raise FileNotFoundError(
+            f"Neither {burst_info} nor {dump_vcd} exists; run the cosim flow "
+            "(python hist_demo.py --through extract_bursts --trace_level port) first."
+        )
+    try:
+        from examples.shared_mem.hist_demo import HistTest
+    except ModuleNotFoundError:
+        from hist_demo import HistTest  # type: ignore[no-redef]
+    ht = HistTest(example_dir=example_dir, ndata=ndata, nbins=nbins)
+    ht.simulate()
+    ht.extract_bursts(vcd_path=dump_vcd)
+    return burst_info
+
+
+# ---------------------------------------------------------------------------
+# Figure rendering
+# ---------------------------------------------------------------------------
+
+def render_burst_diagram(burst_info_path: Path, out_svg: Path) -> Path:
+    """The multi-buffer burst layout: read/write bursts on a byte-address axis."""
+    report = json.loads(Path(burst_info_path).read_text(encoding="utf-8"))
+    exp = report["expected"]
+    rows = [("m_axi read", exp["read_bursts"]), ("m_axi write", exp["write_bursts"])]
+
+    fig, ax = plt.subplots(figsize=(8.5, 2.6))
+    max_addr = 0
+    for row_idx, (_label, bursts) in enumerate(rows):
+        y = len(rows) - 1 - row_idx
+        for b in bursts:
+            addr, nwords, name = int(b["addr"]), int(b["nwords"]), str(b["name"])
+            width = nwords * BYTES_PER_WORD
+            ax.barh(y, width, left=addr, height=0.6,
+                    color=_REGION_COLORS.get(name, "#9D9D9D"),
+                    edgecolor="white", linewidth=1.2, zorder=3)
+            ax.text(addr + width / 2, y, f"{name}\n{nwords}w",
+                    ha="center", va="center", fontsize=8, color="white", zorder=4)
+            max_addr = max(max_addr, addr + width)
+
+    ax.set_yticks([len(rows) - 1 - i for i in range(len(rows))])
+    ax.set_yticklabels([label for label, _ in rows])
+    ax.set_xlim(-4, max_addr + 8)
+    ax.set_ylim(-0.6, len(rows) - 0.4)
+    ax.set_xlabel("byte address into the gmem bundle")
+    ax.set_title("Multi-buffer AXI-MM burst layout (ndata=37, nbins=6)")
+    ax.spines[["top", "right", "left"]].set_visible(False)
+    ax.tick_params(axis="y", length=0)
+    ax.grid(axis="x", color="#DDDDDD", zorder=0)
+    _save_svg(fig, Path(out_svg))
+    return Path(out_svg)
+
+
+def render_timing_diagram(burst_info_path: Path, out_svg: Path) -> Path:
+    """One transaction's timeline: read phase, compute gap, write phase."""
+    report = json.loads(Path(burst_info_path).read_text(encoding="utf-8"))
+    clk_ns = float(report["clk_period_ns"])
+    reads = report["actual"]["read_bursts"]
+    writes = report["actual"]["write_bursts"]
+
+    def _span(bursts):
+        starts = [float(b["tstart"]) for b in bursts]
+        ends = [float(b.get("data_tend", b["tstart"])) for b in bursts]
+        return min(starts), max(ends)
+
+    read_t0, read_t1 = _span(reads)
+    write_t0, write_t1 = _span(writes)
+    t_end = write_t1
+
+    # Phases as (label, t_start, t_end, color).
+    phases = [
+        ("command in", read_t0 - clk_ns, read_t0, "#B279A2"),
+        ("read data + edges", read_t0, read_t1, _REGION_COLORS["data"]),
+        ("compute", read_t1, write_t0, "#9D9D9D"),
+        ("write counts", write_t0, write_t1, _REGION_COLORS["counts"]),
+        ("response out", t_end, t_end + clk_ns, "#B279A2"),
+    ]
+
+    fig, ax = plt.subplots(figsize=(8.5, 2.6))
+    for i, (label, t0, t1, color) in enumerate(phases):
+        y = len(phases) - 1 - i
+        ax.barh(y, max(t1 - t0, clk_ns), left=t0, height=0.6, color=color,
+                edgecolor="white", linewidth=1.0, zorder=3)
+        cyc = (t1 - t0) / clk_ns
+        ann = f"{label}  ({cyc:.0f} cyc)" if cyc >= 1 else label
+        ax.text(t1 + clk_ns, y, ann, ha="left", va="center", fontsize=8.5, zorder=4)
+
+    ax.set_yticks([])
+    ax.set_xlim(read_t0 - 3 * clk_ns, t_end + 22 * clk_ns)
+    ax.set_ylim(-0.6, len(phases) - 0.4)
+    ax.set_xlabel(f"time [ns]   (clk period = {clk_ns:.0f} ns)")
+    ax.set_title("Histogram transaction timeline (ndata=37, nbins=6, from RTL cosim)")
+    ax.spines[["top", "right", "left"]].set_visible(False)
+    ax.tick_params(axis="y", length=0)
+    ax.grid(axis="x", color="#DDDDDD", zorder=0)
+    _save_svg(fig, Path(out_svg))
+    return Path(out_svg)
+
+
+# ---------------------------------------------------------------------------
+# Build steps
+# ---------------------------------------------------------------------------
+
+class GenerateBurstDiagramStep(BuildStep):
+    description = "Render the AXI-MM burst-layout SVG from the cosim burst report."
+    consumes: list = []
+    produces = {"burst_diagram_svg": Path("results/burst_diagram.svg")}
+
+    def run(self, config: BuildConfig, **_) -> dict[str, Any]:
+        burst_info = ensure_burst_info(config.root_dir)
+        out = config.root_dir / "results" / "burst_diagram.svg"
+        render_burst_diagram(burst_info, out)
+        return {"burst_diagram_svg": out}
+
+
+class GenerateTimingDiagramStep(BuildStep):
+    description = "Render the transaction-timeline SVG from the cosim burst report."
+    consumes: list = []
+    produces = {"timing_diagram_svg": Path("results/timing_diagram.svg")}
+
+    def run(self, config: BuildConfig, **_) -> dict[str, Any]:
+        burst_info = ensure_burst_info(config.root_dir)
+        out = config.root_dir / "results" / "timing_diagram.svg"
+        render_timing_diagram(burst_info, out)
+        return {"timing_diagram_svg": out}
+
+
+class SyncDocsFiguresStep(BuildStep):
+    """Promote the generated SVGs into the committed docs assets, on demand.
+
+    Copies each manifest entry ``results/*.svg -> docs/.../images/*.svg`` and
+    writes a ``sync_status.json`` provenance record (per figure: source path,
+    content hash) next to the committed assets — the cheap staleness signal a
+    docs lint can check without re-running Vitis."""
+
+    description = "Copy generated figures into docs/images and record provenance."
+    consumes = ["burst_diagram_svg", "timing_diagram_svg"]
+    produces = {"docs_figures_sync": Path("docs/examples/shared_mem/images/sync_status.json")}
+
+    def run(self, config: BuildConfig, **_) -> dict[str, Any]:
+        # docs/ lives at the repo root; the example dir is examples/shared_mem.
+        repo_root = config.root_dir.parents[1]
+        records = []
+        for entry in FIGURE_MANIFEST:
+            src = config.root_dir / entry["source"]
+            dst = repo_root / entry["dest"]
+            if not src.exists():
+                raise RuntimeError(f"Manifest source missing: {src}")
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
+            records.append({
+                "name": entry["name"],
+                "source": entry["source"],
+                "dest": entry["dest"],
+                "source_sha256": _sha256(src),
+            })
+        sync_path = repo_root / "docs" / "examples" / "shared_mem" / "images" / "sync_status.json"
+        sync_path.parent.mkdir(parents=True, exist_ok=True)
+        sync_path.write_text(
+            json.dumps({"figures": records}, indent=2) + "\n", encoding="utf-8")
+        return {"docs_figures_sync": sync_path}


### PR DESCRIPTION
Executes `plans/shared_mem_docs.md`: the `docs/examples/shared_mem/` walkthrough
(six child pages mirroring the regmap example's newcomer-first tone) plus a
reusable committed-figure workflow for the timing/burst diagrams.

## Pages (one commit each)

| Page | Covers |
| ---- | ------ |
| `aximm.md` | AXI memory-mapped concept page: burst transfers, byte-addressed pointers into shared DRAM, the AXI-Lite/Stream/MM split, and the shared-memory architecture (data in memory, command/response on a dedicated stream) |
| `python.md` | `HistAccel` ports + HwParams, the `HistCmd`/`HistResp`/`HistError` schemas, `run_proc`, the `MMIFMaster` (`read_array`/`write_array`) interface, and the hand-written hooks |
| `pysim.md` | the SimPy harness (`run_sim` + `HistController` + `MemComponent` over `DirectMMIF`), parity against the numpy golden, and how the run is timing-aware |
| `codegen.md` | generating `gen/hist.cpp`/`.hpp` + `gen/hist_tb.cpp`: the m_axi signature/pragmas (`depth = sum of buffer maxes`), multi-buffer multi-type array-op lowering, validation→status, the clamped-alloc TB |
| `rtlsim.md` | the four-case C-sim coverage (nbins==1, nbins>1, validation-fail), C-synth, cosim, and multi-buffer burst extraction |
| `timing.md` | embeds the two committed figures, explains how to read the burst layout + transaction timeline, and documents the refresh workflow |

`index.md` now sets `has_children: true` and links all six by their **real**
filenames (the regmap index's stale `simulation.md`/`synthesis.md` links are not
repeated). Every internal link was verified — 57 links across 7 pages all resolve.

## Committed-figure workflow

`shared_mem_figures.py` renders two SVGs **deterministically** (fixed
`svg.hashsalt`, no embedded timestamp) from the cosim burst report:

- **burst_diagram.svg** — the multi-buffer AXI-MM layout: `data` (16+16+5w) and
  `bin_edges` (5w) read bursts, `counts` (6w) write burst, at their byte addresses.
- **timing_diagram.svg** — the transaction timeline (command in → reads → compute
  → write → response out), cycle-annotated.

`SyncDocsFiguresStep` (run via `python shared_mem_build.py --through
sync_docs_figures`) promotes `results/*.svg` (gitignored) into
`docs/examples/shared_mem/images/` (committed) via an explicit manifest, and
writes `sync_status.json` provenance (source path + content hash). The source
report regenerates from the **committed** `vcd/dump.vcd` if absent, so a routine
figure refresh needs no Vitis — only matplotlib. Verified: a clean-slate regen
produces byte-identical figures (empty `git diff`).

## Checks

- `pytest tests/hw/ tests/examples/ -k "not vitis"` — green aside from the one
  known pre-existing `test_dataschema_poly`/`poly.hpp` failure (unrelated).
- All internal doc links resolve; figures are real (no placeholders) and
  reproducible from committed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)