### PR TITLE
vectorization (1/2): type-preserving operators + basic_vec example

### DIFF
--- a/examples/basic_vec/.gitignore
+++ b/examples/basic_vec/.gitignore
@@ -1,0 +1,9 @@
+gen/
+results/
+basic_vec_proj/
+*.log
+in_a.txt
+in_b.txt
+in_c.txt
+out_bits.txt
+kernel.cpp

--- a/examples/basic_vec/basic_vec_build.py
+++ b/examples/basic_vec/basic_vec_build.py
@@ -1,0 +1,184 @@
+"""basic_vec — the vectorization front-door: one MAC, ``y = a*b + c``, bit-exact.
+
+For each numeric kind (int / float / fixed) we compute the **same** elementwise MAC
+two ways and assert the raw bits match:
+
+* **Python golden** — the vectorized type-preserving operators on `DataArray`
+  (`a * b + c`), then an explicit `quantize` for the fixed case. No per-element loop.
+* **Vitis kernel** — the corresponding vectorized C++ (`kernels.py`), run in C-sim.
+
+This is the minimal, teaching version of the conformance idea (the rigorous
+all-modes/widths sweep is `examples/schemas/fixedpoint`); it shares the machinery —
+the `BuildDag` + :func:`run_dag_cli` + gen→csim→compare-bits pattern.
+
+CLI::
+
+    python basic_vec_build.py --through gen        # write kernels + vectors (no Vitis)
+    python basic_vec_build.py --through run        # the bit-exact csim conformance (Vitis)
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from pysilicon.build.build import BuildConfig, BuildDag, BuildStep, SourceStep
+from pysilicon.build.cli import run_dag_cli
+from pysilicon.hw.dataschema import DataArray, FloatField, IntField
+from pysilicon.hw.fixpoint import FixedField, from_real, quantize
+from pysilicon.toolchain import toolchain
+from pysilicon.utils.fixputils import to_bits
+
+try:
+    from examples.basic_vec.kernels import render_fixed_mac, render_float_mac, render_int_mac
+except ModuleNotFoundError:  # direct execution from the example dir
+    from kernels import render_fixed_mac, render_float_mac, render_int_mac  # type: ignore[no-redef]
+
+_SOURCE_DIR = Path(__file__).resolve().parent
+
+
+def _int_bits(da: DataArray, W: int) -> list[int]:
+    return [int(b) for b in np.atleast_1d(to_bits(np.asarray(da), W))]
+
+
+def _f32_bits(da: DataArray) -> list[int]:
+    return [int(u) for u in np.asarray(da).astype(np.float32).view(np.uint32)]
+
+
+def _case(name, kernel, a, b, c, expected) -> dict:
+    return {"name": name, "kernel": kernel, "a": a, "b": b, "c": c, "expected": expected}
+
+
+def build_cases() -> list[dict]:
+    """The three MAC cases. Each computes its Python golden with the operators, derives
+    the result type, and renders the matching kernel."""
+    cases: list[dict] = []
+
+    # --- integer: a*b + c, growth-aware (result width derived by the operators) ---
+    I8 = IntField.specialize(8, True)
+
+    def ia(vals):
+        return DataArray.specialize(I8, max_shape=(len(vals),))(vals)
+
+    a, b, c = ia([3, -4, 5, 7]), ia([6, 7, -8, 2]), ia([1, -1, 2, -3])
+    y = a * b + c                                          # IntField<17>
+    wy = y.element_type.get_bitwidth()
+    cases.append(_case("int_mac", render_int_mac(8, 8, 8, wy),
+                       _int_bits(a, 8), _int_bits(b, 8), _int_bits(c, 8), _int_bits(y, wy)))
+
+    # --- float: a*b + c, numpy float32 passthrough (two roundings) ---
+    F32 = FloatField.specialize(32)
+
+    def fa(vals):
+        return DataArray.specialize(F32, max_shape=(len(vals),))(np.array(vals, dtype=np.float32))
+
+    fa_, fb_, fc_ = fa([1.5, 2.5, -3.0]), fa([2.0, -1.5, 0.5]), fa([0.25, 1.0, -0.5])
+    fy = fa_ * fb_ + fc_
+    cases.append(_case("float_mac", render_float_mac(),
+                       _f32_bits(fa_), _f32_bits(fb_), _f32_bits(fc_), _f32_bits(fy)))
+
+    # --- fixed: full-precision a*b + c, then one explicit quantize to the working fmt ---
+    Q = FixedField.specialize(8, 4)
+    qa = from_real([1.5, -2.0, 0.5], Q)
+    qb = from_real([2.0, 1.5, -1.0], Q)
+    qc = from_real([0.5, 0.25, -0.5], Q)
+    qy = quantize(qa * qb + qc, Q)
+    cases.append(_case("fixed_mac",
+                       render_fixed_mac(Q.cpp_type, 8, Q.cpp_type, 8, Q.cpp_type, 8, Q.cpp_type, 8),
+                       _int_bits(qa, 8), _int_bits(qb, 8), _int_bits(qc, 8), _int_bits(qy, 8)))
+    return cases
+
+
+def gen_case_sources(case: dict, work_dir: Path) -> Path:
+    work_dir = Path(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    (work_dir / "kernel.cpp").write_text(case["kernel"], encoding="utf-8")
+    for key in ("a", "b", "c"):
+        (work_dir / f"in_{key}.txt").write_text(
+            "\n".join(str(v) for v in case[key]) + "\n", encoding="utf-8")
+    (work_dir / "expected.json").write_text(
+        json.dumps({"name": case["name"], "expected": case["expected"]}, indent=2), encoding="utf-8")
+    shutil.copy(_SOURCE_DIR / "run.tcl", work_dir / "run.tcl")
+    return work_dir
+
+
+def csim_and_compare(work_dir: Path, *, live_output: bool = False) -> dict:
+    work_dir = Path(work_dir)
+    expected = json.loads((work_dir / "expected.json").read_text(encoding="utf-8"))
+    toolchain.run_vitis_hls(work_dir / "run.tcl", work_dir=work_dir, capture_output=not live_output)
+    vitis = [int(t) for t in (work_dir / "out_bits.txt").read_text(encoding="utf-8").split()]
+    exp = expected["expected"]
+    mism = [{"i": i, "expected": e, "vitis": g} for i, (e, g) in enumerate(zip(exp, vitis)) if e != g]
+    return {"name": expected["name"], "count_ok": len(vitis) == len(exp),
+            "mismatches": mism, "exact": len(vitis) == len(exp) and not mism}
+
+
+def conformance_for_case(case: dict, work_dir: Path, *, live_output: bool = False) -> dict:
+    gen_case_sources(case, work_dir)
+    return csim_and_compare(work_dir, live_output=live_output)
+
+
+@dataclass(kw_only=True)
+class GenStep(BuildStep):
+    description = "Generate the int/float/fixed MAC kernels + input vectors + Python golden bits."
+    consumes = ["basic_vec_source", "kernels_source", "run_tcl"]
+    produces = {"basic_vec_gen": Path("gen")}
+    params = {}
+
+    def run(self, config: BuildConfig, **_) -> dict:
+        gen = config.root_dir / "gen"
+        gen.mkdir(parents=True, exist_ok=True)
+        for case in build_cases():
+            gen_case_sources(case, gen / case["name"])
+        return {"basic_vec_gen": gen}
+
+
+@dataclass(kw_only=True)
+class RunStep(BuildStep):
+    description = "Per kind: Vitis csim, assert Vitis bits == Python operator bits exactly."
+    consumes = ["basic_vec_gen"]
+    produces = {"report": Path("results/basic_vec_report.json")}
+    params = {"live_output": False}
+
+    def run(self, config: BuildConfig, live_output, **_) -> dict:
+        gen = config.root_dir / "gen"
+        results = [csim_and_compare(gen / case["name"], live_output=live_output)
+                   for case in build_cases()]
+        report = config.root_dir / "results" / "basic_vec_report.json"
+        report.parent.mkdir(parents=True, exist_ok=True)
+        n_exact = sum(r["exact"] for r in results)
+        report.write_text(json.dumps(
+            {"n_cases": len(results), "n_exact": n_exact, "all_exact": n_exact == len(results),
+             "results": results}, indent=2), encoding="utf-8")
+        failed = [r for r in results if not r["exact"]]
+        if failed:
+            raise RuntimeError(f"STOP — Vitis disagreed with the Python golden: {failed[0]}")
+        return {"report": report}
+
+
+def build_basic_vec_dag() -> BuildDag:
+    dag = BuildDag()
+    dag.add(SourceStep(artifact="basic_vec_source", path=_SOURCE_DIR / "basic_vec_build.py"))
+    dag.add(SourceStep(artifact="kernels_source", path=_SOURCE_DIR / "kernels.py"))
+    dag.add(SourceStep(artifact="run_tcl", path=_SOURCE_DIR / "run.tcl"))
+    dag.add(GenStep(name="gen"))
+    dag.add(RunStep(name="run"))
+    return dag
+
+
+def main() -> None:
+    run_dag_cli(
+        build_basic_vec_dag,
+        description="basic_vec — vectorized Python golden vs vectorized Vitis (int/float/fixed MAC).",
+        default_through="gen",
+        root_dir=_SOURCE_DIR,
+        extra_args=[(("--live-output",), {"action": "store_true"})],
+        params_from_args=lambda a: {"live_output": a.live_output},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/basic_vec/kernels.py
+++ b/examples/basic_vec/kernels.py
@@ -1,0 +1,97 @@
+"""Vectorized Vitis kernels for the basic_vec example — one MAC, ``y = a*b + c``.
+
+Three kernels (int / float / fixed) over the *same* elementwise op, so the
+pedagogical parallel is exact. Each reads operand bit-vectors (one value per line),
+computes ``a*b + c`` in the typed C++ — **full-precision** product/sum, mirroring the
+Python operators — and writes the result bits. Uniform argv ``(in_a, in_b, in_c,
+out)``. The Python golden produces identical bits.
+
+These are deliberately minimal and readable (the docs pull from them); the rigorous
+all-modes/widths sweep lives in examples/schemas/fixedpoint.
+"""
+from __future__ import annotations
+
+_INT_READ = """#include <ap_int.h>
+#include <fstream>
+#include <vector>
+
+static std::vector<unsigned long long> rd(const char* p) {
+    std::ifstream f(p); std::vector<unsigned long long> v; unsigned long long x;
+    while (f >> x) v.push_back(x); return v;
+}
+"""
+
+
+def render_int_mac(wa: int, wb: int, wc: int, wy: int) -> str:
+    """``ap_int<wy> y = a*b + c`` (signed); full-precision product + sum."""
+    return _INT_READ + f"""
+int main(int argc, char** argv) {{
+    auto A = rd(argv[1]); auto B = rd(argv[2]); auto C = rd(argv[3]);
+    std::ofstream out(argv[4]);
+    for (size_t i = 0; i < A.size(); ++i) {{
+        ap_int<{wa}> a; a.range({wa} - 1, 0) = (ap_uint<{wa}>)A[i];
+        ap_int<{wb}> b; b.range({wb} - 1, 0) = (ap_uint<{wb}>)B[i];
+        ap_int<{wc}> c; c.range({wc} - 1, 0) = (ap_uint<{wc}>)C[i];
+        ap_int<{wy}> y = a * b + c;
+        out << (unsigned long long)y.range({wy} - 1, 0) << "\\n";
+    }}
+    return 0;
+}}
+"""
+
+
+def render_float_mac() -> str:
+    """``float y = a*b + c`` via a split intermediate; built with -ffp-contract=off
+    (see run.tcl) so it is two roundings — matching numpy float32, not a fused FMA."""
+    return """#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+static std::vector<uint32_t> rd(const char* p) {
+    std::ifstream f(p); std::vector<uint32_t> v; unsigned long long x;
+    while (f >> x) v.push_back((uint32_t)x); return v;
+}
+static float u2f(uint32_t u) { float f; std::memcpy(&f, &u, 4); return f; }
+static uint32_t f2u(float f) { uint32_t u; std::memcpy(&u, &f, 4); return u; }
+
+int main(int argc, char** argv) {
+    auto A = rd(argv[1]); auto B = rd(argv[2]); auto C = rd(argv[3]);
+    std::ofstream out(argv[4]);
+    for (size_t i = 0; i < A.size(); ++i) {
+        float a = u2f(A[i]), b = u2f(B[i]), c = u2f(C[i]);
+        float t = a * b;
+        float y = t + c;
+        out << (unsigned long long)f2u(y) << "\\n";
+    }
+    return 0;
+}
+"""
+
+
+def render_fixed_mac(type_a: str, wa: int, type_b: str, wb: int,
+                     type_c: str, wc: int, type_y: str, wy: int) -> str:
+    """``target_t y = a*b + c`` — full-precision a*b+c, quantize-on-assign to target."""
+    return """#include <ap_fixed.h>
+#include <ap_int.h>
+#include <fstream>
+#include <vector>
+
+static std::vector<unsigned long long> rd(const char* p) {
+    std::ifstream f(p); std::vector<unsigned long long> v; unsigned long long x;
+    while (f >> x) v.push_back(x); return v;
+}
+""" + f"""
+int main(int argc, char** argv) {{
+    auto A = rd(argv[1]); auto B = rd(argv[2]); auto C = rd(argv[3]);
+    std::ofstream out(argv[4]);
+    for (size_t i = 0; i < A.size(); ++i) {{
+        {type_a} a; a.range({wa} - 1, 0) = (ap_uint<{wa}>)A[i];
+        {type_b} b; b.range({wb} - 1, 0) = (ap_uint<{wb}>)B[i];
+        {type_c} c; c.range({wc} - 1, 0) = (ap_uint<{wc}>)C[i];
+        {type_y} y = a * b + c;
+        out << (unsigned long long)y.range({wy} - 1, 0) << "\\n";
+    }}
+    return 0;
+}}
+"""

--- a/examples/basic_vec/run.tcl
+++ b/examples/basic_vec/run.tcl
@@ -1,0 +1,21 @@
+# Vitis HLS C-simulation driver for one basic_vec MAC kernel.
+# Uniform argv: in_a in_b in_c out_bits.  -ffp-contract=off keeps the float kernel's
+# a*b+c as two roundings (matching numpy float32), never a fused FMA.
+open_project -reset basic_vec_proj
+set_top main
+add_files -tb kernel.cpp -cflags "-ffp-contract=off"
+
+open_solution -reset "solution1"
+set_part {xc7z020clg484-1}
+create_clock -period 10
+
+set d [file dirname [file normalize [info script]]]
+set argv_paths "[file join $d in_a.txt] [file join $d in_b.txt] [file join $d in_c.txt] [file join $d out_bits.txt]"
+
+if {[catch {csim_design -argv $argv_paths} res]} {
+    puts "PYSILICON_ERROR: HLS C-Simulation failed."
+    puts $res
+    exit 1
+}
+puts "PYSILICON_SUCCESS: basic_vec csim passed."
+exit 0

--- a/pysilicon/hw/dataschema.py
+++ b/pysilicon/hw/dataschema.py
@@ -26,6 +26,8 @@ from typing import Any, ClassVar, TypeAlias
 import numpy as np
 from numpy.typing import NDArray
 
+from pysilicon.utils.fixputils import MAX_WIDTH
+
 Words: TypeAlias = NDArray[np.uint32] | NDArray[np.uint64]
 
 from pysilicon.build.build import Buildable, BuildConfig, BuildResult
@@ -2595,6 +2597,20 @@ class DataArray(DataSchema):
             f"{type(self).__name__}(element_type={elem_name}, shape={np.asarray(self.val).shape})"
         )
 
+    # --- type-preserving arithmetic operators (sugar; full-precision, no loss) ---
+    # `+`/`-`/`*` over two DataArrays return a new DataArray whose element format is
+    # *derived* (full precision): int grows (a*b -> Wa+Wb, a+b -> max+1), fixed reuses
+    # FixedField's derivation, float is numpy passthrough. Rounding stays an explicit
+    # quantize(); `.val` stays the numpy escape hatch. See _datarray_binop.
+    def __mul__(self, other: Any) -> "DataArray":
+        return _datarray_binop(self, other, "mul")
+
+    def __add__(self, other: Any) -> "DataArray":
+        return _datarray_binop(self, other, "add")
+
+    def __sub__(self, other: Any) -> "DataArray":
+        return _datarray_binop(self, other, "sub")
+
     @classmethod
     def _normalized_shape(cls) -> tuple[int, ...]:
         shape = tuple(int(dim) for dim in cls.max_shape)
@@ -4230,3 +4246,72 @@ __all__ = [
     "DataList",
     "DataArray",
 ]
+
+
+# ---------------------------------------------------------------------------
+# DataArray arithmetic operators (sugar over the per-type functions)
+# ---------------------------------------------------------------------------
+def _wrap_datarray(val: Any, elem: type[DataSchema]) -> DataArray:
+    """Wrap a numpy array + element type into a fresh DataArray[elem]."""
+    arr = np.asarray(val)
+    shape = arr.shape if arr.shape else (1,)
+    return DataArray.specialize(elem, max_shape=tuple(shape))(arr.reshape(shape))
+
+
+def _elem_kind(elem: type[DataSchema]) -> str:
+    if hasattr(elem, "get_format"):                 # FixedField (duck-typed; avoids a cycle)
+        return "fixed"
+    if isinstance(elem, type) and issubclass(elem, IntField):
+        return "int"
+    if isinstance(elem, type) and issubclass(elem, FloatField):
+        return "float"
+    return "other"
+
+
+def _int_binop(a: DataArray, b: DataArray, op: str) -> DataArray:
+    ea, eb = a.element_type, b.element_type
+    if bool(ea.signed) != bool(eb.signed):
+        raise NotImplementedError(
+            "mixed signed/unsigned integer arithmetic is not supported in v1 (numpy would "
+            "coerce int64/uint64 to float64); use a common signedness first.")
+    Wa, Wb = ea.get_bitwidth(), eb.get_bitwidth()
+    if op == "mul":
+        Wr, signed_r = Wa + Wb, bool(ea.signed)
+    else:                                            # add / sub: +1 carry bit
+        Wr = max(Wa, Wb) + 1
+        signed_r = True if op == "sub" else bool(ea.signed)   # subtraction may go negative
+    if Wr > MAX_WIDTH:
+        raise NotImplementedError(
+            f"integer {op} result width {Wr} exceeds the {MAX_WIDTH}-bit limit "
+            "(numpy would silently wrap); wide (>64-bit) support is Future.")
+    dtype = np.int64 if signed_r else np.uint64
+    av = np.asarray(a.val).astype(dtype)
+    bv = np.asarray(b.val).astype(dtype)
+    out = av * bv if op == "mul" else (av + bv if op == "add" else av - bv)
+    return _wrap_datarray(out, IntField.specialize(Wr, signed_r))
+
+
+def _float_binop(a: DataArray, b: DataArray, op: str) -> DataArray:
+    av, bv = np.asarray(a.val), np.asarray(b.val)
+    out = av * bv if op == "mul" else (av + bv if op == "add" else av - bv)
+    bw = 64 if out.dtype == np.float64 else 32       # numpy passthrough; no growth
+    return _wrap_datarray(out, FloatField.specialize(bw))
+
+
+def _datarray_binop(a: DataArray, b: Any, op: str) -> DataArray:
+    if not isinstance(b, DataArray):
+        raise TypeError(
+            f"DataArray '{op}' needs both operands to be DataArray (got {type(b).__name__}); "
+            "scalar/array operands are not supported in v1 — use .val for raw numpy.")
+    ka, kb = _elem_kind(a.element_type), _elem_kind(b.element_type)
+    if ka != kb or ka == "other":
+        raise TypeError(
+            f"cannot apply '{op}' to {a.element_type.__name__} and {b.element_type.__name__} "
+            "arrays (operands must be the same numeric kind: int, fixed, or float).")
+    if ka == "fixed":
+        # sugar over the existing FixedField functions; lazy import avoids a module cycle
+        from pysilicon.hw.fixpoint import add as _fadd, mult as _fmult, sub as _fsub
+        return {"mul": _fmult, "add": _fadd, "sub": _fsub}[op](a, b)
+    if ka == "int":
+        return _int_binop(a, b, op)
+    return _float_binop(a, b, op)

--- a/tests/examples/test_basic_vec.py
+++ b/tests/examples/test_basic_vec.py
@@ -1,0 +1,28 @@
+"""Phase 2 milestone: basic_vec — vectorized Python golden == vectorized Vitis, bit-exact.
+
+The -m vitis test runs the int/float/fixed MAC (y = a*b + c) in Vitis C-sim and asserts
+the bits equal the Python operator golden, zero LSB disagreement. A failed csim is a
+real failure; only skip when Vitis is absent.
+"""
+import pytest
+
+from examples.basic_vec.basic_vec_build import build_cases, conformance_for_case
+from pysilicon.toolchain import toolchain
+
+CASES = build_cases()
+
+
+def test_three_kinds_with_golden():
+    assert {c["name"] for c in CASES} == {"int_mac", "float_mac", "fixed_mac"}
+    for c in CASES:
+        assert c["expected"] and len(c["a"]) == len(c["b"]) == len(c["c"]) == len(c["expected"])
+
+
+@pytest.mark.vitis
+@pytest.mark.parametrize("case", CASES, ids=[c["name"] for c in CASES])
+def test_vectorized_python_matches_vitis_bit_exact(tmp_path, case):
+    if not toolchain.find_vitis_path():
+        pytest.skip("Vitis installation not found; cannot run basic_vec conformance.")
+    r = conformance_for_case(case, tmp_path)
+    assert r["count_ok"], f"{case['name']}: wrong output count"
+    assert r["exact"], f"{case['name']}: {len(r['mismatches'])} LSB disagreement(s): {r['mismatches'][:5]}"

--- a/tests/hw/test_vec_operators.py
+++ b/tests/hw/test_vec_operators.py
@@ -1,0 +1,110 @@
+"""Phase 1: type-preserving arithmetic operators on DataArray.
+
+Operators (`+`/`-`/`*`) are full-precision sugar over the per-type math: fixed reuses
+the FixedField functions (operator == function), int grows (a*b -> Wa+Wb, a+b ->
+max+1) under the shared single-64-bit fail-fast guard, float is numpy passthrough.
+Rounding stays an explicit quantize(); `.val` stays the numpy escape.
+"""
+import numpy as np
+import pytest
+
+from pysilicon.hw.dataschema import DataArray, FloatField, IntField
+from pysilicon.hw.fixpoint import (
+    FixedField, add, from_real, mult, quantize, sub, to_real,
+)
+
+
+def iarr(W, signed, vals):
+    return DataArray.specialize(IntField.specialize(W, signed), max_shape=(len(vals),))(vals)
+
+
+def farr(bw, vals):
+    return DataArray.specialize(FloatField.specialize(bw), max_shape=(len(vals),))(vals)
+
+
+# --- fixed: operators are exactly the free functions -------------------------
+@pytest.mark.parametrize("opsym,fn", [("mul", mult), ("add", add), ("sub", sub)])
+def test_fixed_operator_equals_function(opsym, fn):
+    Q = FixedField.specialize(8, 4)
+    a, b = from_real([1.5, -2.0, 0.5, 7.0], Q), from_real([2.0, 1.5, -1.0, 1.0], Q)
+    op = {"mul": a * b, "add": a + b, "sub": a - b}[opsym]
+    ref = fn(a, b)
+    assert op.element_type.cpp_type == ref.element_type.cpp_type
+    np.testing.assert_array_equal(np.asarray(op), np.asarray(ref))
+
+
+def test_fixed_full_precision_no_loss_then_explicit_quantize():
+    Q = FixedField.specialize(8, 4)
+    a, b = from_real([1.5, -2.0, 0.5], Q), from_real([2.0, 1.5, -1.0], Q)
+    c = from_real([0.5, 0.5, 0.5], Q)
+    y = a * b + c                                  # full precision, no rounding
+    assert y.element_type.bitwidth > Q.bitwidth    # grew
+    np.testing.assert_array_equal(to_real(y), to_real(a) * to_real(b) + to_real(c))
+    q = quantize(y, Q)                             # rounding only here
+    assert q.element_type.cpp_type == Q.cpp_type
+
+
+# --- int: growth-aware, exact ------------------------------------------------
+def test_int_growth_and_values():
+    a, b = iarr(8, True, [3, -4, 5]), iarr(8, True, [6, 7, -8])
+    p, s, d = a * b, a + b, a - b
+    assert p.element_type.get_bitwidth() == 16            # Wa+Wb
+    assert s.element_type.get_bitwidth() == 9             # max+1
+    assert d.element_type.get_bitwidth() == 9 and d.element_type.signed
+    np.testing.assert_array_equal(np.asarray(p), [18, -28, -40])
+    np.testing.assert_array_equal(np.asarray(s), [9, 3, -3])
+    np.testing.assert_array_equal(np.asarray(d), [-3, -11, 13])
+
+
+def test_int_unsigned_and_a_mul_b_plus_c():
+    a, b = iarr(8, False, [200, 100]), iarr(8, False, [3, 2])
+    p = a * b
+    assert p.element_type.get_bitwidth() == 16 and not p.element_type.signed
+    np.testing.assert_array_equal(np.asarray(p), [600, 200])      # exact, no int8 wrap
+    # a*b + c full precision matches plain numpy int
+    c = iarr(8, True, [1, -1, 2])
+    x, y = iarr(8, True, [3, -4, 5]), iarr(8, True, [6, 7, -8])
+    np.testing.assert_array_equal(np.asarray(x * y + c),
+                                  np.asarray(x).astype(np.int64) * np.asarray(y) + np.asarray(c))
+
+
+# --- float: numpy passthrough, no growth -------------------------------------
+def test_float_passthrough():
+    fa, fb = farr(32, [1.5, 2.5, 3.5]), farr(32, [2.0, 2.0, 2.0])
+    p = fa * fb
+    assert p.element_type.get_bitwidth() == 32           # no growth
+    np.testing.assert_array_equal(np.asarray(p), np.float32([3.0, 5.0, 7.0]))
+    np.testing.assert_array_equal(np.asarray(fa * fb + fa), np.asarray(fa) * np.asarray(fb) + np.asarray(fa))
+
+
+# --- guards ------------------------------------------------------------------
+def test_over_64_raises_int_and_fixed():
+    big = iarr(40, True, [1, 2])
+    with pytest.raises(NotImplementedError):
+        big * big                                         # 80 bits
+    A = FixedField.specialize(40, 20)
+    fa = from_real([1.0], A)
+    with pytest.raises(NotImplementedError):
+        fa * fa
+
+
+def test_mixed_sign_raises_int_and_fixed():
+    with pytest.raises(NotImplementedError):
+        iarr(8, True, [1]) * iarr(8, False, [1])
+    with pytest.raises(NotImplementedError):
+        from_real([1.0], FixedField.specialize(8, 4, signed=True)) * \
+            from_real([1.0], FixedField.specialize(8, 4, signed=False))
+
+
+def test_cross_kind_and_scalar_operands_raise():
+    with pytest.raises(TypeError):
+        iarr(8, True, [1]) * farr(32, [1.0])              # int x float
+    with pytest.raises(TypeError):
+        iarr(8, True, [1, 2]) * 2                          # scalar operand (v1)
+
+
+def test_existing_fixedfield_math_unchanged():
+    # operators are pure sugar; the underlying functions/bits are untouched
+    Q = FixedField.specialize(8, 4, q_mode=FixedField.specialize(8, 4).q_mode)
+    a, b = from_real([3.3, -3.9], Q), from_real([2.5, 1.1], Q)
+    np.testing.assert_array_equal(np.asarray(a * b), np.asarray(mult(a, b)))


### PR DESCRIPTION
First half of plans/vectorization.md — merged at the Phase-2 milestone checkpoint so the codebase reaches a clean point before the pysilicon→waveflow rename. The docs section + examples reorg (Phases 3–4) follow **after** the rename (written directly in the new naming).

**Phase 1 — operators (`arith`):** type-preserving `+`/`-`/`*` on numeric `DataArray`, returning full-precision results, as **sugar over the existing functions** — `fixed` delegates to `fixpoint.add/mult/sub`; `int` grows (a*b→Wa+Wb, a+b→max+1); `float` is numpy passthrough. Both operands must be DataArray of the same numeric kind (else a clear error); rounding stays an explicit `quantize`; `.val` stays the numpy escape hatch.

**Phase 2 — `examples/basic_vec`:** pedagogical Python-golden-vector → vectorized Vitis kernel → functional bit-match across int/float/fixed, reusing the conformance rig.

**Verified independently:** operators are clean sugar (no reimplementation of the bit-exact math); non-vitis suite has zero new failures (the extra tests/poly failures are pre-existing on main); **37/37 on real Vitis** (`basic_vec` + `fixedpoint` conformance intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)