### PR TITLE
docs: Vectorization guide section + examples reorg (vectorization plan Phases 3–4)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ search_enabled: true
 markdown: kramdown
 kramdown:
   input: GFM
+  hard_wrap: false   # reflow single newlines in paragraphs (hard-wrapped source -> flowing text)
 
 # Optional: GitHub repo link
 github_repo_url: "https://github.com/sdrangan/waveflow"

--- a/docs/examples/basic_vec/index.md
+++ b/docs/examples/basic_vec/index.md
@@ -1,0 +1,73 @@
+---
+title: Basic Vectorization (MAC)
+parent: Examples
+nav_order: 1
+has_children: false
+---
+# Basic Vectorization — one MAC, bit-exact
+
+`basic_vec` is the **front-door for [vectorization](../../guide/vectorization/)**:
+the smallest possible demonstration that a Python-vectorized golden model and a
+vectorized Vitis kernel produce **the same bits**. It is a *data/schema* example —
+it teaches how to **represent and compute on data**, before any module-to-module
+interface is introduced.
+
+The whole example is one elementwise multiply-accumulate:
+
+```python
+y = a * b + c
+```
+
+computed over arrays — **no per-element Python loop** — for each of the three
+numeric kinds, with the result asserted equal to a Vitis C-sim **bit-for-bit**:
+
+- **integer** — growth-aware operators (`a*b` is `Wa+Wb` wide, `+c` adds a carry
+  bit); the Python `Int17` result matches `ap_int<17> y = a*b + c;`.
+- **float** — numpy `float32` passthrough; the kernel is built with
+  `-ffp-contract=off` so its `a*b + c` is the same **two roundings** numpy does.
+- **fixed** — full-precision `a*b + c` then one explicit `quantize` back to the
+  working format, matching `ap_fixed<...> y = a*b + c;`.
+
+This is the **teaching** counterpart to the rigorous all-modes/all-widths sweep in
+`examples/schemas/fixedpoint`; the two share the same conformance machinery
+(`BuildDag` + `run_dag_cli` + gen→csim→compare-bits).
+
+## What it demonstrates
+
+- The two computing paths from the [vectorization guide](../../guide/vectorization/):
+  the **type-preserving operators** (`a*b + c`, full-precision growth, explicit
+  `quantize`) producing a golden bit-vector, versus the raw numpy `.val` escape.
+- That keeping data in numpy arrays end-to-end is what makes functional simulation
+  **fast *and* bit-exact** — the core Waveflow differentiator.
+
+## File map
+
+The example lives in [`examples/basic_vec/`](../../../examples/basic_vec/):
+
+- `basic_vec_build.py` — builds the three MAC cases: computes each Python golden
+  with the operators, derives the result type, renders the matching kernel, and runs
+  the gen→csim→compare-bits conformance DAG.
+- `kernels.py` — the three minimal vectorized Vitis kernels (int / float / fixed)
+  over the *same* `a*b + c`, deliberately readable (the guide pulls from them).
+- `run.tcl` — the Vitis HLS C-simulation driver (`-ffp-contract=off` for the float
+  kernel).
+
+## Running it
+
+```bash
+# Generate kernels + input vectors + the Python golden bits (no Vitis needed):
+python examples/basic_vec/basic_vec_build.py --through gen
+
+# The full bit-exact conformance against Vitis C-sim (requires Vitis HLS):
+python examples/basic_vec/basic_vec_build.py --through run
+```
+
+The `run` stage asserts, per kind, that the Vitis output bits equal the Python
+operator bits **exactly**; any mismatch stops the build.
+
+## Next
+
+- [Vectorization guide](../../guide/vectorization/) — the selling point, the two
+  paths, and the per-kind detail (integer / float / fixed) this example embodies.
+- [Fixed-point (FixedField)](../../guide/schema/fixpoint.md) — the fixed-point type
+  behind the fixed case.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -7,11 +7,41 @@ has_children: true
 
 # Examples
 
