### PR TITLE
docs(examples): expand basic_vec into a 4-page walkthrough

### DIFF
--- a/docs/examples/basic_vec/eval.md
+++ b/docs/examples/basic_vec/eval.md
@@ -1,0 +1,53 @@
+---
+title: Confirming the match
+parent: Basic Vectorization (MAC)
+nav_order: 3
+---
+# Confirming the match
+
+The [Python golden](./python.md) and the [Vitis kernels](./vitis.md) are compared
+**bit-for-bit** by a small build DAG — the same `gen → csim → compare` machinery the rigorous
+`examples/schemas/fixedpoint` conformance uses.
+
+## The build DAG
+
+```python
+def build_basic_vec_dag() -> BuildDag:
+    dag = BuildDag()
+    dag.add(SourceStep(artifact="basic_vec_source", path=...))   # the sources
+    dag.add(SourceStep(artifact="kernels_source",   path=...))
+    dag.add(SourceStep(artifact="run_tcl",          path=...))
+    dag.add(GenStep(name="gen"))                                 # write kernels + vectors + golden
+    dag.add(RunStep(name="run"))                                 # Vitis csim + compare bits
+    return dag
+```
+
+- **`gen`** — for each kind, computes the Python golden (the operators), renders the matching
+  kernel, and writes `kernel.cpp`, `in_{a,b,c}.txt`, and `expected.json` (the golden bits).
+  No Vitis needed.
+- **`run`** — runs each kernel in Vitis C-sim and asserts the emitted bits equal
+  `expected.json` **exactly**; the first mismatch **stops the build**:
+
+```python
+failed = [r for r in results if not r["exact"]]
+if failed:
+    raise RuntimeError(f"STOP — Vitis disagreed with the Python golden: {failed[0]}")
+```
+
+## Running it
+
+```bash
+python examples/basic_vec/basic_vec_build.py --through gen   # generate (no Vitis)
+python examples/basic_vec/basic_vec_build.py --through run   # the bit-exact conformance (Vitis)
+```
+
+When `run` passes, the Python operator model and the Vitis kernel produced **identical bits**
+for int, float, and fixed — the whole point of `basic_vec`: a vectorized Python golden that
+predicts the hardware exactly. The same contract runs as a test in
+`tests/examples/test_basic_vec.py` (under `pytest -m vitis`).
+
+## See also
+
+- [Vectorization guide](../../guide/vectorization/) — the concepts this example embodies (the
+  two paths, growth rules, why vectorized sim is fast *and* bit-exact).
+- `examples/schemas/fixedpoint` — the rigorous all-modes/all-widths conformance sweep.

--- a/docs/examples/basic_vec/index.md
+++ b/docs/examples/basic_vec/index.md
@@ -2,72 +2,55 @@
 title: Basic Vectorization (MAC)
 parent: Examples
 nav_order: 1
-has_children: false
+has_children: true
 ---
 # Basic Vectorization — one MAC, bit-exact
 
-`basic_vec` is the **front-door for [vectorization](../../guide/vectorization/)**:
-the smallest possible demonstration that a Python-vectorized golden model and a
-vectorized Vitis kernel produce **the same bits**. It is a *data/schema* example —
-it teaches how to **represent and compute on data**, before any module-to-module
-interface is introduced.
+`basic_vec` is the **front-door for [vectorization](../../guide/vectorization/)**: the
+smallest demonstration that a Python-vectorized golden model and a vectorized Vitis kernel
+produce **the same bits**. It is a *data/schema* example — how to **represent and compute on
+data**, before any module-to-module interface is introduced.
 
-The whole example is one elementwise multiply-accumulate:
+The whole example is one elementwise multiply-accumulate, computed over arrays (no
+per-element Python loop) for each of the three numeric kinds, with the result asserted equal
+to Vitis C-sim **bit-for-bit**:
 
 ```python
 y = a * b + c
 ```
 
