### PR TITLE
docs(hero): fix codegen dependency in the lead figure (2x2 relayout)

### DIFF
--- a/docs/assets/waveflow_hero.svg
+++ b/docs/assets/waveflow_hero.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 310"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 360"
      role="img" aria-labelledby="t d" style="color-scheme: light dark;">
   <title id="t">Waveflow flow</title>
-  <desc id="d">Python model to Python sim to HLS codegen to RTL synthesis/simulation (violet build
-    pipeline). A teal Design / verify / calibrate / iterate tier is fed by a fast inner loop from
-    Python sim and a slow outer loop from RTL, and returns to refine the model. AI assists codegen
-    and the iteration loop.</desc>
+  <desc id="d">From one Python model, two independent branches: down-right to a fast bit-exact Python
+    sim, and up to HLS codegen then RTL synthesis/simulation. A fast loop from the sim and a slow loop
+    from RTL both feed a Design / verify / calibrate / iterate tier that refines the model. AI assists
+    codegen and the iteration loop.</desc>
 
   <style>
     /* NYU Violet (#57068C) build pipeline + teal feedback loops, theme-aware via light-dark() */
@@ -15,7 +15,6 @@
     .sub   { fill: light-dark(#7A6E86,#B4A4C8); font: 400 11px 'Segoe UI',Helvetica,Arial,sans-serif; }
     .barlbl{ fill: light-dark(#0C5E57,#D6F2EE); font: 700 15px 'Segoe UI',Helvetica,Arial,sans-serif; }
     .ai    { fill: light-dark(#57068C,#D9C2F2); font: 700 15px 'Segoe UI',Helvetica,Arial,sans-serif; }
-    .tag   { fill: light-dark(#3E7D77,#8FC9C2); font: italic 11px 'Segoe UI',Helvetica,Arial,sans-serif; }
     .meta  { stroke: light-dark(#8A4FB8,#B98FE0); stroke-width: 1.6; stroke-dasharray: 5 4; fill: none;
              stroke-linecap: round; }
     .loop  { stroke: light-dark(#138A80,#5FD0C5); stroke-width: 3; fill: none;
@@ -28,64 +27,61 @@
   </style>
 
   <defs>
-    <marker id="arrm" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 5 L0 10 z" class="afill"/>
-    </marker>
     <marker id="tarr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto">
       <path d="M0 0 L10 5 L0 10 z" class="tfill"/>
     </marker>
+    <marker id="arrm" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path d="M0 0 L10 5 L0 10 z" class="afill"/>
+    </marker>
   </defs>
 
-  <!-- ===== four-stage build pipeline (violet) ===== -->
-  <g>
-    <rect class="box" x="38"  y="68" width="176" height="86" rx="10"/>
-    <text class="head" x="126" y="106" text-anchor="middle">Python model</text>
-    <text class="sub"  x="126" y="125" text-anchor="middle">architecture &#183; algorithms</text>
+  <!-- ===== hardware path (top row): HLS codegen -> RTL synth/sim ===== -->
+  <rect class="box" x="64"  y="44" width="180" height="72" rx="10"/>
+  <text class="head" x="154" y="78" text-anchor="middle">HLS codegen</text>
+  <text class="sub"  x="154" y="97" text-anchor="middle">typed &#183; interface-defined</text>
 
-    <rect class="box" x="254" y="68" width="176" height="86" rx="10"/>
-    <text class="head" x="342" y="106" text-anchor="middle">Python sim</text>
-    <text class="sub"  x="342" y="125" text-anchor="middle">fast &#183; bit-exact</text>
-    <text class="sub"  x="342" y="139" text-anchor="middle">cycle-approximate</text>
+  <rect class="box" x="404" y="44" width="180" height="72" rx="10"/>
+  <text class="head" x="494" y="78" text-anchor="middle">RTL synth / sim</text>
+  <text class="sub"  x="494" y="97" text-anchor="middle">slow &#183; cycle-exact</text>
 
-    <rect class="box" x="470" y="68" width="176" height="86" rx="10"/>
-    <text class="head" x="558" y="106" text-anchor="middle">HLS codegen</text>
-    <text class="sub"  x="558" y="125" text-anchor="middle">typed &#183; interface-defined</text>
+  <!-- ===== Python path (bottom row): Python model -> Python sim ===== -->
+  <rect class="box" x="64"  y="156" width="180" height="72" rx="10"/>
+  <text class="head" x="154" y="187" text-anchor="middle">Python model</text>
+  <text class="sub"  x="154" y="206" text-anchor="middle">architecture &#183; algorithms</text>
 
-    <rect class="box" x="686" y="68" width="176" height="86" rx="10"/>
-    <text class="head" x="774" y="106" text-anchor="middle">RTL synth / sim</text>
-    <text class="sub"  x="774" y="125" text-anchor="middle">slow &#183; cycle-exact</text>
-  </g>
+  <rect class="box" x="404" y="156" width="180" height="72" rx="10"/>
+  <text class="head" x="494" y="184" text-anchor="middle">Python sim</text>
+  <text class="sub"  x="494" y="201" text-anchor="middle">fast &#183; bit-exact</text>
+  <text class="sub"  x="494" y="214" text-anchor="middle">cycle-approximate</text>
 
-  <!-- ===== forward dataflow: violet block arrows ===== -->
-  <polygon class="vfill" points="216,106 239,106 239,101 252,111 239,121 239,116 216,116"/>
-  <polygon class="vfill" points="432,106 455,106 455,101 468,111 455,121 455,116 432,116"/>
-  <polygon class="vfill" points="648,106 671,106 671,101 684,111 671,121 671,116 648,116"/>
+  <!-- ===== forward build: violet block arrows (model branches up + right) ===== -->
+  <polygon class="vfill" points="149,156 159,156 159,134 164,134 154,118 144,134 149,134"/>  <!-- model -> codegen (up) -->
+  <polygon class="vfill" points="246,75 389,75 389,70 402,80 389,90 389,85 246,85"/>          <!-- codegen -> RTL -->
+  <polygon class="vfill" points="246,187 389,187 389,182 402,192 389,202 389,197 246,197"/>   <!-- model -> sim -->
 
-  <!-- ===== feedback loops: teal arrows ===== -->
-  <!-- return (bent): Design tier -> refine the model -->
-  <path class="loop" d="M270 266 H134 Q126 266 126 258 V157" marker-end="url(#tarr)"/>
-  <!-- inner / fast loop (straight): Python sim -> Design tier -->
-  <path class="loop" d="M342 156 V241" marker-end="url(#tarr)"/>
-  <text class="tag" x="350" y="201">fast loop</text>
-  <!-- outer / slow loop (bent): RTL -> Design tier -->
-  <path class="loop" d="M774 156 V258 Q774 266 766 266 H632" marker-end="url(#tarr)"/>
-  <text class="tag" x="782" y="205">slow loop</text>
+  <!-- ===== feedback loops: teal ===== -->
+  <!-- fast inner loop: Python sim -> design tier -->
+  <path class="loop" d="M494 228 V274" marker-end="url(#tarr)"/>
+  <!-- slow outer loop: RTL -> design tier (around the right) -->
+  <path class="loop" d="M584 80 H606 Q614 80 614 88 V291 Q614 299 606 299 H526" marker-end="url(#tarr)"/>
+  <!-- return: design tier -> refine the model -->
+  <path class="loop" d="M154 276 V230" marker-end="url(#tarr)"/>
 
-  <!-- ===== teal Design tier (narrower) + AI-agent robot ===== -->
-  <rect class="bar" x="270" y="243" width="360" height="46" rx="23"/>
+  <!-- ===== design tier + AI-agent robot ===== -->
+  <rect class="bar" x="124" y="276" width="400" height="46" rx="23"/>
   <g>  <!-- robot, agent of iteration -->
-    <line  class="vio"  x1="300" y1="258" x2="300" y2="254"/>
-    <circle class="vfill" cx="300" cy="253" r="1.6"/>
-    <rect  class="rhead" x="290" y="258" width="20" height="15" rx="3"/>
-    <circle class="vfill" cx="296" cy="265" r="1.7"/>
-    <circle class="vfill" cx="304" cy="265" r="1.7"/>
-    <line  class="vio"  x1="296" y1="269.5" x2="304" y2="269.5"/>
+    <line  class="vio"  x1="194" y1="292" x2="194" y2="288"/>
+    <circle class="vfill" cx="194" cy="287" r="1.6"/>
+    <rect  class="rhead" x="184" y="292" width="20" height="15" rx="3"/>
+    <circle class="vfill" cx="190" cy="299" r="1.7"/>
+    <circle class="vfill" cx="198" cy="299" r="1.7"/>
+    <line  class="vio"  x1="190" y1="303.5" x2="198" y2="303.5"/>
   </g>
-  <text class="barlbl" x="480" y="272" text-anchor="middle">Design &#183; verify &#183; calibrate &#183; iterate</text>
+  <text class="barlbl" x="356" y="304" text-anchor="middle">Design &#183; verify &#183; calibrate &#183; iterate</text>
 
   <!-- ===== AI assist over codegen ===== -->
-  <rect class="chip" x="518" y="14" width="80" height="32" rx="16"/>
-  <path class="afill" d="M544 19 L546.47 27.53 L555 30 L546.47 32.47 L544 41 L541.53 32.47 L533 30 L541.53 27.53 Z"/>
-  <text class="ai" x="570" y="35" text-anchor="middle">AI</text>
-  <line class="meta" x1="558" y1="46" x2="558" y2="66" marker-end="url(#arrm)"/>
+  <rect class="chip" x="120" y="10" width="68" height="24" rx="12"/>
+  <path class="afill" d="M140 15 L141.63 20.37 L147 22 L141.63 23.63 L140 29 L138.37 23.63 L133 22 L138.37 20.37 Z"/>
+  <text class="ai" x="164" y="27" text-anchor="middle">AI</text>
+  <line class="meta" x1="154" y1="34" x2="154" y2="44" marker-end="url(#arrm)"/>
 </svg>


### PR DESCRIPTION
The front-page hero implied **HLS codegen depends on the Python sim** (linear chain `Python model → Python sim → HLS codegen → RTL`). It doesn't — codegen is generated from the Python **model**, independent of simulation.

**Fix:** re-lay out as a 2×2 so the model *branches*:
- **top row (hardware path):** HLS codegen → RTL synth/sim
- **bottom row (Python path):** Python model → Python sim
- the **Python model** feeds *up* to codegen and *right* to sim — two independent branches.

Feedback unchanged in spirit: fast loop from Python sim and slow loop from RTL both feed the **Design · verify · calibrate · iterate** tier, which returns to the model. AI spark over codegen retained. (viewBox 680×360.)

Docs-only; independent of the in-flight `vmac` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)