-Waveflow's examples are a **teaching progression**: each one introduces a single
-new hardware-interface concept on top of the previous, using a small computation
-as its vehicle. Every directory is named for the **pattern** it teaches; the
-computation keeps its own identity in the files inside (e.g. `stream_inband/`
-holds the polynomial accelerator in `poly.py`).
+Waveflow's examples are a **teaching progression**, and they come in **two
+families**. You learn to *represent and compute on data* first, then how to *move
+that data between modules* over real hardware protocols:
+
+1. **Data & schema patterns** — how a design's numbers are typed, stored, and
+   computed on, kept **vectorized** (numpy arrays end to end) so functional
+   simulation is fast *and* bit-exact. Start here.
+2. **Interface patterns** — how a host and an accelerator exchange that data over
+   the AXI-* protocols, one new interface concept per example.
+
+The rationale is bottom-up: the interface examples *carry* schema-typed data across
+their ports, so it pays to understand the data layer before the protocols that
+transport it. Every directory is named for the **pattern** it teaches; the
+computation keeps its own identity in the files inside (e.g. `stream_inband/` holds
+the polynomial accelerator in `poly.py`).
+
+## Family 1 — data & schema patterns
+
+These teach the [data schema](../guide/schema/) and
+[vectorization](../guide/vectorization/) layers: typed fields, numpy-backed arrays,
+and the type-preserving operators, all proven **bit-exact** against Vitis.
+
+| Example | Vehicle | What it teaches | Status |
+|---|---|---|---|
+| [`basic_vec`](./basic_vec/) | one MAC (`a*b + c`) | vectorized golden vs vectorized Vitis, bit-exact for int / float / fixed — the [vectorization](../guide/vectorization/) front-door | available |
+| `schemas/fixedpoint` | edge-value sweep | the rigorous fixed-point conformance harness (all `QMode`/`OMode` × widths) behind [FixedField](../guide/schema/fixpoint.md) | available (code) |
+
+`basic_vec` is the teaching front-door (minimal, readable); `schemas/fixedpoint` is
+the exhaustive proof. They share the same conformance machinery.
+
+## Family 2 — interface patterns
+
+These move more of the host↔accelerator contract off the control plane and into
+shared structures at each step, one new interface concept at a time. They are the
+full five-stage flow below.
 
 ## The general Waveflow flow
 
@@ -30,7 +60,7 @@ stages, each derived from the one before:
 
 The *Flow coverage* column below cites these stage numbers.
 
-## The five patterns
+## The five interface patterns
 
 The progression moves more of the host↔accelerator contract off the control
 plane and into shared structures at each step: from **all control in registers**,

--- a/docs/examples/regmap/index.md
+++ b/docs/examples/regmap/index.md
@@ -1,7 +1,7 @@
 ---
 title: Register Map (simple function)
 parent: Examples
-nav_order: 1
+nav_order: 2
 has_children: true
 ---
 # Register Map Interface for a Simple Function

--- a/docs/examples/shared_mem/index.md
+++ b/docs/examples/shared_mem/index.md
@@ -1,7 +1,7 @@
 ---
 title: Shared Memory (histogram)
 parent: Examples
-nav_order: 4
+nav_order: 5
 has_children: true
 ---
 

--- a/docs/examples/stream_inband/index.md
+++ b/docs/examples/stream_inband/index.md
@@ -1,7 +1,7 @@
 ---
 title: Stream In-Band Control (polynomial)
 parent: Examples
-nav_order: 3
+nav_order: 4
 has_children: true
 ---
 

--- a/docs/guide/ai_tooling/index.md
+++ b/docs/guide/ai_tooling/index.md
@@ -1,7 +1,7 @@
 ---
 title: AI Tooling
 parent: Guide
-nav_order: 10
+nav_order: 11
 has_children: true
 ---
 

--- a/docs/guide/ai_tooling/mcp_setup.md
+++ b/docs/guide/ai_tooling/mcp_setup.md
@@ -13,7 +13,7 @@ Waveflow is being designed with agentic assistance to help build and simulate mo
 
 ## Set-Up
 
-To set up the MCP server on VS Code, first follow the [instructions](./python.md) to create and activate a virtual environment, then install `waveflow` into that environment. You can install from a cloned `waveflow` repository or from a published package source, as long as the environment you activate contains `waveflow`.
+To set up the MCP server on VS Code, first follow the [instructions](../installation/) to create and activate a virtual environment, then install `waveflow` into that environment. You can install from a cloned `waveflow` repository or from a published package source, as long as the environment you activate contains `waveflow`.
 
 Independent of where the virtual environment is installed, navigate to the root folder of the repository where you wish to work:
 

--- a/docs/guide/build/index.md
+++ b/docs/guide/build/index.md
@@ -1,7 +1,7 @@
 ---
 title: Build System
 parent: Guide
-nav_order: 6
+nav_order: 7
 has_children: true
 ---
 

--- a/docs/guide/components/index.md
+++ b/docs/guide/components/index.md
@@ -1,7 +1,7 @@
 ---
 title: Hardware Components
 parent: Guide
-nav_order: 4
+nav_order: 5
 has_children: true
 ---
 

--- a/docs/guide/developer/index.md
+++ b/docs/guide/developer/index.md
@@ -1,7 +1,7 @@
 ---
 title: Developers
 parent: Guide