-computed over arrays — **no per-element Python loop** — for each of the three
-numeric kinds, with the result asserted equal to a Vitis C-sim **bit-for-bit**:
-
-- **integer** — growth-aware operators (`a*b` is `Wa+Wb` wide, `+c` adds a carry
-  bit); the Python `Int17` result matches `ap_int<17> y = a*b + c;`.
-- **float** — numpy `float32` passthrough; the kernel is built with
-  `-ffp-contract=off` so its `a*b + c` is the same **two roundings** numpy does.
-- **fixed** — full-precision `a*b + c` then one explicit `quantize` back to the
-  working format, matching `ap_fixed<...> y = a*b + c;`.
+| kind | Python | Vitis kernel | bit-exact because |
+|------|--------|--------------|-------------------|
+| **integer** | growth-aware operators (`Int17` result) | `ap_int<17> y = a*b + c;` | integer arithmetic is exact; the operators track the growth |
+| **float** | numpy `float32` passthrough | `a*b + c`, built `-ffp-contract=off` | same two roundings (no fused FMA) |
+| **fixed** | `quantize(a*b + c, Q)` | `ap_fixed<8,4> y = a*b + c;` | full precision, then quantize-on-assign |
 
 This is the **teaching** counterpart to the rigorous all-modes/all-widths sweep in
-`examples/schemas/fixedpoint`; the two share the same conformance machinery
-(`BuildDag` + `run_dag_cli` + gen→csim→compare-bits).
+`examples/schemas/fixedpoint` — the two share the same conformance machinery (`BuildDag` +
+`run_dag_cli` + gen→csim→compare-bits). The *concepts* (operators, the two paths, growth
+rules) live in the [vectorization guide](../../guide/vectorization/); this walkthrough shows
+them end-to-end on one example.
 
-## What it demonstrates
+## The walkthrough
 
-- The two computing paths from the [vectorization guide](../../guide/vectorization/):
-  the **type-preserving operators** (`a*b + c`, full-precision growth, explicit
-  `quantize`) producing a golden bit-vector, versus the raw numpy `.val` escape.
-- That keeping data in numpy arrays end-to-end is what makes functional simulation
-  **fast *and* bit-exact** — the core Waveflow differentiator.
+1. **[The Python model](./python.md)** — the vectorized golden: declare the arrays, apply
+   `a*b + c`, derive the result type, emit the golden bits.
+2. **[The Vitis equivalent](./vitis.md)** — the hand-written C++ kernels that mirror the op.
+3. **[Confirming the match](./eval.md)** — the build DAG, the Vitis C-sim, the bit comparison.
 
 ## File map
 
-The example lives in [`examples/basic_vec/`](../../../examples/basic_vec/):
-
-- `basic_vec_build.py` — builds the three MAC cases: computes each Python golden
-  with the operators, derives the result type, renders the matching kernel, and runs
-  the gen→csim→compare-bits conformance DAG.
-- `kernels.py` — the three minimal vectorized Vitis kernels (int / float / fixed)
-  over the *same* `a*b + c`, deliberately readable (the guide pulls from them).
-- `run.tcl` — the Vitis HLS C-simulation driver (`-ffp-contract=off` for the float
-  kernel).
+In [`examples/basic_vec/`](../../../examples/basic_vec/):
+- `basic_vec_build.py` — the three MAC cases + the gen→csim→compare conformance DAG.
+- `kernels.py` — the three minimal, **hand-written** Vitis kernels (int / float / fixed).
+- `run.tcl` — the Vitis C-sim driver (`-ffp-contract=off` for the float kernel).
 
 ## Running it
 
 ```bash
-# Generate kernels + input vectors + the Python golden bits (no Vitis needed):
-python examples/basic_vec/basic_vec_build.py --through gen
-
-# The full bit-exact conformance against Vitis C-sim (requires Vitis HLS):
-python examples/basic_vec/basic_vec_build.py --through run
+python examples/basic_vec/basic_vec_build.py --through gen   # kernels + vectors + golden (no Vitis)
+python examples/basic_vec/basic_vec_build.py --through run   # the bit-exact csim conformance (Vitis)
 ```
 
