### PR TITLE
docs(schema): add Fields intro page + refocus Data Lists

### DIFF
--- a/docs/guide/schema/codegen.md
+++ b/docs/guide/schema/codegen.md
@@ -1,7 +1,7 @@
 ---
 title: Code Generation
 parent: Data Schemas
-nav_order: 2
+nav_order: 7
 ---
 
 # Auto-generating Vitis HLS Files

--- a/docs/guide/schema/datalists.md
+++ b/docs/guide/schema/datalists.md
@@ -1,61 +1,65 @@
 ---
-title: Fields and Lists
+title: Data Lists
 parent: Data Schemas
-nav_order: 1
-has_children: true
+nav_order: 2
+has_children: false
 ---
 
-# Data Fields and Data Lists
+# Data Lists — structured records
+
+A **`DataList`** groups several named [fields](./fields.md) into one structured record — the
+hardware equivalent of a C `struct` or a Python dataclass. You reach for it whenever related
+values travel together: a command header, a packet, a configuration block. Each entry has a
+name, a **schema** (its type), and a description — and an entry can itself be another schema,
+an [array](./dataarrays.md) or a nested `DataList`.
 
 ## Example
 
-A representative schema appears in the [polynomial example](../../examples/stream_inband/):
+From the [polynomial example](../../examples/stream_inband/), a command header carrying a
+transaction id, a coefficient array, and a sample count:
 
 ```python
-include_dir = "include"
-
 class CoeffArray(DataArray):
     element_type = Float32
     static = True
     ncoeff = 4
     max_shape = (ncoeff,)
     cpp_storage = "raw"
-    include_dir = include_dir
 
 class PolyCmdHdr(DataList):
     elements = {
-        "tx_id": {
-            "schema": IntField.specialize(bitwidth=16, signed=False),
-            "description": "Transaction ID",
-        },
-        "coeffs": {
-            "schema": CoeffArray,
-            "description": "Polynomial coefficients",
-        },
-        "nsamp": {
-            "schema": IntField.specialize(bitwidth=16, signed=False),
-            "description": "Number of samples",
-        },
+        "tx_id":  {"schema": IntField.specialize(bitwidth=16, signed=False),
+                   "description": "Transaction ID"},
+        "coeffs": {"schema": CoeffArray,
+                   "description": "Polynomial coefficients"},
+        "nsamp":  {"schema": IntField.specialize(bitwidth=16, signed=False),
+                   "description": "Number of samples"},
     }
-    include_dir = include_dir
 ```
 
-Key points:
+A `DataList` entry can be a simple field (`tx_id`, `nsamp` are `IntField`s) or a whole nested
+schema (`coeffs` is a `DataArray`). Every bit width is explicit and shared between the Python
+model and the generated C++ — there is no separate, hand-maintained struct to drift out of
+sync.
 
-- `DataList` models structured records (field dictionaries with types/descriptions).
-- `DataArray` models typed arrays and can be nested inside `DataList` fields.
-- Bitwidth and schema typing are explicit and shared across Python and generated C++.
+## Creating and accessing instances
 
-## Creating instances in Python
+Each named entry becomes an attribute on the instance — read and write it by name:
 
 ```python
-coeffs = CoeffArray()
-coeffs.val = np.array([1.0, -2.0, -3.0, 4.0], dtype=np.float32)
+cmd = PolyCmdHdr()
+cmd.tx_id  = 42
+cmd.coeffs = np.array([1.0, -2.0, -3.0, 4.0], dtype=np.float32)
+cmd.nsamp  = 100
 
-cmd_hdr = PolyCmdHdr()
-cmd_hdr.tx_id = 42
-cmd_hdr.coeffs = coeffs.val
-cmd_hdr.nsamp = 100
+print(cmd.tx_id)    # 42
+print(cmd.nsamp)    # 100
 ```
 
-These schema objects can be serialized directly for simulation interfaces, test vectors, and generated testbench flows.
+A `DataList` instance serializes directly to the packed bit representation used by simulation
+interfaces, test vectors, and generated testbenches — see [Code Generation](./codegen.md).
+
+---
+
+Related: the typed-array building block is [Data Arrays](./dataarrays.md); for fields that
+share storage, see [Data Unions](./dataunion.md).

