### PR TITLE
hw: add BooleanField (1-bit ap_uint<1> flag field)

### DIFF
--- a/docs/guide/schema/fields.md
+++ b/docs/guide/schema/fields.md
@@ -50,6 +50,23 @@ Float32 = FloatField.specialize(bitwidth=32)    # IEEE single precision
 Float64 = FloatField.specialize(bitwidth=64)    # IEEE double precision
 ```
 
+### `BooleanField` — a one-bit flag
+
+A boolean flag is common enough to get its own type. `BooleanField` is a fixed
+`ap_uint<1>` (an `IntField` subclass), but its `.val` is a Python `bool`:
+
+```python
+from waveflow.hw.dataschema import BooleanField
+
+enable = BooleanField(True)
+enable.val            # True  (a Python bool)
+```
+
+It accepts `bool` or `0` / `1` and **rejects any other value**, so a flag can never
+silently hold `2`. It packs into exactly **one bit** (`ap_uint<1>`), so several flags cost
+only a few bits in a record — handy for `m_axi` control words. Use it directly (no
+`specialize` needed); the equivalent raw form is the one-bit `IntField` shown above.
+
 ## Why arbitrary-precision integers matter in hardware
 
 Software integers come in a few fixed sizes (8/16/32/64). Hardware has no such restriction —

--- a/tests/hw/test_dataschema.py
+++ b/tests/hw/test_dataschema.py
@@ -7,6 +7,7 @@ import pytest
 from waveflow.build.build import BuildConfig
 from waveflow.build.streamutils import MemMgrStep, StreamUtilsStep
 from waveflow.hw import (
+    BooleanField as PublicBooleanField,
     DataArray as PublicDataArray,
     DataField as PublicDataField,
     DataList as PublicDataList,
@@ -17,6 +18,7 @@ from waveflow.hw import (
     MemAddr as PublicMemAddr,
 )
 from waveflow.hw.dataschema import (
+    BooleanField,
     DataArray,
     DataField,
     DataList,
@@ -224,6 +226,83 @@ def test_enumfield_explicit_overrides_win():
     assert mode_field.cpp_class_name() == "CustomMode"
     assert mode_field.resolved_include_filename() == "custom_mode.h"
     assert mode_field.resolved_tb_include_filename() == "custom_mode_tb.h"
+
+
+# --- BooleanField -------------------------------------------------------------
+def test_booleanfield_construction_and_defaults():
+    assert BooleanField.get_bitwidth() == 1
+    assert BooleanField.signed is False
+    assert BooleanField.cpp_class_name() == "ap_uint<1>"
+    assert BooleanField.can_gen_include is False
+    assert issubclass(BooleanField, IntField)
+
+    init = BooleanField.init_value()
+    assert init is False and isinstance(init, bool)
+    assert BooleanField().val is False
+    assert PublicBooleanField is BooleanField
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, True), (False, False),
+        (1, True), (0, False),
+        (np.int64(1), True), (np.uint8(0), False),
+        (np.bool_(True), True), (np.bool_(False), False),
+    ],
+)
+def test_booleanfield_coerces_to_python_bool(value, expected):
+    field = BooleanField(value)
+    assert field.val is expected            # exact Python bool singleton
+    assert isinstance(field.val, bool)
+
+
+@pytest.mark.parametrize("bad", [2, -1, 255, 1.0, 0.0, "1"])
+def test_booleanfield_rejects_out_of_range(bad):
+    with pytest.raises(ValueError):
+        BooleanField(bad)
+    with pytest.raises(ValueError):
+        BooleanField().val = bad        # also rejected on direct assignment
+
+
+@pytest.mark.parametrize("word_bw", [32, 64])
+@pytest.mark.parametrize("value", [True, False])
+def test_booleanfield_serialize_deserialize_roundtrip(value, word_bw):
+    packed = BooleanField(value).serialize(word_bw=word_bw)
+    assert int(packed[0]) == (1 if value else 0)          # exact 1-bit payload
+    restored = BooleanField().deserialize(packed, word_bw=word_bw)
+    assert restored.val is value
+
+
+def test_booleanfield_one_bit_width_packs_tightly():
+    # Three booleans + a byte pack into a single 32-bit word (3 + 8 = 11 bits used).
+    class Flags(DataList):
+        elements = {"a": BooleanField, "b": BooleanField, "c": BooleanField, "n": U8}
+
+    flags = Flags(a=True, b=False, c=True, n=200)
+    packed = flags.serialize(word_bw=32)
+    assert packed.shape == (1,)
+    restored = Flags().deserialize(packed, word_bw=32)
+    assert restored.val == {"a": True, "b": False, "c": True, "n": np.uint32(200)}
+
+
+def test_booleanfield_specialize_caches_and_honors_overrides():
+    assert BooleanField.specialize() is BooleanField.specialize()
+    a = BooleanField.specialize(include_dir="a")
+    b = BooleanField.specialize(include_dir="b")
+    assert a is not b
+    assert a.get_bitwidth() == 1 and a.cpp_class_name() == "ap_uint<1>"
+    assert a.include_dir == "a" and b.include_dir == "b"
+
+
+def test_booleanfield_codegen_emits_ap_uint1(tmp_path: Path):
+    class Toggle(DataList):
+        elements = {"enable": BooleanField, "count": U8}
+
+    result = Toggle.as_buildable(word_bw_supported=[32]).run(BuildConfig(root_dir=tmp_path))
+    content = result.artifacts["include"].read_text(encoding="utf-8")
+    assert "ap_uint<1> enable;" in content                # exact 1-bit struct member
+    assert "res.range(0, 0) = data.enable;" in content    # packs into a single bit
 
 
 def test_inline_enum_specialization_keeps_expected_metadata():

--- a/waveflow/hw/__init__.py
+++ b/waveflow/hw/__init__.py
@@ -1,6 +1,7 @@
 """Public hardware-schema API exports."""
 
 from .dataschema import (
+    BooleanField,
     DataArray,
     DataField,
     DataList,
@@ -61,6 +62,7 @@ __all__ = [
     "MemAddr",
     "FloatField",
     "EnumField",
+    "BooleanField",
     "DataList",
     "DataArray",
     "Words",

--- a/waveflow/hw/dataschema.py
+++ b/waveflow/hw/dataschema.py
@@ -1891,6 +1891,67 @@ class EnumField(DataField):
         )
 
 
+class BooleanField(IntField):
+    """A 1-bit boolean flag field.
+
+    A fixed ``ap_uint<1>`` :class:`IntField` (exact 1-bit ``m_axi`` packing) whose runtime
+    value is a Python ``bool``.  ``_convert`` accepts ``bool`` / ``0`` / ``1`` and rejects
+    any other value; it serializes / deserializes and code-generates like any other field
+    (the stored bit is ``0`` / ``1``).  Use it directly (``BooleanField``) for a flag, the
+    same way a default ``IntField`` is a 32-bit int.
+    """
+
+    bitwidth: ClassVar[int] = 1
+    signed: ClassVar[bool] = False
+    cpp_type: ClassVar[str] = "ap_uint<1>"
+    can_gen_include: ClassVar[bool] = False
+    _specializations: ClassVar[dict[tuple[Any, ...], type[BooleanField]]] = {}
+
+    @classmethod
+    def specialize(cls, **kwargs: Any) -> type[BooleanField]:  # type: ignore[override]
+        """Return a cached ``BooleanField`` subclass.
+
+        The width is fixed at 1 bit; only structural metadata overrides (such as
+        ``include_dir`` / ``include_filename``) vary, so unlike :class:`IntField` this
+        takes no ``bitwidth`` / ``signed`` parameters.
+        """
+        overrides = cls.validate_specialize_kwargs(kwargs)
+        override_items = tuple(sorted(overrides.items()))
+        key = (cls, override_items)
+        cached = cls._specializations.get(key)
+        if cached is not None:
+            return cached
+
+        specialized_attrs = cls.merge_specialize_attrs(
+            {
+                "bitwidth": 1,
+                "signed": False,
+                "cpp_type": "ap_uint<1>",
+                "__module__": cls.__module__,
+                "__doc__": "1-bit boolean field (ap_uint<1>).",
+            },
+            overrides,
+        )
+        specialized = type("Boolean", (cls,), specialized_attrs)
+        cls._specializations[key] = specialized
+        return specialized
+
+    def _convert(self, value: Any) -> bool:
+        """Coerce to a Python ``bool``; accept ``bool`` / ``0`` / ``1``, reject the rest."""
+        if isinstance(value, (bool, np.bool_)):
+            return bool(value)
+        if isinstance(value, (int, np.integer)) and int(value) in (0, 1):
+            return bool(value)
+        raise ValueError(
+            f"{type(self).__name__} accepts only bool or 0/1, got {value!r}."
+        )
+
+    @classmethod
+    def init_value(cls) -> bool:
+        """Return the initial Python-side boolean value (``False``)."""
+        return False
+
+
 class DataList(DataSchema):
     """Structured aggregate with schema defined entirely at the class level.
 
@@ -4243,6 +4304,7 @@ __all__ = [
     "MemAddr",
     "FloatField",
     "EnumField",
+    "BooleanField",
     "DataList",
     "DataArray",
 ]


### PR DESCRIPTION
Adds a `BooleanField` to the Waveflow type system — a fixed 1-bit `IntField` subclass for boolean flags, slotted next to `EnumField`.

- `bitwidth=1`, unsigned, `cpp_type="ap_uint<1>"` (exact 1-bit m_axi packing); `can_gen_include=False`.
- `_convert` coerces to Python `bool` — accepts `bool`/`0`/`1` (incl. numpy), **rejects everything else** so a flag can't silently hold 2.
- Param-free cached `specialize` (always 1 bit); `init_value=False`; encodes/decodes + codegens via inherited `IntField` machinery.
- Exported from `waveflow.hw` and `dataschema.__all__`.

Tests (22, all green) mirror the IntField/EnumField patterns; a short subsection added to the schema fields page. **Verified independently:** zero new failures vs the `main` baseline (the 15 pre-existing non-vitis failures — build×9, dataschema_poly×1, poly-timing×5 — reproduce identically on `main`).

Prerequisite for VMAC Phase 1.5 (the command flags switch to `BooleanField`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)