-The `run` stage asserts, per kind, that the Vitis output bits equal the Python
-operator bits **exactly**; any mismatch stops the build.
-
-## Next
-
-- [Vectorization guide](../../guide/vectorization/) — the selling point, the two
-  paths, and the per-kind detail (integer / float / fixed) this example embodies.
-- [Fixed-point (FixedField)](../../guide/schema/fixpoint.md) — the fixed-point type
-  behind the fixed case.
+The `run` stage asserts, per kind, that the Vitis output bits equal the Python operator bits
+**exactly**; any mismatch stops the build.

--- a/docs/examples/basic_vec/python.md
+++ b/docs/examples/basic_vec/python.md
@@ -1,0 +1,78 @@
+---
+title: The Python model
+parent: Basic Vectorization (MAC)
+nav_order: 1
+---
+# The Python golden model
+
+The golden is one vectorized MAC per numeric kind — `a*b + c` over `DataArray`s, with **no
+per-element loop**. The same expression, three inner types. (For the *concepts* — operators,
+growth rules, the `.val` escape — see the [vectorization guide](../../guide/vectorization/);
+here we just build this example.)
+
+## Integer — growth-aware operators
+
+```python
+from waveflow.hw.dataschema import DataArray, IntField
+
+I8 = IntField.specialize(8, True)                         # ap_int<8>
+ia = lambda vals: DataArray.specialize(I8, max_shape=(len(vals),))(vals)
+
+a, b, c = ia([3, -4, 5, 7]), ia([6, 7, -8, 2]), ia([1, -1, 2, -3])
+y = a * b + c                                             # -> Int17
+y.element_type.get_bitwidth()                             # 17  (a*b is 16, +c adds a carry bit)
+```
+
+The operators **derive the result width** (`a*b` → `8+8=16`, `+c` → `+1`), so `Int17`
+exactly mirrors `ap_int<17> y = a*b + c;` — no overflow, no manual sizing.
+
+## Float — numpy passthrough
+
+```python
+import numpy as np
+from waveflow.hw.dataschema import FloatField
+
+F32 = FloatField.specialize(32)
+fa = lambda vals: DataArray.specialize(F32, max_shape=(len(vals),))(np.array(vals, dtype=np.float32))
+
+a, b, c = fa([1.5, 2.5, -3.0]), fa([2.0, -1.5, 0.5]), fa([0.25, 1.0, -0.5])
+y = a * b + c                                             # float32, no growth
+```
+
+For float, the operators are numpy passthrough — `a*b + c` is the same **two roundings**
+numpy does (multiply, then add). The Vitis kernel must reproduce *exactly* that (no fused
+FMA) — see [the float kernel](./vitis.md#float).
+
+## Fixed — grow then quantize
+
+```python
+from waveflow.hw.fixpoint import FixedField, from_real, quantize
+
+Q = FixedField.specialize(8, 4)                          # ap_fixed<8,4>
+a = from_real([1.5, -2.0, 0.5], Q)
+b = from_real([2.0, 1.5, -1.0], Q)
+c = from_real([0.5, 0.25, -0.5], Q)
+y = quantize(a * b + c, Q)                               # full precision, then ONE quantize
+```
+
+`a*b + c` grows to full precision (the product widens, the sum grows a bit); the explicit
+`quantize(..., Q)` rounds back to `ap_fixed<8,4>` — exactly what `ap_fixed<8,4> y = a*b + c;`
+does on assignment.
+
+## The golden bits
+
+Each result is serialized to the **stored bits** the kernel will emit — integer/fixed via
+`to_bits`, float via the IEEE bit-view:
+
+```python
+import numpy as np
+from waveflow.utils.fixputils import to_bits
+
+# integer / fixed: stored W-bit integers
+int_bits = [int(x) for x in to_bits(np.asarray(y), 8)]
+# float: raw IEEE bits
+float_bits = [int(u) for u in np.asarray(y).astype(np.float32).view(np.uint32)]
+```
+
+These golden bit-vectors go into `expected.json`; the kernel's output is compared against
+them in [the eval step](./eval.md).

--- a/docs/examples/basic_vec/vitis.md
+++ b/docs/examples/basic_vec/vitis.md
@@ -1,0 +1,61 @@
+---
+title: The Vitis equivalent
+parent: Basic Vectorization (MAC)
+nav_order: 2
+---
+# The Vitis equivalent (hand-written)
+
+> **These kernels are hand-written, not generated.** `basic_vec` keeps the Vitis side a few
+> deliberately-minimal C++ templates ([`kernels.py`](../../../examples/basic_vec/kernels.py))
+> so the Python↔C++ parallel is explicit. The *generated* codegen flow — where Waveflow
+> emits the kernel from a component model — is shown in the
+> [polynomial example](../stream_inband/). Here, hand-written keeps the focus on the
+> bit-exactness, not the code generation.
+
+Each kernel reads operand bit-vectors (one value per line), computes the **same** `a*b + c`
+in the typed C++, and writes the result bits. Uniform `argv = (in_a, in_b, in_c, out)`.
+
+## Integer {#integer}
+
+```cpp
+ap_int<wa> a; a.range(wa-1, 0) = (ap_uint<wa>)A[i];   // reconstruct each operand bit-for-bit
+ap_int<wb> b; b.range(wb-1, 0) = (ap_uint<wb>)B[i];
+ap_int<wc> c; c.range(wc-1, 0) = (ap_uint<wc>)C[i];
+ap_int<wy> y = a * b + c;                              // full precision (wy = 17)
+out << (unsigned long long)y.range(wy-1, 0) << "\n";  // emit the stored bits
+```
+
+`ap_int` arithmetic grows automatically (`a*b` is `wa+wb`, `+c` adds a bit), so declaring `y`
+at the operator-derived `wy = 17` captures the full result — matching the Python `Int17`.
+`.range()` reconstructs each operand from its stored bits exactly.
+
+## Float {#float}
+
+```cpp
+float a = u2f(A[i]), b = u2f(B[i]), c = u2f(C[i]);     // bit-view back to float
+float t = a * b;                                       // split intermediate ...
+float y = t + c;                                       // ... two roundings, not a fused FMA
+out << (unsigned long long)f2u(y) << "\n";
+```
+
+The split (`t = a*b; y = t + c`) plus **`-ffp-contract=off`** in
+[`run.tcl`](../../../examples/basic_vec/run.tcl) forbids the compiler from fusing `a*b + c`
+into a single-rounding FMA — so it is the same two roundings numpy `float32` does. (The
+*opposite* case — complex multiply, where numpy itself *is* FMA-fused — is covered in
+[the complex docs](../../guide/schema/complex.md).)
+
+## Fixed {#fixed}
+
+```cpp
+ap_fixed<8,4> a; a.range(7,0) = (ap_uint<8>)A[i];
+// ... b, c likewise ...
+ap_fixed<8,4> y = a * b + c;                           // full precision a*b+c, quantize on assign
+out << (unsigned long long)y.range(7,0) << "\n";
+```
+
+`a*b + c` is computed at full precision; the **assignment** to `ap_fixed<8,4> y` quantizes it
+back — exactly the Python `quantize(a*b + c, Q)`. Operands are reconstructed via `.range()`
+from their stored bits.
+
+The full parameterized templates (`render_int_mac` / `render_float_mac` / `render_fixed_mac`)
+are in [`examples/basic_vec/kernels.py`](../../../examples/basic_vec/kernels.py).


### PR DESCRIPTION
Expands the `basic_vec` front-door stub (one hard-to-follow page) into a 4-page walkthrough matching the other examples, **complementing** `guide/vectorization` rather than re-teaching it.

- **index** → landing (`has_children`): the per-kind table (int/float/fixed → matching Vitis kernel), file map, run commands.
- **python** → the vectorized golden — int growth-aware operators (`Int17`), float numpy passthrough, fixed grow-then-`quantize` — + the golden bits. **All snippets verified to run** (integer result bitwidth = 17, confirmed).
- **vitis** → the **hand-written** kernels (named `vitis.md`, not "codegen", since nothing is code-*generated* here): `.range()` reconstruction, full-precision growth, the float `-ffp-contract=off` two-roundings; points to the poly example for the generated flow.
- **eval** → the `gen→csim→compare` DAG, the STOP-on-mismatch, the run commands.

0 dangling links; nav nests under the example. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)