--- a/docs/guide/schema/fields.md
+++ b/docs/guide/schema/fields.md
@@ -1,0 +1,125 @@
+---
+title: Fields
+parent: Data Schemas
+nav_order: 1
+has_children: false
+---
+
+# Fields — the basic typed values
+
+A **field** is the smallest typed unit of data in a PySilicon design: a single value with
+an explicit **bit width** and interpretation (integer, float, …). Everything larger is
+built out of fields — structured records ([Data Lists](./datalists.md)) and typed arrays
+([Data Arrays](./dataarrays.md)).
+
+## Why bit widths are explicit — the hardware mindset
+
+In ordinary software a number is "just an `int`": the language picks 32 or 64 bits and you
+never think about it. In **hardware, every value has a chosen bit width**, because each bit
+is physical — it costs flip-flops, wires, logic, power, and timing margin. A counter that
+only ever reaches 1000 needs **10 bits**, not 32; the other 22 bits are wasted silicon. So
+in PySilicon a field's width is part of its *type*, declared up front, and it maps directly
+to the arbitrary-precision types Vitis HLS uses (`ap_int<W>` and friends).
+
+The first surprise coming from software is exactly this: **you size every number.**
+
+## The two simple fields
+
+PySilicon has two basic numeric fields. (A third — fixed-point — is important enough in DSP
+to get [its own page](./fixpoint.md); we set it aside here.)
+
+### `IntField` — arbitrary-precision integer
+
+```python
+from pysilicon.hw.dataschema import IntField
+
+Int16 = IntField.specialize(bitwidth=16, signed=True)    # signed 16-bit
+UInt8 = IntField.specialize(bitwidth=8,  signed=False)   # unsigned 8-bit
+Flag  = IntField.specialize(bitwidth=1,  signed=False)   # a single bit
+```
+
+`bitwidth` can be anything from 1 to thousands of bits — you pick exactly what the value
+needs.
+
+### `FloatField` — IEEE floating point
+
+```python
+from pysilicon.hw.dataschema import FloatField
+
+Float32 = FloatField.specialize(bitwidth=32)    # IEEE single precision
+Float64 = FloatField.specialize(bitwidth=64)    # IEEE double precision
+```
+
+## Why arbitrary-precision integers matter in hardware
+
+Software integers come in a few fixed sizes (8/16/32/64). Hardware has no such restriction —
+you build a register exactly as wide as you need, and **narrower is better**: less area,
+less power, shorter carry chains (so a higher clock speed), and room to pack more parallel
+units onto the chip. A 12-bit ADC sample is a 12-bit value; a counter over five states is 3
+bits. `IntField`'s free choice of `bitwidth` models this directly (it lowers to
+`ap_int<W>` / `ap_uint<W>`), so your Python model carries the **same** precision the
+hardware will — no accidental 32-bit assumptions creeping in.
+
+## Why floating point is "expensive" in hardware
+
+Floating point is wonderfully convenient in software — huge dynamic range, no manual
+scaling — but in hardware an FP unit is **big and slow**. An FP multiply or add consumes
+several DSP blocks plus extra logic for exponent handling and normalization, and takes
+multiple pipeline cycles; the same operation in integer or fixed-point can be a single DSP
+in one cycle. So on a high-throughput datapath, designers usually **avoid floating point**
+and work in integer/fixed-point instead — accepting the burden of choosing scales and
+widths in exchange for far less area, power, and latency. `FloatField` is still useful (for
+golden references and non-critical control values), but the performance-critical numeric
+work is where [fixed-point](./fixpoint.md) comes in.
+
+## Declaring and using fields
+
+A specialized field is a *type*; make an instance by calling it with a value, and read or
+write the value through `.val`:
+
+```python
+x = Int16(42)
+print(x.val)        # 42
+x.val = -7          # set a new value
+
+f = Float32(1.5)
+print(f.val)        # 1.5
+```
+
+Fields know how to serialize themselves to the packed bit representation used in simulation
+and in generated C++ — that machinery is shared with the larger schema types and is covered
+under [Code Generation](./codegen.md).
+
+## Modeling overflow: wrap vs saturate
+
+What happens when a value doesn't fit its bit width? Hardware does not raise an exception —
+it does one of two things, and **which one is a design choice you model explicitly**:
+
+- **Wrap** (two's-complement overflow) — the high bits are simply dropped, so the value
+  "wraps around." Cheap (it's just truncation) and the default behavior of plain integer
+  arithmetic.
+- **Saturate** — the value is clamped to the largest/smallest representable, so an overshoot
+  sticks at the maximum instead of wrapping to a negative. Costs a comparator, but is far
+  safer for signals (a saturating adder never flips a loud sample into a quiet one).
+
+PySilicon provides both as vectorized helpers:
+
+```python
+from pysilicon.utils.fixputils import truncate, saturate
+
+# An 8-bit signed value holds [-128, 127]. What becomes of 200?
+truncate(200, wid=8, signed=True)   # wrap  -> -56
+saturate(200, wid=8, signed=True)   # clamp ->  127
+
+# They work on numpy arrays too (vectorized — element-wise):
+import numpy as np
+saturate(np.array([200, -300, 50]), wid=8, signed=True)   # -> [127, -128, 50]
+```
+
+These same two behaviors, applied automatically on every assignment, are what the overflow
+modes `AP_WRAP` / `AP_SAT` select for [fixed-point](./fixpoint.md) fields.
+
+---
+
+Next: group fields into records with [Data Lists](./datalists.md), or into typed arrays with
+[Data Arrays](./dataarrays.md).


### PR DESCRIPTION
The schema guide dove straight into a `DataList` example with no field foundation. This splits it:

- **fields.md** (new, nav 1) — a newcomer/non-hardware intro: what a field is, why bit widths are explicit in hardware, `IntField` (arbitrary-precision) + `FloatField`, **why FP is expensive in HW** and **why arbitrary-precision integers matter**, declaring/accessing fields via `.val`, and **modeling overflow (wrap vs saturate)** via `fixputils.truncate`/`saturate`.
- **datalists.md** (nav 2) — refocused purely on the `DataList` record type (was "Fields and Lists"); the field material moved to fields.md.
- **codegen.md** → nav 7 (last), after the type pages.

All documented code snippets were executed and verified to produce their stated outputs; all internal links resolve. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)