-nav_order: 9
+nav_order: 10
 has_children: true
 ---
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -11,6 +11,7 @@ Welcome to Waveflow.  This folder will have guides to use the Waveflow functiona
 
 - [Installation](./installation/)
 - [Data Schemas](./schema)
+- [Vectorization](./vectorization/)
 - [Memory Modeling](./memory/)
 - [Timing Analysis Tools](./timing)
 - [Hardware Interfaces](./interface/overview.md)

--- a/docs/guide/interface/index.md
+++ b/docs/guide/interface/index.md
@@ -1,7 +1,7 @@
 ---
 title: Interfaces
 parent: Guide
-nav_order: 3
+nav_order: 4
 has_children: true
 ---
 

--- a/docs/guide/memory/index.md
+++ b/docs/guide/memory/index.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Modeling
 parent: Guide
-nav_order: 7
+nav_order: 8
 has_children: true
 ---
 

--- a/docs/guide/schema/codegen.md
+++ b/docs/guide/schema/codegen.md
@@ -1,7 +1,7 @@
 ---
 title: Code Generation
 parent: Data Schemas
-nav_order: 7
+nav_order: 6
 ---
 
 # Auto-generating Vitis HLS Files

--- a/docs/guide/schema/fixpoint.md
+++ b/docs/guide/schema/fixpoint.md
@@ -10,8 +10,10 @@ has_children: false
 `FixedField` is a **Vitis-bit-exact** fixed-point scalar type. It maps to Vitis HLS
 `ap_fixed<W, I, Q, O>` (or `ap_ufixed<...>`) and its Python value model reproduces the
 hardware **bit-for-bit** — for quantization *and* arithmetic. It is defined in
-[`waveflow/hw/fixpoint.py`](../../../waveflow/hw/fixpoint.py); vector operations are
-covered on the [Fixed-point vectors & arithmetic](./fixp_vector.md) page.
+[`waveflow/hw/fixpoint.py`](../../../waveflow/hw/fixpoint.py); vector operations (the
+**compute**) are covered on the
+[Fixed-point vectorization](../vectorization/fixed.md) page in the
+[Vectorization](../vectorization/) section.
 
 ## The `ap_fixed` model
 
@@ -56,8 +58,8 @@ class:
 `AP_TRN`, and `AP_WRAP` — exactly Vitis's `ap_fixed` defaults — so
 `FixedField.specialize(W, I)` already matches the default hardware type.
 
-A single `FixedField` is a scalar; arrays use `DataArray[FixedField]` (see the
-[vector page](./fixp_vector.md)).
+A single `FixedField` is a scalar; arrays use `DataArray[FixedField]` (see
+[Fixed-point vectorization](../vectorization/fixed.md)).
 
 ## Quantization (`QMode`) and overflow (`OMode`) modes
 
@@ -114,6 +116,7 @@ comparison is never loosened. Run it with `pytest -m vitis -k fixedpoint`.
 
 ## See also
 
-- [Fixed-point vectors & arithmetic](./fixp_vector.md) — `DataArray[FixedField]`,
-  `mult`/`add`/`quantize`, result-format propagation, and a worked FIR.
+- [Fixed-point vectorization](../vectorization/fixed.md) — the compute:
+  `DataArray[FixedField]`, the `a*b + c` operators / `mult`/`add`/`quantize`,
+  result-format propagation, and a worked FIR.
 - [Data Fields and Lists](./datalists.md) — the `IntField` base and serialization.

--- a/docs/guide/synthesis/index.md
+++ b/docs/guide/synthesis/index.md
@@ -1,7 +1,7 @@
 ---
 title: Synthesis
 parent: Guide
-nav_order: 5
+nav_order: 6
 has_children: true
 ---
 

--- a/docs/guide/timing/axistream.md
+++ b/docs/guide/timing/axistream.md
@@ -22,7 +22,7 @@ The `TDATA` signals for the streams are:
 - `apatb_poly_top.AESL_inst_poly.in_stream_TDATA[31:0]`
 - `apatb_poly_top.AESL_inst_poly.out_stream_TDATA[31:0]`
 
