### PR TITLE
docs: exclude examples/*.md from the nav tree

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,14 @@ exclude:
   - vendor/
   - node_modules/
 
-
-
+# examples/ stays served (above) so generated reports + source files remain
+# linkable, but the example dirs' own markdown (README.md, CODEGEN_NOTES.md, …) is
+# developer notes, not site content — keep every examples/*.md out of the nav tree
+# and search. (docs/examples/ is a different path and is unaffected.)
+defaults:
+  - scope:
+      path: "examples"
+    values:
+      nav_exclude: true
+      search_exclude: true
 


### PR DESCRIPTION
Fixes the stray top-level nav entries (`regmap`, `codegen notes`, …) on the docs site — e.g. https://sdrangan.github.io/pysilicon/examples/regmap/ and .../examples/shared_mem/CODEGEN_NOTES.html.

**Cause:** `_config.yml` deliberately keeps `examples/` un-excluded so generated HTML reports + source files stay linkable — but that also renders the example dirs' own `README.md`/`CODEGEN_NOTES.md` (developer notes) and Just-the-Docs picks them into the nav.

**Fix:** a `defaults` scope setting `nav_exclude: true` + `search_exclude: true` for `path: examples` — drops every `examples/*.md` from the nav + search while leaving the directory served (no broken report/source links). `docs/examples/` is a different path and is unaffected.

Visible after the next GitHub Pages deploy. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)