### PR TITLE
utils: extract json_scalar/hex_word + vcd_trace into shared utils

### DIFF
--- a/examples/shared_mem/hist_build.py
+++ b/examples/shared_mem/hist_build.py
@@ -31,7 +31,8 @@ from pysilicon.hw.arrayutils import (
 from pysilicon.hw.dataschema import DataSchemaStep
 from pysilicon.hw.memory import AddrUnit, Memory
 from pysilicon.toolchain import toolchain
-from pysilicon.utils.vcd import AximmBeatType
+from pysilicon.utils.jsonutil import hex_word, json_scalar
+from pysilicon.utils.vcd import AximmBeatType, vcd_trace
 
 try:
     from examples.shared_mem.hist import (
@@ -64,21 +65,6 @@ TRACE_LEVELS = ("none", "port", "all")
 DEFAULT_MAX_READ_BURST_LENGTH = 16
 DEFAULT_MAX_WRITE_BURST_LENGTH = 16
 
-def _json_scalar(value):
-    if isinstance(value, (np.integer, np.floating)):
-        return value.item()
-    return value
-
-def _json_hex_word(value, bitwidth: int) -> str:
-    if bitwidth <= 0:
-        raise ValueError("bitwidth must be positive.")
-
-    int_value = int(_json_scalar(value))
-    mask = (1 << bitwidth) - 1
-    hex_width = (bitwidth + 3) // 4
-    return f"0x{(int_value & mask):0{hex_width}x}"
-
-
 def _run_tcl(config: BuildConfig, *, start_at: str, through: str,
              trace_level: str, live_output: bool) -> None:
     """Drive run.tcl over a stage range (the env HistTest.test_vitis used)."""
@@ -91,10 +77,6 @@ def _run_tcl(config: BuildConfig, *, start_at: str, through: str,
             "PYSILICON_HIST_TRACE_LEVEL": trace_level,
         },
     )
-
-
-def _vcd_trace(trace_level: str) -> str:
-    return trace_level if trace_level in ("port", "all") else "*"
 
 
 # --- Migrated HLS / burst / timing harness (from hist_demo.HistTest) ---
@@ -364,32 +346,32 @@ class HistTest(object):
             raw_len = burst.get(len_key)
             nwords = len(burst.get("data", []))
             if raw_len is not None:
-                nwords = int(_json_scalar(raw_len)) + 1
+                nwords = int(json_scalar(raw_len)) + 1
             layout.append({
-                "addr": int(_json_scalar(addr)),
+                "addr": int(json_scalar(addr)),
                 "nwords": int(nwords),
             })
         return layout
 
     @staticmethod
     def _burst_to_jsonable(burst: dict[str, object], data_bitwidth: int) -> dict[str, object]:
-        beat_types = [int(_json_scalar(value)) for value in burst.get("beat_type", [])]
-        data_values = [_json_scalar(value) for value in np.asarray(burst.get("data", [])).tolist()]
+        beat_types = [int(json_scalar(value)) for value in burst.get("beat_type", [])]
+        data_values = [json_scalar(value) for value in np.asarray(burst.get("data", [])).tolist()]
         return {
-            "addr": None if burst.get("addr") is None else int(_json_scalar(burst["addr"])),
-            "start_idx": int(_json_scalar(burst["start_idx"])),
-            "tstart": float(_json_scalar(burst["tstart"])),
-            "data_start_idx": None if burst.get("data_start_idx") is None else int(_json_scalar(burst["data_start_idx"])),
-            "data_end_idx": None if burst.get("data_end_idx") is None else int(_json_scalar(burst["data_end_idx"])),
-            "data_tstart": None if burst.get("data_tstart") is None else float(_json_scalar(burst["data_tstart"])),
-            "data_tend": None if burst.get("data_tend") is None else float(_json_scalar(burst["data_tend"])),
-            "queue_wait_cycles": None if burst.get("queue_wait_cycles") is None else int(_json_scalar(burst["queue_wait_cycles"])),
+            "addr": None if burst.get("addr") is None else int(json_scalar(burst["addr"])),
+            "start_idx": int(json_scalar(burst["start_idx"])),
+            "tstart": float(json_scalar(burst["tstart"])),
+            "data_start_idx": None if burst.get("data_start_idx") is None else int(json_scalar(burst["data_start_idx"])),
+            "data_end_idx": None if burst.get("data_end_idx") is None else int(json_scalar(burst["data_end_idx"])),
+            "data_tstart": None if burst.get("data_tstart") is None else float(json_scalar(burst["data_tstart"])),
+            "data_tend": None if burst.get("data_tend") is None else float(json_scalar(burst["data_tend"])),
+            "queue_wait_cycles": None if burst.get("queue_wait_cycles") is None else int(json_scalar(burst["queue_wait_cycles"])),
             "beat_type": beat_types,
             "beat_type_names": [AximmBeatType(value).name.lower() for value in beat_types],
             "data": data_values,
-            "data_hex": [_json_hex_word(value, data_bitwidth) for value in data_values],
-            "awlen": None if burst.get("awlen") is None else int(_json_scalar(burst["awlen"])),
-            "arlen": None if burst.get("arlen") is None else int(_json_scalar(burst["arlen"])),
+            "data_hex": [hex_word(value, data_bitwidth) for value in data_values],
+            "awlen": None if burst.get("awlen") is None else int(json_scalar(burst["awlen"])),
+            "arlen": None if burst.get("arlen") is None else int(json_scalar(burst["arlen"])),
         }
 
     def extract_bursts(
@@ -748,7 +730,7 @@ class CosimStep(BuildStep):
         case = HistCase(ndata=ndata, nbins=nbins, seed=seed)
         data, edges = case.write_inputs(data_dir)
         _run_tcl(config, start_at="csim", through="cosim",
-                 trace_level=_vcd_trace(trace_level), live_output=live_output)
+                 trace_level=vcd_trace(trace_level), live_output=live_output)
         ok, detail = case.check_outputs(data_dir, data, edges)
         if not ok:
             raise RuntimeError(f"Cosim output mismatch (reference vector): {detail}")
@@ -766,7 +748,7 @@ class GenerateVcdStep(BuildStep):
 
     def run(self, config: BuildConfig, ndata, nbins, trace_level, **_) -> dict[str, Any]:
         ht = HistTest(example_dir=config.root_dir, ndata=ndata, nbins=nbins)
-        vcd = ht.generate_vcd(trace_level=_vcd_trace(trace_level))
+        vcd = ht.generate_vcd(trace_level=vcd_trace(trace_level))
         return {"vcd": Path(vcd)}
 
 

--- a/pysilicon/utils/jsonutil.py
+++ b/pysilicon/utils/jsonutil.py
@@ -1,0 +1,37 @@
+"""Small JSON-serialization helpers shared by build scripts that write status /
+burst / timing JSON.
+
+``json_scalar`` coerces a numpy scalar to a native Python scalar so ``json.dumps``
+accepts it; ``hex_word`` formats an integer as a fixed-width, masked hex string.
+The numpy-scalar coercion idiom recurs across the example build scripts and the
+data-model serialization (e.g. ``dataschema._to_jsonable``, which walks nested
+structures and can call ``json_scalar`` as its scalar-level primitive).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def json_scalar(value):
+    """Coerce a numpy integer/floating scalar to a native Python scalar.
+
+    Pass-through for any value that is not a numpy scalar, so it is safe to apply
+    blanket-ly before ``json.dumps``.
+    """
+    if isinstance(value, (np.integer, np.floating)):
+        return value.item()
+    return value
+
+
+def hex_word(value, bitwidth: int) -> str:
+    """Format ``value`` as a ``0x``-prefixed, zero-padded hex string of exactly
+    ``ceil(bitwidth/4)`` digits, masked to ``bitwidth`` bits.
+
+    Raises ``ValueError`` if ``bitwidth`` is not positive.
+    """
+    if bitwidth <= 0:
+        raise ValueError("bitwidth must be positive.")
+    int_value = int(json_scalar(value))
+    mask = (1 << bitwidth) - 1
+    hex_width = (bitwidth + 3) // 4
+    return f"0x{(int_value & mask):0{hex_width}x}"

--- a/pysilicon/utils/vcd.py
+++ b/pysilicon/utils/vcd.py
@@ -17,6 +17,16 @@ class AximmBeatType(IntEnum):
     IDLE = 1
     STALL = 2
 
+
+def vcd_trace(trace_level: str) -> str:
+    """Map a user trace level to the HLS cosim VCD trace pattern.
+
+    ``"port"`` and ``"all"`` pass through unchanged; any other value maps to
+    ``"*"`` (the xsim "trace everything" pattern).
+    """
+    return trace_level if trace_level in ("port", "all") else "*"
+
+
 def binary_str_to_numeric(
         bin_str : str,
         dtype : str,

--- a/tests/utils/test_jsonutil.py
+++ b/tests/utils/test_jsonutil.py
@@ -1,0 +1,35 @@
+"""Unit tests for pysilicon.utils.jsonutil (json_scalar, hex_word)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pysilicon.utils.jsonutil import hex_word, json_scalar
+
+
+def test_json_scalar_coerces_numpy_scalars():
+    out_i = json_scalar(np.int64(7))
+    assert out_i == 7 and isinstance(out_i, int)
+    out_f = json_scalar(np.float32(1.5))
+    assert out_f == 1.5 and isinstance(out_f, float)
+
+
+def test_json_scalar_passes_through_native_values():
+    # Non-numpy values are returned unchanged (the same object).
+    for v in (3, 2.5, "x", None, [1, 2]):
+        assert json_scalar(v) is v
+
+
+def test_hex_word_fixed_width_masked():
+    assert hex_word(255, 8) == "0xff"
+    assert hex_word(0, 16) == "0x0000"
+    assert hex_word(np.uint32(0xABCD), 16) == "0xabcd"
+    assert hex_word(0x1FF, 8) == "0xff"          # masks to width
+    assert hex_word(1, 12) == "0x001"            # ceil(bitwidth/4) digits
+
+
+def test_hex_word_rejects_nonpositive_bitwidth():
+    with pytest.raises(ValueError):
+        hex_word(1, 0)
+    with pytest.raises(ValueError):
+        hex_word(1, -4)

--- a/tests/utils/test_vcd.py
+++ b/tests/utils/test_vcd.py
@@ -20,7 +20,14 @@ import pytest
 
 from vcdvcd import VCDVCD
 
-from pysilicon.utils.vcd import AximmBeatType, SigInfo, VcdParser
+from pysilicon.utils.vcd import AximmBeatType, SigInfo, VcdParser, vcd_trace
+
+
+def test_vcd_trace_maps_levels():
+    assert vcd_trace("port") == "port"
+    assert vcd_trace("all") == "all"
+    assert vcd_trace("none") == "*"
+    assert vcd_trace("whatever") == "*"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Find a home for the general helpers that were buried as private functions in `hist_build.py`:

- **`json_scalar`** (numpy scalar → native, for `json.dumps`) + **`hex_word`** (int → fixed-width masked hex) → new `pysilicon/utils/jsonutil.py`. The numpy-coercion idiom recurs across the build scripts + `dataschema`/`dataunion`; `json_scalar` is the reusable scalar primitive.
- **`vcd_trace`** (trace-level → xsim VCD pattern) → `pysilicon/utils/vcd.py`, next to the other VCD helpers.
- **`_run_tcl` stays in `hist_build.py`** — it hardcodes the hist-specific `PYSILICON_HIST_*` env protocol, so it's the example's run.tcl adapter, not a shared primitive.

Verbatim move (behavior unchanged); `build_hist_dag` imports + builds; added `tests/utils/test_jsonutil.py` + a `vcd_trace` test (5 passed). Non-vitis suite green aside from the 10 known pre-existing failures; changed files ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)