-You can find these names from the print out of the signals -- see the section on [parsing the VCD outputs](./parsing).  After identifying the signal names for the AXI4 streams, you can use the code below to load the stream signals:
+You can find these names from the print out of the signals -- see the section on [parsing the VCD outputs](./parsing.md).  After identifying the signal names for the AXI4 streams, you can use the code below to load the stream signals:
 
 ```python
 # Create a parsing class

--- a/docs/guide/timing/index.md
+++ b/docs/guide/timing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Timing Analysis Tools
 parent: Guide
-nav_order: 8
+nav_order: 9
 has_children: true
 ---
 

--- a/docs/guide/vectorization/fixed.md
+++ b/docs/guide/vectorization/fixed.md
@@ -1,20 +1,27 @@
 ---
-title: Fixed-point vectors & arithmetic
-parent: Data Schemas
-nav_order: 6
+title: Fixed-point vectorization
+parent: Vectorization
+nav_order: 4
 has_children: false
 ---
 
-# Fixed-Point Vectors and Arithmetic
+# Fixed-Point Vectorization
 
-Fixed-point arrays use [`DataArray[FixedField]`](./dataarrays.md) — the same
+This is the [vectorization](./index.md) story for fixed-point — the **compute**.
+The fixed-point *type* itself (the `ap_fixed` model, `QMode`/`OMode`, the
+defaults-match-Vitis contract) lives on the
+[FixedField type page](../schema/fixpoint.md); read that first if you haven't.
+
+Fixed-point arrays use [`DataArray[FixedField]`](../schema/dataarrays.md) — the same
 numpy-backed array schema as every other element type, so they get flat storage,
-array access, and codegen for free. Vector operations are **free functions** in
+array access, and codegen for free. This is the case that most needs the
+[type-preserving operators](./index.md#the-two-paths): fixed-point grows bits and
+rounds on assignment, so working through `.val` by hand is easy to get wrong. The
+operators (`*`, `+`, `-`) are sugar over the **free functions** in
 [`waveflow/hw/fixpoint.py`](../../../waveflow/hw/fixpoint.py) (not methods — the
 container stays a plain container): `mult`, `add`, `sub`, `shift`, `fixed_sum`, and
 `quantize`. They run entirely in the **integer domain** and match the Vitis `ap_fixed`
-datapath bit-for-bit. See the [FixedField type page](./fixpoint.md) for the format
-itself.
+datapath bit-for-bit.
 
 ## Arrays of fixed-point values
 
@@ -60,6 +67,26 @@ to_real(mult(a, b))                    # array([ 3., -3., -0.5])  -- exact
 # bring a product back to a working format (this is where rounding/overflow happen):
 quantize(mult(a, b), Q8_4)             # DataArray[ap_fixed<8, 4>]
 ```
+
+### Operator form (the primary spelling)
+
+The [operators](./index.md#2-type-preserving-operators--ab--c-then-quantize) are
+sugar over these functions, so a multiply-add reads like the math — and like the
+HLS `ap_fixed<...> y = a*b + c;` it mirrors. The intermediates grow to full
+precision; the single `quantize` is the only rounding:
+
+```python
+from waveflow.hw.fixpoint import quantize, to_real
+
+c = from_real([0.5, 0.25, -0.5], Q8_4)
+
+full = a * b + c                       # ap_fixed<17, 9>  -- full precision, no loss
+y    = quantize(full, Q8_4)            # ap_fixed<8, 4>   -- the one explicit rounding
+to_real(y)                             # array([ 3.5 , -2.75, -1.  ])
+```
+
+This is exactly the fixed case of [`examples/basic_vec`](../../examples/), checked
+bit-for-bit against a Vitis kernel.
 
 ## Single 64-bit dtype, fail-fast above it
 
@@ -129,6 +156,9 @@ asserts the bits match the Python ops — run `pytest -m vitis -k fixedpoint`.
 
 ## See also
 
-- [Fixed-point (FixedField)](./fixpoint.md) — the format, `QMode`/`OMode`, the
-  defaults-match-Vitis contract.
-- [Data arrays](./dataarrays.md) — the `DataArray` container these build on.
+- [Fixed-point (FixedField)](../schema/fixpoint.md) — the fixed-point *type*: the
+  format, `QMode`/`OMode`, the defaults-match-Vitis contract.
+- [Vectorization overview](./index.md) — the two paths and when to use each.
+- [Integer vectorization](./integer.md) — the same growth-then-`quantize` story
+  without a binary point.
+- [Data arrays](../schema/dataarrays.md) — the `DataArray` container these build on.

--- a/docs/guide/vectorization/fixed.md
+++ b/docs/guide/vectorization/fixed.md
@@ -85,7 +85,7 @@ y    = quantize(full, Q8_4)            # ap_fixed<8, 4>   -- the one explicit ro
 to_real(y)                             # array([ 3.5 , -2.75, -1.  ])
 ```
 
-This is exactly the fixed case of [`examples/basic_vec`](../../examples/), checked
+This is exactly the fixed case of [`examples/basic_vec`](../../examples/basic_vec/), checked
 bit-for-bit against a Vitis kernel.
 
 ## Single 64-bit dtype, fail-fast above it

--- a/docs/guide/vectorization/float.md
+++ b/docs/guide/vectorization/float.md
@@ -32,7 +32,7 @@ np.asarray(y)                                            # array([ 3.25, -2.75, 
 y.element_type.get_bitwidth()                            # 32  (no growth — float32 in, float32 out)
 ```
 
-This is the float case of [`examples/basic_vec`](../../examples/). A `float64` array
+This is the float case of [`examples/basic_vec`](../../examples/basic_vec/). A `float64` array
 stays 64-bit the same way.
 
 ## When to use `.val` vs the operators
@@ -77,4 +77,3 @@ asserts the Vitis C-sim output bits match them exactly.
 - [Integer vectorization](./integer.md) / [Fixed-point vectorization](./fixed.md) —
   the cases where the operators' growth tracking matters.
 - [Fields](../schema/fields.md) — `FloatField` and the scalar field types.
-</content>

--- a/docs/guide/vectorization/float.md
+++ b/docs/guide/vectorization/float.md
@@ -1,0 +1,80 @@
+---
+title: Float vectorization
+parent: Vectorization
+nav_order: 3
+---
+
+# Float vectorization
+
+Floating-point arrays are `DataArray[FloatField]` — numpy-backed by an IEEE-754
+`float32` or `float64` `ndarray`. Float is the simplest vectorization case: IEEE
+floats **don't grow**, so the [type-preserving operators](./index.md#the-two-paths)
+are just **NumPy passthrough** over the same arrays, and the
+[`.val` escape hatch](./index.md#1-the-numpy-escape-hatch--val) is equally correct.
+
+## Operators are passthrough
+
+`FloatField.specialize(W)` picks the width (32 or 64); the operators run the NumPy
+op and keep the same float type — no width derivation, no `quantize` step:
+
+```python
+import numpy as np
+from waveflow.hw.dataschema import DataArray, FloatField
+
+F32 = FloatField.specialize(32)                          # float (single precision)
+
+def fa(vals):
+    return DataArray.specialize(F32, max_shape=(len(vals),))(np.array(vals, np.float32))
+
+a, b, c = fa([1.5, 2.5, -3.0]), fa([2.0, -1.5, 0.5]), fa([0.25, 1.0, -0.5])
+y = a * b + c
+np.asarray(y)                                            # array([ 3.25, -2.75, -2.  ], dtype=float32)
+y.element_type.get_bitwidth()                            # 32  (no growth — float32 in, float32 out)
+```
+
+This is the float case of [`examples/basic_vec`](../../examples/). A `float64` array
+stays 64-bit the same way.
+
+## When to use `.val` vs the operators
+
+For float, **`.val` is fine** — it's the recommended path when you want raw NumPy.
+Because floats don't grow and don't need an explicit `quantize`, raw NumPy on `.val`
+*is* the bit-exact model:
+
+```python
+y = a.val * b.val + c.val                                # identical result, raw numpy
+y.dtype                                                  # dtype('float32')
+```
+
+The operators give you nothing extra here beyond keeping the value in a `DataArray`
+(the bit-growth bookkeeping they add for [integer](./integer.md) and
+[fixed-point](./fixed.md) has no float analog). Use whichever reads better;
+[fixed-point is the case that *needs* the operators](./index.md#when-to-use-which).
+
+## Golden references — matching the kernel bit-for-bit
+
+The reason float still belongs in a bit-exact story is the **two-roundings**
+subtlety. `y = a*b + c` in IEEE float rounds **twice** — once for the product, once
+for the add. A fused multiply-add (FMA) rounds **once** and gives a *different* last
+bit. NumPy's `a*b + c` is two roundings; to match it, the generated Vitis kernel is
+compiled with `-ffp-contract=off` so the C++ `a*b + c` is also two roundings, never
+a fused FMA (see `examples/basic_vec/run.tcl`).
+
+To compare against the kernel you look at the **raw IEEE bits**, not the printed
+decimal — reinterpret the `float32` array as `uint32`:
+
+```python
+[int(u) for u in np.asarray(a).astype(np.float32).view(np.uint32)]
+# [1069547520, 1075838976, 3225419776]
+```
+
+`examples/basic_vec` emits exactly these bit-vectors as the Python golden and
+asserts the Vitis C-sim output bits match them exactly.
+
+## See also
+
+- [Vectorization overview](./index.md) — the two paths and when to use each.
+- [Integer vectorization](./integer.md) / [Fixed-point vectorization](./fixed.md) —
+  the cases where the operators' growth tracking matters.
+- [Fields](../schema/fields.md) — `FloatField` and the scalar field types.
+</content>

--- a/docs/guide/vectorization/index.md
+++ b/docs/guide/vectorization/index.md
@@ -123,10 +123,8 @@ simulation fast. The operators just add the bit-growth bookkeeping on top.
 
 - [FixedField](../schema/fixpoint.md) — the fixed-point *type* (the `ap_fixed`
   model, `QMode`/`OMode`, defaults-match-Vitis).
-- [`examples/basic_vec`](../../examples/) — the worked front-door: one MAC,
+- [`examples/basic_vec`](../../examples/basic_vec/) — the worked front-door: one MAC,
   `y = a*b + c`, computed with these operators and checked **bit-exact against
   Vitis** for int / float / fixed.
 - [Timing Analysis](../timing/) — where cycle/throughput modeling lives (the
   separate, non-functional concern).
-</content>
-</invoke>

--- a/docs/guide/vectorization/index.md
+++ b/docs/guide/vectorization/index.md
@@ -1,0 +1,132 @@
+---
+title: Vectorization
+parent: Guide
+nav_order: 3
+has_children: true
+---
+
+# Vectorization
+
+Vectorization is how Waveflow's functional simulation is **fast *and* bit-exact**.
+Data lives in NumPy arrays from end to end — operands, intermediates, and results
+are all `ndarray`s — so a whole vector of values flows through one C-level NumPy
+call instead of a Python loop over elements. The numbers Waveflow computes match
+the Vitis HLS datapath **bit-for-bit**, and they are computed at NumPy speed.
+
+This page is the entry point: the selling point, the **two ways to compute** on
+array data, when to use each, and an honest framing of the tradeoff. The per-kind
+pages drill in:
+
+- [Integer vectorization](./integer.md) — NumPy integer arrays, growth-aware
+  operators, the width-tracking caveat.
+- [Float vectorization](./float.md) — NumPy passthrough and golden references.
+- [Fixed-point vectorization](./fixed.md) — full-precision `a*b + c`, one explicit
+  `quantize`, bit-exact with `ap_fixed`. (The fixed-point *type* itself is on the
+  [FixedField](../schema/fixpoint.md) page.)
+
+## Why vectorization is the differentiator
+
+The Waveflow thesis is bit-exact *and* fast. The speed comes from keeping data
+**vectorized**: a `DataArray` is numpy-backed, and `.val` is the underlying
+`ndarray`. `FixedField` is deliberately **integer-backed on a single 64-bit dtype**
+(not an arbitrary-precision object array) **specifically so fixed-point arrays stay
+vectorized** — every fixed-point op is a NumPy integer op over the whole array.
+
+This is a deliberate **abstraction/speed tradeoff**, not a claim that other tools
+are wrong:
+
+- **Per-element fixed-point packages** (arbitrary-precision Python fixed-point
+  libraries) model each value exactly at any width, but fall back to per-element
+  Python for big widths — correct, but not vectorized, so slower over large arrays.
+- **RTL / cycle-level Python simulators** (e.g. PyMTL) model the design
+  cycle-by-cycle. That is a *different abstraction level*: they pay per-cycle costs
+  that don't vectorize over data, in exchange for cycle-accurate timing.
+
+Waveflow sits at the **transaction level with vectorized data**: it gives fast
+**functional** (bit-exact) simulation, and handles timing
+[separately](../timing/). Pick the level that fits the question you're asking — for
+"are my bits right, fast, over a lot of data," vectorized functional sim is the
+sweet spot.
+
+## The two paths
+
+There are two ways to compute on array data, and the distinction matters most for
+fixed-point:
+
+### 1. The NumPy escape hatch — `.val`
+
+`DataArray.val` is the raw underlying `ndarray`. Reach through it and you get plain
+NumPy: maximum speed, every NumPy function available, and **you** manage the result
+width and dtype.
+
+```python
+import numpy as np
+from waveflow.hw.dataschema import DataArray, FloatField
+
+F32 = FloatField.specialize(32)
+a = DataArray.specialize(F32, max_shape=(3,))(np.array([1.5, 2.5, -3.0], np.float32))
+b = DataArray.specialize(F32, max_shape=(3,))(np.array([2.0, -1.5, 0.5], np.float32))
+
+y = a.val * b.val + 0.25          # raw numpy float32 — you own the dtype
+y                                  # array([ 3.25, -3.5 , -1.25], dtype=float32)
+```
+
+### 2. Type-preserving operators — `a*b + c`, then `quantize`
+
+The operators (`+`, `-`, `*`) on a `DataArray` are **type-preserving**: they read
+the operands' formats, run the vectorized NumPy op underneath, and **derive the
+result format** with full precision — no silent loss. They are sugar over the
+underlying `mult`/`add`/`sub` functions. Rounding back to a working format is an
+**explicit** `quantize(x, fmt)` — exactly mirroring `ap_fixed<...> y = a*b + c;` in
+HLS, where the product and sum grow to full width and the assignment is the one
+lossy step.
+
+```python
+from waveflow.hw.fixpoint import FixedField, from_real, quantize, to_real
+
+Q = FixedField.specialize(8, 4)                  # ap_fixed<8, 4>
+a = from_real([1.5, -2.0, 0.5], Q)
+b = from_real([2.0,  1.5, -1.0], Q)
+c = from_real([0.5,  0.25, -0.5], Q)
+
+full = a * b + c                                  # ap_fixed<17, 9> — full precision, no loss
+y    = quantize(full, Q)                          # ap_fixed<8, 4>  — the one explicit rounding
+to_real(y)                                        # array([ 3.5 , -2.75, -1.  ])
+```
+
+### When to use which
+
+| Path | Use it when | Cost you own |
+|------|-------------|--------------|
+| `.val` (numpy escape) | **float** math; or you genuinely want raw NumPy and will manage widths yourself | result dtype/width is on you |
+| operators + `quantize` | **fixed-point** (and growth-aware **integer**) math you want bit-exact with HLS | nothing — formats are derived, loss is explicit |
+
+The short rule:
+
+- **Float** — `.val` is fine. IEEE-754 `float32`/`float64` don't grow, so raw NumPy
+  *is* the bit-exact model; the operators are just NumPy passthrough over the same
+  arrays.
+- **Fixed-point** — use the **operators**. Fixed-point arithmetic grows bits
+  (`a*b` is `Wa+Wb` wide) and rounds on assignment; the operators track that growth
+  and keep the one rounding explicit, so your Python matches `ap_fixed` exactly.
+  Doing fixed-point by hand through `.val` means re-deriving formats and rounding
+  yourself — easy to get subtly wrong.
+- **Integer** — either works; the operators add growth-aware width tracking
+  (`a*b` → `Wa+Wb` bits, `a+b` → `+1`) with a fail-fast guard above 64 bits, which
+  raw `.val` NumPy won't give you (it silently wraps). See
+  [Integer vectorization](./integer.md).
+
+Both paths keep data in NumPy arrays the whole way — that's what makes the
+simulation fast. The operators just add the bit-growth bookkeeping on top.
+
+## See also
+
+- [FixedField](../schema/fixpoint.md) — the fixed-point *type* (the `ap_fixed`
+  model, `QMode`/`OMode`, defaults-match-Vitis).
+- [`examples/basic_vec`](../../examples/) — the worked front-door: one MAC,
+  `y = a*b + c`, computed with these operators and checked **bit-exact against
+  Vitis** for int / float / fixed.
+- [Timing Analysis](../timing/) — where cycle/throughput modeling lives (the
+  separate, non-functional concern).
+</content>
+</invoke>

--- a/docs/guide/vectorization/integer.md
+++ b/docs/guide/vectorization/integer.md
@@ -31,7 +31,7 @@ y = a * b + c
 np.asarray(y)                                            # array([ 19, -29, -38,  11])
 ```
 
-This is the integer case of [`examples/basic_vec`](../../examples/) — one
+This is the integer case of [`examples/basic_vec`](../../examples/basic_vec/) — one
 elementwise MAC, no per-element Python loop.
 
 ## Growth-aware result widths
@@ -99,4 +99,3 @@ ia([1]) * u                              # NotImplementedError: mixed signed/uns
 - [Fixed-point vectorization](./fixed.md) — the same growth-then-`quantize` story
   with a binary point.
 - [Fields](../schema/fields.md) — `IntField` and the scalar field types.
-</content>

--- a/docs/guide/vectorization/integer.md
+++ b/docs/guide/vectorization/integer.md
@@ -1,0 +1,102 @@
+---
+title: Integer vectorization
+parent: Vectorization
+nav_order: 2
+---
+
+# Integer vectorization
+
+Integer arrays are `DataArray[IntField]` — numpy-backed, so the stored values are a
+plain NumPy integer `ndarray` reachable through `.val`. The
+[type-preserving operators](./index.md#the-two-paths) (`+`, `-`, `*`) compute over
+the whole array in one NumPy call **and track bit growth** the way the HLS `ap_int`
+datapath does, so the Python result width matches the hardware.
+
+## Declaring and computing
+
+`IntField.specialize(W, signed)` is the element type; `DataArray.specialize` wraps it
+into a sized array:
+
+```python
+import numpy as np
+from waveflow.hw.dataschema import DataArray, IntField
+
+I8 = IntField.specialize(8, True)                       # ap_int<8>
+
+def ia(vals):
+    return DataArray.specialize(I8, max_shape=(len(vals),))(vals)
+
+a, b, c = ia([3, -4, 5, 7]), ia([6, 7, -8, 2]), ia([1, -1, 2, -3])
+y = a * b + c
+np.asarray(y)                                            # array([ 19, -29, -38,  11])
+```
+
+This is the integer case of [`examples/basic_vec`](../../examples/) — one
+elementwise MAC, no per-element Python loop.
+
+## Growth-aware result widths
+
+Each operator **derives the result width** so intermediates never overflow —
+exactly the `ap_int` growth rules:
+
+| op | result width | rule |
+|----|--------------|------|
+| `a * b` | `Wa + Wb` | product widths add |
+| `a + b`, `a - b` | `max(Wa, Wb) + 1` | one carry bit |
+
+Subtraction always returns a **signed** result (it can go negative). You can read
+the derived type off the result:
+
+```python
+(a * b).element_type.get_bitwidth()     # 16   (8 + 8)
+(a + b).element_type.get_bitwidth()     # 9    (max(8, 8) + 1)
+y.element_type.get_bitwidth()           # 17   (the a*b is 16, +1 for the add)
+y.element_type.__name__                 # 'Int17'
+```
+
+## The width-tracking caveat — `.val` doesn't grow
+
+This is the heart of the two-paths distinction for integers. The operators grow the
+type; the **raw NumPy escape** (`.val`) does not — NumPy keeps a fixed storage dtype
+and **silently wraps** on overflow. For values that stay in range the two agree, but
+the operator-tracked width is what protects you:
+
+```python
+a.val.dtype                              # dtype('int32')  -- raw numpy storage; arithmetic on
+                                         # .val stays this dtype and wraps silently on overflow
+(a * b).element_type.get_bitwidth()      # 16  -- the operator path grows the type instead
+```
+
+If a derived width would exceed **64 bits**, the operators **fail fast** rather than
+let NumPy `int64` wrap invisibly:
+
+```python
+I40 = IntField.specialize(40, True)
+big = DataArray.specialize(I40, max_shape=(1,))([1])
+big * big                                # NotImplementedError: result width 80 exceeds the 64-bit limit
+```
+
+Wide (> 64-bit) support is future work; in practice integer datapaths stay well
+under 64 bits. (For why a single 64-bit dtype is the deliberate choice, see the
+[fixed-point vectorization](./fixed.md#single-64-bit-dtype-fail-fast-above-it)
+page — the same guard backs both.)
+
+## Mixed signed/unsigned is a v1 limitation
+
+Mixing a signed and an unsigned integer array **raises**, because NumPy would coerce
+`int64`/`uint64` to `float64` and silently lose exactness. Bring both operands to a
+common signedness first:
+
+```python
+U8 = IntField.specialize(8, False)
+u = DataArray.specialize(U8, max_shape=(1,))([1])      # ap_uint<8>
+ia([1]) * u                              # NotImplementedError: mixed signed/unsigned ... not supported in v1
+```
+
+## See also
+
+- [Vectorization overview](./index.md) — the two paths and when to use each.
+- [Fixed-point vectorization](./fixed.md) — the same growth-then-`quantize` story
+  with a binary point.
+- [Fields](../schema/fields.md) — `IntField` and the scalar field types.
+</content>


### PR DESCRIPTION
Completes plans/vectorization.md (Phases 1–2 — operators + basic_vec — landed in #56).

**Phase 3 — new `docs/guide/vectorization/` section** (nav 3, after Schema):
- index (the selling point: fast *and* bit-exact via end-to-end NumPy; the two paths — `.val` escape vs type-preserving operators + when to use each; fair speed/abstraction contrast vs per-element fixed-point pkgs / RTL-cycle sim).
- integer / float / fixed pages. `fixp_vector.md` **moved** schema→vectorization (retitled), with `fixpoint↔fixed` cross-links so the fixed-point type/compute story stays whole.
- Guide nav renumbered +1 below Schema; schema gap closed (codegen→6).

**Phase 4 — examples reorg:** two families in `docs/examples/index.md` — **data/schema patterns** (basic_vec, schemas/fixedpoint) **before interface patterns** (regmap…mem_queue), with the bottom-up rationale. New `basic_vec` front-door page the four vectorization pages link to.

**Plus docs polish (this review):** `kramdown hard_wrap:false` so hard-wrapped source reflows into paragraphs (fixes choppy `<br>` breaks site-wide); fixed two pre-existing stale links (`mcp_setup→../installation/`, `axistream→./parsing.md`).

**Independently verified:** nav renumber + `fixp_vector` move (0 stale refs); **0 dangling links** (full docs tree); every snippet executes — MAC outputs/growth widths correct, the `NotImplementedError` blocks are correctly-framed guard demos; the stray `</content>` tool tags were cleaned; non-vitis suite at the pre-existing baseline.

Phase 5 (complex-vectorization) stays gated on ComplexField.

🤖 Generated with [Claude Code](https://claude.com/claude-code)