### PR TITLE
vmac: VMAC vector MAC engine — Phase 1 (schema + golden + csum)

### DIFF
--- a/examples/vmac/golden.py
+++ b/examples/vmac/golden.py
@@ -1,24 +1,34 @@
-"""The VMAC Python golden — the bit-exact reference for ``D = α·A·op(B) + β·C [, reduce]``.
+"""``VmacAccel`` — the VMAC accelerator: structural params + the bit-exact Python golden.
 
-``execute(cmd, mem)`` runs a :class:`~examples.vmac.vmac_cmd.VmacCmd` over a shared-memory
-array, composing the merged ``FixedField`` / ``ComplexField`` operators (``mult`` / ``cmult``,
-``add`` / ``cadd``, ``conj``) for the multiply-accumulate, the wide-accumulator column
-reduction :func:`~waveflow.hw.complexfield.csum` for ``reduce_rows``, and the output
-requantize (right-shift ``SHIFT`` + round + saturate) via the ``ap_fixed``-exact integer
-requantizer.  Everything is **vectorized** — no per-element Python loop.
+A VMAC instance is parameterized by its **structural** widths — fixed at synthesis, the
+HLS template params: ``mem_dwidth`` (MEM_BW), ``mem_awidth``, ``data_bw`` (IN_BW),
+``acc_bw``, ``out_bw``.  ``VmacAccel.specialize(...)`` sets them and **cascades** the
+specialization into the command schema (``Cmd = VmacCmd.specialize(mem_awidth, data_bw)``),
+so a command's field widths track the silicon that consumes it::
 
-The datapath: **multiply (IN_BW × IN_BW) → wide accumulate (full precision, ≤ ACC_BW) →
-right-shift SHIFT → round + saturate → write (OUT_BW)**.  The right-shift is the single
-lossy step; it is exactly an ``ap_fixed`` assignment, so the golden is bit-exact with the
-Vitis kernel (Phase 3).
+    Accel = VmacAccel.specialize(mem_dwidth=512, mem_awidth=32, data_bw=16, acc_bw=48, out_bw=16)
+    cmd   = Accel.Cmd(...)            # a VmacCmd specialized to this accelerator
+    dst   = Accel.execute(cmd, mem)   # the bit-exact golden
 
-``mem`` is the shared memory: a 1-D ``int64`` array of stored integers (``real`` mode) or a
-1-D structured ``[('re','im')]`` array (``complex`` mode).  Operands are **strided** regions
-``M[i, j] = mem[addr + i·row_stride + j·col_stride]``.  ``execute`` writes the requantized
-result into ``mem`` at the ``d`` region (so commands compose) and returns the dst
-``DataArray``.
+``execute`` runs the fused op ``D = α·A·op(B) + β·C [, reduce]`` over a shared-memory
+array, composing the merged ``FixedField`` / ``ComplexField`` operators (``mult`` /
+``cmult``, ``add`` / ``cadd``, ``conj``), the wide-accumulator column reduction
+:func:`~waveflow.hw.complexfield.csum` for ``reduce_rows``, and the output requantize
+(right-shift ``SHIFT`` + round + saturate) via the ``ap_fixed``-exact integer requantizer.
+Vectorized — no per-element Python loop.
+
+The datapath: **multiply (data_bw × data_bw) → wide accumulate (full precision, ≤ acc_bw)
+→ right-shift shift → round + saturate → write (out_bw)**.  The right-shift is the single
+lossy step (an ``ap_fixed`` assignment), so the golden is bit-exact with the Vitis kernel
+(Phase 3).  ``mem`` is the shared memory: a 1-D ``int64`` array of stored integers (``real``
+mode) or a 1-D structured ``[('re','im')]`` array (``complex`` mode); operands are strided
+regions ``M[i, j] = mem[addr + i·row_stride + j·col_stride]``.  ``execute`` writes the
+requantized result into ``mem`` at the ``d`` region (so commands compose) and returns the
+dst ``DataArray``.
 """
 from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 
@@ -32,128 +42,163 @@ from waveflow.utils import fixputils
 from waveflow.utils.fixputils import Format, OMode, QMode
 
 
-def _q(cmd: VmacCmd) -> QMode:
-    return QMode.AP_RND if int(cmd.q_rnd) else QMode.AP_TRN
+class VmacAccel:
+    """A VMAC accelerator instance: structural widths + the Python golden ``execute``."""
 
+    # structural params (synthesis-time; the HLS template params)
+    mem_dwidth: int = 512
+    mem_awidth: int = 32
+    data_bw: int = 32                       # IN_BW — operand element width
+    acc_bw: int = 64                        # accumulator width budget
+    out_bw: int = 32                        # writeback element width
+    Cmd: type[VmacCmd] = VmacCmd            # the command schema (specialized below)
+    _specializations: dict[tuple[Any, ...], type["VmacAccel"]] = {}
 
-def _o(cmd: VmacCmd) -> OMode:
-    return OMode.AP_SAT if int(cmd.o_sat) else OMode.AP_WRAP
+    @classmethod
+    def specialize(
+        cls,
+        *,
+        mem_dwidth: int,
+        mem_awidth: int,
+        data_bw: int,
+        acc_bw: int,
+        out_bw: int,
+    ) -> type["VmacAccel"]:
+        """Return a cached accelerator with these structural widths; cascades into ``Cmd``.
 
+        Same params → same class object (stable schema identity for codegen)."""
+        key = (cls, int(mem_dwidth), int(mem_awidth), int(data_bw), int(acc_bw), int(out_bw))
+        cached = cls._specializations.get(key)
+        if cached is not None:
+            return cached
+        sub = type(f"VmacAccel_d{mem_dwidth}_a{mem_awidth}_w{data_bw}", (cls,), {
+            "mem_dwidth": int(mem_dwidth),
+            "mem_awidth": int(mem_awidth),
+            "data_bw": int(data_bw),
+            "acc_bw": int(acc_bw),
+            "out_bw": int(out_bw),
+            "Cmd": VmacCmd.specialize(mem_awidth=int(mem_awidth), data_bw=int(data_bw)),
+            "__module__": cls.__module__,
+        })
+        cls._specializations[key] = sub
+        return sub
 
-def _fixed_cls(fmt: Format) -> type[FixedField]:
-    return FixedField.specialize(fmt.W, fmt.int_bits, fmt.signed, fmt.q_mode, fmt.o_mode)
+    # --- private datapath helpers --------------------------------------------
+    @staticmethod
+    def _fixed_cls(fmt: Format) -> type[FixedField]:
+        return FixedField.specialize(fmt.W, fmt.int_bits, fmt.signed, fmt.q_mode, fmt.o_mode)
 
+    @staticmethod
+    def _region_idx(reg, n_rows: int, n_cols: int) -> np.ndarray:
+        """The strided index matrix: ``addr + i·row_stride + j·col_stride``."""
+        rows = np.arange(n_rows)[:, None] * int(reg.row_stride)
+        cols = np.arange(n_cols)[None, :] * int(reg.col_stride)
+        return int(reg.addr) + rows + cols
 
-def _region_idx(reg, n_rows: int, n_cols: int) -> np.ndarray:
-    """The strided index matrix for a region: ``addr + i·row_stride + j·col_stride``."""
-    rows = np.arange(n_rows)[:, None] * int(reg.row_stride)
-    cols = np.arange(n_cols)[None, :] * int(reg.col_stride)
-    return int(reg.addr) + rows + cols
+    @classmethod
+    def _operand(cls, M: np.ndarray, in_fmt: Format, complex_mode: bool) -> DataArray:
+        """Wrap a strided matrix view (stored ints / structured) as a DataArray operand."""
+        inner = cls._fixed_cls(in_fmt)
+        elem = ComplexField.specialize(inner) if complex_mode else inner
+        shape = M.shape if M.shape else (1,)
+        return DataArray.specialize(elem, max_shape=tuple(shape))(M)
 
-
-def _operand(M: np.ndarray, in_fmt: Format, complex_mode: bool) -> DataArray:
-    """Wrap a strided matrix view (stored ints / structured) as a DataArray operand."""
-    inner = _fixed_cls(in_fmt)
-    elem = ComplexField.specialize(inner) if complex_mode else inner
-    shape = M.shape if M.shape else (1,)
-    return DataArray.specialize(elem, max_shape=tuple(shape))(M)
-
-
-def _scalar(sc, n_cols: int, in_fmt: Format, mem: np.ndarray, complex_mode: bool) -> DataArray:
-    """Build an alpha/beta operand: direct immediate (shape (1,)) or indirect per-column."""
-    if int(sc.direct):
-        if complex_mode:
-            M = cx.make_complex([int(sc.re)], [int(sc.im)], in_fmt)
-        else:
-            M = np.array([int(sc.re)], dtype=np.int64)
-    else:
-        idx = int(sc.addr) + np.arange(n_cols) * int(sc.stride)
-        M = mem[idx]
-    return _operand(M, in_fmt, complex_mode)
-
-
-def _mult(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
-    return cmult(a, b) if complex_mode else fixpoint.mult(a, b)
-
-
-def _add(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
-    return cadd(a, b) if complex_mode else fixpoint.add(a, b)
-
-
-def _acc_width(t: DataArray, complex_mode: bool) -> int:
-    et = t.element_type
-    return et.inner_type.get_bitwidth() if complex_mode else et.get_bitwidth()
-
-
-def _requantize(t: DataArray, out_bw: int, shift: int, q: QMode, o: OMode,
+    @classmethod
+    def _scalar(cls, sc, n_cols: int, in_fmt: Format, mem: np.ndarray,
                 complex_mode: bool) -> DataArray:
-    """Right-shift ``SHIFT`` + round + saturate to ``OUT_BW`` — the single lossy step,
-    an ``ap_fixed`` assignment via the integer requantizer."""
-    tf = t.element_type.inner_format() if complex_mode else t.element_type.get_format()
-    out_frac = tf.frac_bits - shift
-    if out_frac < 0:
-        raise ValueError(
-            f"SHIFT={shift} exceeds accumulator fractional bits {tf.frac_bits}; "
-            "the output would need more integer bits than OUT_BW.")
-    target = Format(out_bw, out_bw - out_frac, tf.signed, q, o)
-    if complex_mode:
-        re = fixputils.quantize(cx.re_of(t.val), tf, target)
-        im = fixputils.quantize(cx.im_of(t.val), tf, target)
-        elem = ComplexField.specialize(_fixed_cls(target))
-        struct = cx.make_complex(re, im, target)
-        return DataArray.specialize(elem, max_shape=struct.shape)(struct)
-    return fixpoint.quantize(t, _fixed_cls(target))
+        """Build an alpha/beta operand: direct immediate (shape (1,)) or indirect per-column."""
+        if bool(sc.direct):
+            if complex_mode:
+                M = cx.make_complex([int(sc.re)], [int(sc.im)], in_fmt)
+            else:
+                M = np.array([int(sc.re)], dtype=np.int64)
+        else:
+            idx = int(sc.addr) + np.arange(n_cols) * int(sc.stride)
+            M = mem[idx]
+        return cls._operand(M, in_fmt, complex_mode)
 
+    @staticmethod
+    def _mult(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
+        return cmult(a, b) if complex_mode else fixpoint.mult(a, b)
 
-def _writeback(mem: np.ndarray, reg, dst: DataArray, complex_mode: bool) -> None:
-    val = np.asarray(dst.val)
-    if val.ndim == 1:                                   # reduced -> single row of columns
-        idx = int(reg.addr) + np.arange(val.shape[0]) * int(reg.col_stride)
-    else:
-        idx = _region_idx(reg, val.shape[0], val.shape[1])
-    mem[idx] = val
+    @staticmethod
+    def _add(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
+        return cadd(a, b) if complex_mode else fixpoint.add(a, b)
 
+    @staticmethod
+    def _acc_width(t: DataArray, complex_mode: bool) -> int:
+        et = t.element_type
+        return et.inner_type.get_bitwidth() if complex_mode else et.get_bitwidth()
 
-def execute(cmd: VmacCmd, mem: np.ndarray) -> DataArray:
-    """Execute a ``VmacCmd`` over ``mem``; write the dst region and return the dst array."""
-    mode = VmacMode(int(cmd.mode))
-    complex_mode = mode == VmacMode.COMPLEX
-    in_fmt = Format(int(cmd.in_bw), int(cmd.int_bits), True)
-    n, m = int(cmd.n_rows), int(cmd.n_cols)
-    mem = np.asarray(mem)
+    @classmethod
+    def _requantize(cls, t: DataArray, out_bw: int, shift: int, q: QMode, o: OMode,
+                    complex_mode: bool) -> DataArray:
+        """Right-shift ``shift`` + round + saturate to ``out_bw`` — the single lossy step."""
+        tf = t.element_type.inner_format() if complex_mode else t.element_type.get_format()
+        out_frac = tf.frac_bits - shift
+        if out_frac < 0:
+            raise ValueError(
+                f"shift={shift} exceeds accumulator fractional bits {tf.frac_bits}; "
+                "the output would need more integer bits than out_bw.")
+        target = Format(out_bw, out_bw - out_frac, tf.signed, q, o)
+        if complex_mode:
+            re = fixputils.quantize(cx.re_of(t.val), tf, target)
+            im = fixputils.quantize(cx.im_of(t.val), tf, target)
+            elem = ComplexField.specialize(cls._fixed_cls(target))
+            struct = cx.make_complex(re, im, target)
+            return DataArray.specialize(elem, max_shape=struct.shape)(struct)
+        return fixpoint.quantize(t, cls._fixed_cls(target))
 
-    def region(reg) -> DataArray:
-        return _operand(mem[_region_idx(reg, n, m)], in_fmt, complex_mode)
+    @classmethod
+    def _writeback(cls, mem: np.ndarray, reg, dst: DataArray) -> None:
+        val = np.asarray(dst.val)
+        if val.ndim == 1:                                   # reduced -> single row of columns
+            idx = int(reg.addr) + np.arange(val.shape[0]) * int(reg.col_stride)
+        else:
+            idx = cls._region_idx(reg, val.shape[0], val.shape[1])
+        mem[idx] = val
 
-    # op(B) and A·op(B)
-    a = region(cmd.a)
-    if int(cmd.b_one):
-        ab = a
-    else:
-        b = region(cmd.b)
-        if int(cmd.b_conj) and complex_mode:            # conj is a no-op for real data
-            b = conj(b)
-        ab = _mult(a, b, complex_mode)
+    # --- the golden ----------------------------------------------------------
+    @classmethod
+    def execute(cls, cmd: VmacCmd, mem: np.ndarray) -> DataArray:
+        """Execute a ``VmacCmd`` over ``mem``; write the dst region and return the dst array."""
+        complex_mode = VmacMode(int(cmd.mode)) == VmacMode.COMPLEX
+        in_fmt = Format(cls.data_bw, int(cmd.int_bits), True)
+        n, m = int(cmd.n_rows), int(cmd.n_cols)
+        mem = np.asarray(mem)
 
-    # alpha · A·op(B)
-    alpha = _scalar(cmd.alpha, m, in_fmt, mem, complex_mode)
-    t = _mult(alpha, ab, complex_mode)
+        def region(reg) -> DataArray:
+            return cls._operand(mem[cls._region_idx(reg, n, m)], in_fmt, complex_mode)
 
-    # + beta · C
-    if not int(cmd.c_zero):
-        beta = _scalar(cmd.beta, m, in_fmt, mem, complex_mode)
-        t = _add(t, _mult(beta, region(cmd.c), complex_mode), complex_mode)
+        # op(B) and A·op(B)
+        a = region(cmd.a)
+        if bool(cmd.b_one):
+            ab = a
+        else:
+            b = region(cmd.b)
+            if bool(cmd.b_conj) and complex_mode:           # conj is a no-op for real data
+                b = conj(b)
+            ab = cls._mult(a, b, complex_mode)
 
-    # optional row reduction (wide accumulator)
-    if int(cmd.reduce_rows):
-        t = csum(t, axis=0)
+        # alpha · A·op(B)
+        alpha = cls._scalar(cmd.alpha, m, in_fmt, mem, complex_mode)
+        t = cls._mult(alpha, ab, complex_mode)
 
-    # accumulator-width budget check (the provisioned ACC_BW must hold full precision)
-    acc_w = _acc_width(t, complex_mode)
-    if acc_w > int(cmd.acc_bw):
-        raise ValueError(
-            f"accumulator width {acc_w} exceeds ACC_BW={int(cmd.acc_bw)}; widen ACC_BW.")
+        # + beta · C
+        if not bool(cmd.c_zero):
+            beta = cls._scalar(cmd.beta, m, in_fmt, mem, complex_mode)
+            t = cls._add(t, cls._mult(beta, region(cmd.c), complex_mode), complex_mode)
 
-    dst = _requantize(t, int(cmd.out_bw), int(cmd.shift), _q(cmd), _o(cmd), complex_mode)
-    _writeback(mem, cmd.d, dst, complex_mode)
-    return dst
+        # optional row reduction (wide accumulator)
+        if bool(cmd.reduce_rows):
+            t = csum(t, axis=0)
+
+        # accumulator-width budget check (the provisioned acc_bw must hold full precision)
+        acc_w = cls._acc_width(t, complex_mode)
+        if acc_w > cls.acc_bw:
+            raise ValueError(
+                f"accumulator width {acc_w} exceeds acc_bw={cls.acc_bw}; widen acc_bw.")
+
+        dst = cls._requantize(t, cls.out_bw, int(cmd.shift), cmd.q_mode, cmd.o_mode, complex_mode)
+        cls._writeback(mem, cmd.d, dst)
+        return dst

--- a/examples/vmac/golden.py
+++ b/examples/vmac/golden.py
@@ -1,0 +1,159 @@
+"""The VMAC Python golden — the bit-exact reference for ``D = α·A·op(B) + β·C [, reduce]``.
+
+``execute(cmd, mem)`` runs a :class:`~examples.vmac.vmac_cmd.VmacCmd` over a shared-memory
+array, composing the merged ``FixedField`` / ``ComplexField`` operators (``mult`` / ``cmult``,
+``add`` / ``cadd``, ``conj``) for the multiply-accumulate, the wide-accumulator column
+reduction :func:`~waveflow.hw.complexfield.csum` for ``reduce_rows``, and the output
+requantize (right-shift ``SHIFT`` + round + saturate) via the ``ap_fixed``-exact integer
+requantizer.  Everything is **vectorized** — no per-element Python loop.
+
+The datapath: **multiply (IN_BW × IN_BW) → wide accumulate (full precision, ≤ ACC_BW) →
+right-shift SHIFT → round + saturate → write (OUT_BW)**.  The right-shift is the single
+lossy step; it is exactly an ``ap_fixed`` assignment, so the golden is bit-exact with the
+Vitis kernel (Phase 3).
+
+``mem`` is the shared memory: a 1-D ``int64`` array of stored integers (``real`` mode) or a
+1-D structured ``[('re','im')]`` array (``complex`` mode).  Operands are **strided** regions
+``M[i, j] = mem[addr + i·row_stride + j·col_stride]``.  ``execute`` writes the requantized
+result into ``mem`` at the ``d`` region (so commands compose) and returns the dst
+``DataArray``.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from examples.vmac.vmac_cmd import VmacCmd, VmacMode
+from waveflow.hw import fixpoint
+from waveflow.hw.complexfield import ComplexField, cadd, cmult, conj, csum
+from waveflow.hw.dataschema import DataArray
+from waveflow.hw.fixpoint import FixedField
+from waveflow.utils import complexutils as cx
+from waveflow.utils import fixputils
+from waveflow.utils.fixputils import Format, OMode, QMode
+
+
+def _q(cmd: VmacCmd) -> QMode:
+    return QMode.AP_RND if int(cmd.q_rnd) else QMode.AP_TRN
+
+
+def _o(cmd: VmacCmd) -> OMode:
+    return OMode.AP_SAT if int(cmd.o_sat) else OMode.AP_WRAP
+
+
+def _fixed_cls(fmt: Format) -> type[FixedField]:
+    return FixedField.specialize(fmt.W, fmt.int_bits, fmt.signed, fmt.q_mode, fmt.o_mode)
+
+
+def _region_idx(reg, n_rows: int, n_cols: int) -> np.ndarray:
+    """The strided index matrix for a region: ``addr + i·row_stride + j·col_stride``."""
+    rows = np.arange(n_rows)[:, None] * int(reg.row_stride)
+    cols = np.arange(n_cols)[None, :] * int(reg.col_stride)
+    return int(reg.addr) + rows + cols
+
+
+def _operand(M: np.ndarray, in_fmt: Format, complex_mode: bool) -> DataArray:
+    """Wrap a strided matrix view (stored ints / structured) as a DataArray operand."""
+    inner = _fixed_cls(in_fmt)
+    elem = ComplexField.specialize(inner) if complex_mode else inner
+    shape = M.shape if M.shape else (1,)
+    return DataArray.specialize(elem, max_shape=tuple(shape))(M)
+
+
+def _scalar(sc, n_cols: int, in_fmt: Format, mem: np.ndarray, complex_mode: bool) -> DataArray:
+    """Build an alpha/beta operand: direct immediate (shape (1,)) or indirect per-column."""
+    if int(sc.direct):
+        if complex_mode:
+            M = cx.make_complex([int(sc.re)], [int(sc.im)], in_fmt)
+        else:
+            M = np.array([int(sc.re)], dtype=np.int64)
+    else:
+        idx = int(sc.addr) + np.arange(n_cols) * int(sc.stride)
+        M = mem[idx]
+    return _operand(M, in_fmt, complex_mode)
+
+
+def _mult(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
+    return cmult(a, b) if complex_mode else fixpoint.mult(a, b)
+
+
+def _add(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
+    return cadd(a, b) if complex_mode else fixpoint.add(a, b)
+
+
+def _acc_width(t: DataArray, complex_mode: bool) -> int:
+    et = t.element_type
+    return et.inner_type.get_bitwidth() if complex_mode else et.get_bitwidth()
+
+
+def _requantize(t: DataArray, out_bw: int, shift: int, q: QMode, o: OMode,
+                complex_mode: bool) -> DataArray:
+    """Right-shift ``SHIFT`` + round + saturate to ``OUT_BW`` — the single lossy step,
+    an ``ap_fixed`` assignment via the integer requantizer."""
+    tf = t.element_type.inner_format() if complex_mode else t.element_type.get_format()
+    out_frac = tf.frac_bits - shift
+    if out_frac < 0:
+        raise ValueError(
+            f"SHIFT={shift} exceeds accumulator fractional bits {tf.frac_bits}; "
+            "the output would need more integer bits than OUT_BW.")
+    target = Format(out_bw, out_bw - out_frac, tf.signed, q, o)
+    if complex_mode:
+        re = fixputils.quantize(cx.re_of(t.val), tf, target)
+        im = fixputils.quantize(cx.im_of(t.val), tf, target)
+        elem = ComplexField.specialize(_fixed_cls(target))
+        struct = cx.make_complex(re, im, target)
+        return DataArray.specialize(elem, max_shape=struct.shape)(struct)
+    return fixpoint.quantize(t, _fixed_cls(target))
+
+
+def _writeback(mem: np.ndarray, reg, dst: DataArray, complex_mode: bool) -> None:
+    val = np.asarray(dst.val)
+    if val.ndim == 1:                                   # reduced -> single row of columns
+        idx = int(reg.addr) + np.arange(val.shape[0]) * int(reg.col_stride)
+    else:
+        idx = _region_idx(reg, val.shape[0], val.shape[1])
+    mem[idx] = val
+
+
+def execute(cmd: VmacCmd, mem: np.ndarray) -> DataArray:
+    """Execute a ``VmacCmd`` over ``mem``; write the dst region and return the dst array."""
+    mode = VmacMode(int(cmd.mode))
+    complex_mode = mode == VmacMode.COMPLEX
+    in_fmt = Format(int(cmd.in_bw), int(cmd.int_bits), True)
+    n, m = int(cmd.n_rows), int(cmd.n_cols)
+    mem = np.asarray(mem)
+
+    def region(reg) -> DataArray:
+        return _operand(mem[_region_idx(reg, n, m)], in_fmt, complex_mode)
+
+    # op(B) and A·op(B)
+    a = region(cmd.a)
+    if int(cmd.b_one):
+        ab = a
+    else:
+        b = region(cmd.b)
+        if int(cmd.b_conj) and complex_mode:            # conj is a no-op for real data
+            b = conj(b)
+        ab = _mult(a, b, complex_mode)
+
+    # alpha · A·op(B)
+    alpha = _scalar(cmd.alpha, m, in_fmt, mem, complex_mode)
+    t = _mult(alpha, ab, complex_mode)
+
+    # + beta · C
+    if not int(cmd.c_zero):
+        beta = _scalar(cmd.beta, m, in_fmt, mem, complex_mode)
+        t = _add(t, _mult(beta, region(cmd.c), complex_mode), complex_mode)
+
+    # optional row reduction (wide accumulator)
+    if int(cmd.reduce_rows):
+        t = csum(t, axis=0)
+
+    # accumulator-width budget check (the provisioned ACC_BW must hold full precision)
+    acc_w = _acc_width(t, complex_mode)
+    if acc_w > int(cmd.acc_bw):
+        raise ValueError(
+            f"accumulator width {acc_w} exceeds ACC_BW={int(cmd.acc_bw)}; widen ACC_BW.")
+
+    dst = _requantize(t, int(cmd.out_bw), int(cmd.shift), _q(cmd), _o(cmd), complex_mode)
+    _writeback(mem, cmd.d, dst, complex_mode)
+    return dst

--- a/examples/vmac/golden.py
+++ b/examples/vmac/golden.py
@@ -39,7 +39,7 @@ from waveflow.hw.dataschema import DataArray
 from waveflow.hw.fixpoint import FixedField
 from waveflow.utils import complexutils as cx
 from waveflow.utils import fixputils
-from waveflow.utils.fixputils import Format, OMode, QMode
+from waveflow.utils.fixputils import Format, add_format, mult_format, sum_format
 
 
 class VmacAccel:
@@ -125,29 +125,87 @@ class VmacAccel:
     def _add(a: DataArray, b: DataArray, complex_mode: bool) -> DataArray:
         return cadd(a, b) if complex_mode else fixpoint.add(a, b)
 
-    @staticmethod
-    def _acc_width(t: DataArray, complex_mode: bool) -> int:
-        et = t.element_type
-        return et.inner_type.get_bitwidth() if complex_mode else et.get_bitwidth()
+    # --- numeric model: datapath format derivation (the Phase-3 codegen spec) ----
+    @classmethod
+    def _in_fmt(cls, cmd: VmacCmd) -> Format:
+        """The operand ``FixedField`` format: ``W = data_bw`` (structural), ``I = int_bits``
+        (runtime), so ``F = data_bw - int_bits`` fractional bits."""
+        return Format(cls.data_bw, int(cmd.int_bits), signed=True)
 
     @classmethod
-    def _requantize(cls, t: DataArray, out_bw: int, shift: int, q: QMode, o: OMode,
-                    complex_mode: bool) -> DataArray:
-        """Right-shift ``shift`` + round + saturate to ``out_bw`` — the single lossy step."""
-        tf = t.element_type.inner_format() if complex_mode else t.element_type.get_format()
-        out_frac = tf.frac_bits - shift
+    def accumulator_format(cls, cmd: VmacCmd) -> Format:
+        """The wide-accumulator ``FixedField`` format for ``cmd`` — full precision, no loss.
+
+        Composes the datapath as pure format algebra (no data):
+
+        - **product** ``A·op(B)``: ``data_bw × data_bw`` (fraction bits add) — real uses
+          ``mult_format``, complex ``cmult_format`` (``sub_format``-based, +1 integer bit);
+        - **scale** by ``alpha``: one more multiply;
+        - **+ β·C**: aligned add (``add_format``) — fractions align, integer bits +1 (carry);
+        - **row reduction**: ``+⌈log₂ n_rows⌉`` integer bits (``sum_format``).
+
+        Fractional growth is identical for real and complex (complex's extra bit lands in
+        the *integer* part), so ``F_acc`` depends only on the multiply depth."""
+        complex_mode = VmacMode(int(cmd.mode)) == VmacMode.COMPLEX
+        mul = cx.cmult_format if complex_mode else mult_format
+        in_fmt = cls._in_fmt(cmd)
+        if bool(cmd.b_one):
+            ab = in_fmt                                         # op(B) = 1, A·op(B) = A
+        else:
+            op_b = in_fmt
+            if bool(cmd.b_conj) and complex_mode:               # conj grows the inner: (W+1, I+1)
+                op_b = cx.conj_format(in_fmt)
+            ab = mul(in_fmt, op_b)
+        acc = mul(in_fmt, ab)                                   # alpha · A·op(B)
+        if not bool(cmd.c_zero):
+            acc = add_format(acc, mul(in_fmt, in_fmt))          # + beta · C (aligned, +1 int bit)
+        if bool(cmd.reduce_rows):
+            acc = sum_format(acc, int(cmd.n_rows))              # + ceil(log2 n_rows) int bits
+        return acc
+
+    @classmethod
+    def output_format(cls, cmd: VmacCmd) -> type[FixedField]:
+        """The exact output (per-lane) ``FixedField`` for ``cmd`` — the Phase-3 codegen target.
+
+        The single lossy step is the right-shift ``SHIFT``, which picks the output binary
+        point: ``F_out = F_acc − SHIFT`` (so ``I_out = out_bw − F_out``), then round
+        (``q_mode``) + saturate (``o_mode``) into ``out_bw`` bits.  Fail-loud on a mis-sized
+        accelerator: an accumulator wider than ``acc_bw``, a ``SHIFT`` past the accumulator's
+        fractional bits, or an ``out_bw`` too small to hold the integer part.  (Complex
+        output is a ``ComplexField`` over this per-lane format.)"""
+        acc = cls.accumulator_format(cmd)
+        if acc.W > cls.acc_bw:
+            raise ValueError(
+                f"accumulator width {acc.W} exceeds acc_bw={cls.acc_bw}; widen acc_bw.")
+        shift = int(cmd.shift)
+        out_frac = acc.frac_bits - shift
         if out_frac < 0:
             raise ValueError(
-                f"shift={shift} exceeds accumulator fractional bits {tf.frac_bits}; "
-                "the output would need more integer bits than out_bw.")
-        target = Format(out_bw, out_bw - out_frac, tf.signed, q, o)
+                f"SHIFT={shift} exceeds accumulator fractional bits {acc.frac_bits}; "
+                "the right-shift would reach into the integer bits (SHIFT out of range).")
+        int_bits = cls.out_bw - out_frac
+        if int_bits < 0:
+            raise ValueError(
+                f"out_bw={cls.out_bw} is too small for the integer part: SHIFT={shift} keeps "
+                f"{out_frac} fractional bits, exceeding out_bw (need out_bw >= {out_frac}).")
+        # binary-point relationship: F_out = F_acc − SHIFT, hence I_out = out_bw − F_acc + SHIFT
+        assert int_bits == cls.out_bw - (acc.frac_bits - shift)
+        return FixedField.specialize(cls.out_bw, int_bits, acc.signed, cmd.q_mode, cmd.o_mode)
+
+    @classmethod
+    def _requantize(cls, t: DataArray, out_cls: type[FixedField], complex_mode: bool) -> DataArray:
+        """Requantize the wide accumulator ``t`` into the output ``FixedField`` ``out_cls`` —
+        right-shift + round + saturate, an ``ap_fixed`` assignment via the ``ap_fixed``-exact
+        integer requantizer (``fixputils.quantize``)."""
+        target = out_cls.get_format()
         if complex_mode:
-            re = fixputils.quantize(cx.re_of(t.val), tf, target)
-            im = fixputils.quantize(cx.im_of(t.val), tf, target)
-            elem = ComplexField.specialize(cls._fixed_cls(target))
+            src = t.element_type.inner_format()
+            re = fixputils.quantize(cx.re_of(t.val), src, target)
+            im = fixputils.quantize(cx.im_of(t.val), src, target)
+            elem = ComplexField.specialize(out_cls)
             struct = cx.make_complex(re, im, target)
             return DataArray.specialize(elem, max_shape=struct.shape)(struct)
-        return fixpoint.quantize(t, cls._fixed_cls(target))
+        return fixpoint.quantize(t, out_cls)
 
     @classmethod
     def _writeback(cls, mem: np.ndarray, reg, dst: DataArray) -> None:
@@ -163,9 +221,10 @@ class VmacAccel:
     def execute(cls, cmd: VmacCmd, mem: np.ndarray) -> DataArray:
         """Execute a ``VmacCmd`` over ``mem``; write the dst region and return the dst array."""
         complex_mode = VmacMode(int(cmd.mode)) == VmacMode.COMPLEX
-        in_fmt = Format(cls.data_bw, int(cmd.int_bits), True)
+        in_fmt = cls._in_fmt(cmd)
         n, m = int(cmd.n_rows), int(cmd.n_cols)
         mem = np.asarray(mem)
+        out_cls = cls.output_format(cmd)        # fail-loud config guards (acc_bw / SHIFT / out_bw)
 
         def region(reg) -> DataArray:
             return cls._operand(mem[cls._region_idx(reg, n, m)], in_fmt, complex_mode)
@@ -193,12 +252,14 @@ class VmacAccel:
         if bool(cmd.reduce_rows):
             t = csum(t, axis=0)
 
-        # accumulator-width budget check (the provisioned acc_bw must hold full precision)
-        acc_w = cls._acc_width(t, complex_mode)
-        if acc_w > cls.acc_bw:
-            raise ValueError(
-                f"accumulator width {acc_w} exceeds acc_bw={cls.acc_bw}; widen acc_bw.")
+        # invariant: the actual accumulator format must equal the derived spec (the format
+        # algebra in accumulator_format mirrors the operators it composes).
+        actual = t.element_type.inner_format() if complex_mode else t.element_type.get_format()
+        spec = cls.accumulator_format(cmd)
+        if (actual.W, actual.int_bits, actual.signed) != (spec.W, spec.int_bits, spec.signed):
+            raise AssertionError(
+                f"accumulator format mismatch: actual {actual} != derived {spec}")
 
-        dst = cls._requantize(t, cls.out_bw, int(cmd.shift), cmd.q_mode, cmd.o_mode, complex_mode)
+        dst = cls._requantize(t, out_cls, complex_mode)
         cls._writeback(mem, cmd.d, dst)
         return dst

--- a/examples/vmac/param_schema.py
+++ b/examples/vmac/param_schema.py
@@ -1,0 +1,67 @@
+"""``ParamSchema`` — a ``DataList`` whose field widths are set by named parameters.
+
+The **Level-1** parameterization stopgap (Phase 3.5).  A concrete schema declares:
+
+- ``_param_defaults`` — the parameter names mapped to their default values;
+- ``elements_for(**params)`` — a classmethod returning the ``elements`` dict for those values.
+
+The base supplies the rest: a generic cached :meth:`specialize` (builds a subclass with
+``elements = elements_for(**merged)``, cached so **same params → same class object** —
+stable schema identity for codegen, like ``IntField.specialize``) and, via
+``__init_subclass__``, the default ``elements`` (``elements_for(**_param_defaults)``).  So a
+parameterized schema collapses to just ``_param_defaults`` + ``elements_for`` — no
+hand-written ``specialize`` / cache / ``type()`` boilerplate.
+
+This is deliberately minimal and **temporary**.  The proper declarative design (Level 2 — a
+symbolic ``Param`` unified with ``HwParam``) is deferred; do not build on this.
+"""
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from waveflow.hw.dataschema import DataList
+
+
+class ParamSchema(DataList):
+    """Base for a ``DataList`` whose ``elements`` are a function of named parameters."""
+
+    _param_defaults: ClassVar[dict[str, Any]] = {}
+    _specializations: ClassVar[dict[Any, type["ParamSchema"]]] = {}
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # A *concrete* parameterized schema declares its own ``_param_defaults``; give it a
+        # fresh specialization cache and its default ``elements``.  Subclasses built BY
+        # ``specialize`` inherit the params and already carry their own ``elements`` (set in
+        # the ``type()`` call), so they are skipped here.
+        if "_param_defaults" in cls.__dict__:
+            cls._specializations = {}
+            cls.elements = cls.elements_for(**cls._param_defaults)
+
+    @classmethod
+    def elements_for(cls, **params: Any) -> dict[str, Any]:
+        """Return the ``elements`` dict for the given parameter values (override this)."""
+        raise NotImplementedError(f"{cls.__name__} must define elements_for(**params).")
+
+    @classmethod
+    def specialize(cls, **params: Any) -> type["ParamSchema"]:
+        """Return a cached subclass whose ``elements`` are built for ``params`` (defaults
+        filled in).  Keyword-only; same params → the same class object."""
+        unknown = set(params) - set(cls._param_defaults)
+        if unknown:
+            raise TypeError(
+                f"{cls.__name__}.specialize() got unknown param(s) {sorted(unknown)}; "
+                f"valid params: {sorted(cls._param_defaults)}.")
+        merged = {**cls._param_defaults, **params}
+        key = (cls, tuple(sorted(merged.items())))
+        cached = cls._specializations.get(key)
+        if cached is not None:
+            return cached
+        suffix = "_".join(f"{k}{merged[k]}" for k in sorted(merged))
+        specialized = type(f"{cls.__name__}_{suffix}", (cls,), {
+            "elements": cls.elements_for(**merged),
+            "__module__": cls.__module__,
+            "__doc__": cls.__doc__,
+        })
+        cls._specializations[key] = specialized
+        return specialized

--- a/examples/vmac/vmac_cmd.py
+++ b/examples/vmac/vmac_cmd.py
@@ -24,7 +24,8 @@ from __future__ import annotations
 from enum import IntEnum
 from typing import Any
 
-from waveflow.hw.dataschema import BooleanField, DataList, EnumField, IntField
+from examples.vmac.param_schema import ParamSchema
+from waveflow.hw.dataschema import BooleanField, EnumField, IntField
 from waveflow.utils.fixputils import OMode, QMode
 
 # --- field aliases (names match the auto-generated IntField subclass __name__) ----
@@ -32,10 +33,6 @@ UInt32 = IntField.specialize(32, signed=False)
 Int32 = IntField.specialize(32, signed=True)
 UInt16 = IntField.specialize(16, signed=False)
 UInt8 = IntField.specialize(8, signed=False)
-
-# default structural widths for an unspecialized schema (the accelerator overrides these)
-_DEFAULT_AWIDTH = 32
-_DEFAULT_DATA_BW = 32
 
 
 class VmacMode(IntEnum):
@@ -47,123 +44,80 @@ class VmacMode(IntEnum):
 ModeField = EnumField.specialize(VmacMode)
 
 
-# --- element builders (rebuilt from the structural widths) --------------------
-def _region_elements(mem_awidth: int) -> dict[str, Any]:
-    addr = IntField.specialize(mem_awidth, signed=False)
-    offset = IntField.specialize(mem_awidth, signed=True)
-    return {
-        "addr": {"schema": addr, "description": "base offset into shared memory"},
-        "row_stride": offset,
-        "col_stride": offset,
-    }
-
-
-def _scalar_elements(mem_awidth: int, data_bw: int) -> dict[str, Any]:
-    addr = IntField.specialize(mem_awidth, signed=False)
-    offset = IntField.specialize(mem_awidth, signed=True)
-    imm = IntField.specialize(data_bw, signed=True)
-    return {
-        "direct": {"schema": BooleanField, "description": "True = immediate re/im; False = indirect addr/stride"},
-        "re": imm,                    # immediate stored integer (real part), data_bw bits
-        "im": imm,                    # immediate stored integer (imag part; complex mode)
-        "addr": addr,
-        "stride": offset,
-    }
-
-
-class Region(DataList):
+# Region / Scalar / VmacCmd are width-parameterized schemas: each declares its parameter
+# defaults + an ``elements_for`` builder, and inherits the cached ``specialize`` from
+# :class:`ParamSchema` (Phase 3.5, Level-1 stopgap).
+class Region(ParamSchema):
     """A strided operand region: ``M[i, j] = mem[addr + i·row_stride + j·col_stride]``."""
-    elements = _region_elements(_DEFAULT_AWIDTH)
-    _specializations: dict[tuple[Any, ...], type[Region]] = {}
+    _param_defaults = {"mem_awidth": 32}
 
     @classmethod
-    def specialize(cls, mem_awidth: int) -> type[Region]:
-        """Return a cached ``Region`` whose ``addr`` / strides are ``mem_awidth`` bits."""
-        key = (cls, int(mem_awidth))
-        cached = cls._specializations.get(key)
-        if cached is not None:
-            return cached
-        sub = type(f"Region_a{mem_awidth}", (cls,), {
-            "elements": _region_elements(mem_awidth),
-            "__module__": cls.__module__,
-            "__doc__": cls.__doc__,
-        })
-        cls._specializations[key] = sub
-        return sub
+    def elements_for(cls, mem_awidth: int) -> dict[str, Any]:
+        addr = IntField.specialize(mem_awidth, signed=False)
+        offset = IntField.specialize(mem_awidth, signed=True)
+        return {
+            "addr": {"schema": addr, "description": "base offset into shared memory"},
+            "row_stride": offset,
+            "col_stride": offset,
+        }
 
 
-class Scalar(DataList):
+class Scalar(ParamSchema):
     """An ``alpha`` / ``beta`` operand: direct immediate (``re`` / ``im`` stored ints) or
     indirect (per-column pointer ``addr`` + ``stride``; ``stride 0`` broadcasts)."""
-    elements = _scalar_elements(_DEFAULT_AWIDTH, _DEFAULT_DATA_BW)
-    _specializations: dict[tuple[Any, ...], type[Scalar]] = {}
+    _param_defaults = {"mem_awidth": 32, "data_bw": 32}
 
     @classmethod
-    def specialize(cls, mem_awidth: int, data_bw: int) -> type[Scalar]:
-        """Return a cached ``Scalar`` (``addr`` = ``mem_awidth`` bits; ``re`` / ``im`` =
-        ``data_bw`` bits)."""
-        key = (cls, int(mem_awidth), int(data_bw))
-        cached = cls._specializations.get(key)
-        if cached is not None:
-            return cached
-        sub = type(f"Scalar_a{mem_awidth}_w{data_bw}", (cls,), {
-            "elements": _scalar_elements(mem_awidth, data_bw),
-            "__module__": cls.__module__,
-            "__doc__": cls.__doc__,
-        })
-        cls._specializations[key] = sub
-        return sub
+    def elements_for(cls, mem_awidth: int, data_bw: int) -> dict[str, Any]:
+        addr = IntField.specialize(mem_awidth, signed=False)
+        offset = IntField.specialize(mem_awidth, signed=True)
+        imm = IntField.specialize(data_bw, signed=True)
+        return {
+            "direct": {"schema": BooleanField,
+                       "description": "True = immediate re/im; False = indirect addr/stride"},
+            "re": imm,                # immediate stored integer (real part), data_bw bits
+            "im": imm,                # immediate stored integer (imag part; complex mode)
+            "addr": addr,
+            "stride": offset,
+        }
 
 
-def _cmd_elements(mem_awidth: int, data_bw: int) -> dict[str, Any]:
-    reg = Region.specialize(mem_awidth)
-    scalar = Scalar.specialize(mem_awidth, data_bw)
-    return {
-        # global matrix shape (operands share it; dst is (1, n_cols) when reduced)
-        "n_rows": UInt16,
-        "n_cols": UInt16,
-        # strided operand / destination regions
-        "a": reg,
-        "b": reg,
-        "c": reg,
-        "d": reg,
-        # scaling scalars
-        "alpha": scalar,
-        "beta": scalar,
-        # op flags
-        "b_one": {"schema": BooleanField, "description": "op(B) = 1 (skip the A·B multiply)"},
-        "c_zero": {"schema": BooleanField, "description": "drop the beta·C term"},
-        "b_conj": {"schema": BooleanField, "description": "op(B) = conj(B) (complex; no-op for real)"},
-        "reduce_rows": {"schema": BooleanField, "description": "sum the rows (per-column reduction)"},
-        # datapath mode + runtime numeric format
-        "mode": ModeField,
-        "int_bits": UInt8,            # I of the operand format (F = data_bw - int_bits)
-        "shift": UInt8,               # output right-shift (the single lossy step)
-        "q_rnd": {"schema": BooleanField, "description": "output rounding: False = AP_TRN, True = AP_RND"},
-        "o_sat": {"schema": BooleanField, "description": "output overflow: False = AP_WRAP, True = AP_SAT"},
-    }
+class VmacCmd(ParamSchema):
+    """The VMAC fused instruction — the runtime tier (see module docstring).
 
-
-class VmacCmd(DataList):
-    """The VMAC fused instruction — the runtime tier (see module docstring)."""
-    elements = _cmd_elements(_DEFAULT_AWIDTH, _DEFAULT_DATA_BW)
-    _specializations: dict[tuple[Any, ...], type[VmacCmd]] = {}
+    Region/scalar field widths track the accelerator's ``mem_awidth`` (addresses) and
+    ``data_bw`` (immediates); the cascade runs through ``Region`` / ``Scalar`` specialize.
+    """
+    _param_defaults = {"mem_awidth": 32, "data_bw": 32}
 
     @classmethod
-    def specialize(cls, mem_awidth: int, data_bw: int) -> type[VmacCmd]:
-        """Return a cached ``VmacCmd`` whose region/scalar field widths track the
-        accelerator's ``mem_awidth`` (addresses) and ``data_bw`` (immediates)."""
-        key = (cls, int(mem_awidth), int(data_bw))
-        cached = cls._specializations.get(key)
-        if cached is not None:
-            return cached
-        sub = type(f"VmacCmd_a{mem_awidth}_w{data_bw}", (cls,), {
-            "elements": _cmd_elements(mem_awidth, data_bw),
-            "__module__": cls.__module__,
-            "__doc__": cls.__doc__,
-        })
-        cls._specializations[key] = sub
-        return sub
+    def elements_for(cls, mem_awidth: int, data_bw: int) -> dict[str, Any]:
+        reg = Region.specialize(mem_awidth=mem_awidth)
+        scalar = Scalar.specialize(mem_awidth=mem_awidth, data_bw=data_bw)
+        return {
+            # global matrix shape (operands share it; dst is (1, n_cols) when reduced)
+            "n_rows": UInt16,
+            "n_cols": UInt16,
+            # strided operand / destination regions
+            "a": reg,
+            "b": reg,
+            "c": reg,
+            "d": reg,
+            # scaling scalars
+            "alpha": scalar,
+            "beta": scalar,
+            # op flags
+            "b_one": {"schema": BooleanField, "description": "op(B) = 1 (skip the A·B multiply)"},
+            "c_zero": {"schema": BooleanField, "description": "drop the beta·C term"},
+            "b_conj": {"schema": BooleanField, "description": "op(B) = conj(B) (complex; no-op for real)"},
+            "reduce_rows": {"schema": BooleanField, "description": "sum the rows (per-column reduction)"},
+            # datapath mode + runtime numeric format
+            "mode": ModeField,
+            "int_bits": UInt8,        # I of the operand format (F = data_bw - int_bits)
+            "shift": UInt8,           # output right-shift (the single lossy step)
+            "q_rnd": {"schema": BooleanField, "description": "output rounding: False = AP_TRN, True = AP_RND"},
+            "o_sat": {"schema": BooleanField, "description": "output overflow: False = AP_WRAP, True = AP_SAT"},
+        }
 
     @property
     def q_mode(self) -> QMode:

--- a/examples/vmac/vmac_cmd.py
+++ b/examples/vmac/vmac_cmd.py
@@ -1,0 +1,89 @@
+"""``VmacCmd`` — the VMAC fused-instruction DataSchema.
+
+A configurable vector MAC engine (VMAC) executes the fused op
+
+    D = alpha · A · op(B) + beta · C   [, reduced over rows]
+
+over a **strided** region of shared memory.  ``VmacCmd`` is the runtime instruction: the
+operand regions (addr + strides; the matrix shape is global), the ``alpha`` / ``beta``
+scalars (direct immediate or indirect pointer+stride, scalar or per-column), the op flags
+(``b_one`` / ``c_zero`` / ``b_conj``), the reduction axis, the ``real`` | ``complex`` mode,
+and the numeric format/parameters (``IN_BW`` / ``int_bits`` / ``OUT_BW`` / ``SHIFT`` /
+``ACC_BW`` + round/saturate).  It is a plain :class:`DataList`, so it serializes /
+deserializes (encode/decode round-trips) like any schema.
+
+The Python golden that *executes* a ``VmacCmd`` lives in :mod:`examples.vmac.golden`.
+"""
+from __future__ import annotations
+
+from enum import IntEnum
+
+from waveflow.hw.dataschema import DataList, EnumField, IntField
+
+# --- field aliases ------------------------------------------------------------
+U32 = IntField.specialize(32, signed=False)
+I32 = IntField.specialize(32, signed=True)
+U16 = IntField.specialize(16, signed=False)
+U8 = IntField.specialize(8, signed=False)
+U1 = IntField.specialize(1, signed=False)
+
+
+class VmacMode(IntEnum):
+    """Datapath mode — sets the element width (``IN_BW`` real / ``2·IN_BW`` complex)."""
+    REAL = 0
+    COMPLEX = 1
+
+
+ModeField = EnumField.specialize(VmacMode)
+
+
+class Region(DataList):
+    """A strided operand region: ``M[i, j] = mem[addr + i·row_stride + j·col_stride]``."""
+    elements = {
+        "addr": {"schema": U32, "description": "base offset into shared memory"},
+        "row_stride": I32,
+        "col_stride": I32,
+    }
+
+
+class Scalar(DataList):
+    """An ``alpha`` / ``beta`` operand: direct immediate (``re``/``im`` stored ints) or
+    indirect (per-column pointer ``addr`` + ``stride``; ``row_stride 0`` broadcasts)."""
+    elements = {
+        "direct": {"schema": U1, "description": "1 = immediate re/im; 0 = indirect addr/stride"},
+        "re": I32,                    # immediate stored integer (real part)
+        "im": I32,                    # immediate stored integer (imag part; complex mode)
+        "addr": U32,
+        "stride": I32,
+    }
+
+
+class VmacCmd(DataList):
+    """The VMAC fused instruction (see module docstring)."""
+    elements = {
+        # global matrix shape (operands share it; dst is (1, n_cols) when reduced)
+        "n_rows": U16,
+        "n_cols": U16,
+        # strided operand / destination regions
+        "a": Region,
+        "b": Region,
+        "c": Region,
+        "d": Region,
+        # scaling scalars
+        "alpha": Scalar,
+        "beta": Scalar,
+        # op flags
+        "b_one": {"schema": U1, "description": "op(B) = 1 (skip the A·B multiply)"},
+        "c_zero": {"schema": U1, "description": "drop the beta·C term"},
+        "b_conj": {"schema": U1, "description": "op(B) = conj(B) (complex; no-op for real)"},
+        "reduce_rows": {"schema": U1, "description": "sum the rows (per-column reduction)"},
+        # datapath mode + numeric format / parameters
+        "mode": ModeField,
+        "in_bw": U8,
+        "int_bits": U8,               # I of the operand format (F = in_bw - int_bits)
+        "out_bw": U8,
+        "shift": U8,                  # output right-shift (the single lossy step)
+        "acc_bw": U8,                 # accumulator width budget (golden asserts no overflow)
+        "q_rnd": {"schema": U1, "description": "output rounding: 0 = AP_TRN, 1 = AP_RND"},
+        "o_sat": {"schema": U1, "description": "output overflow: 0 = AP_WRAP, 1 = AP_SAT"},
+    }

--- a/examples/vmac/vmac_cmd.py
+++ b/examples/vmac/vmac_cmd.py
@@ -1,31 +1,41 @@
-"""``VmacCmd`` — the VMAC fused-instruction DataSchema.
+"""``VmacCmd`` — the VMAC fused-instruction DataSchema (runtime tier).
 
 A configurable vector MAC engine (VMAC) executes the fused op
 
     D = alpha · A · op(B) + beta · C   [, reduced over rows]
 
-over a **strided** region of shared memory.  ``VmacCmd`` is the runtime instruction: the
-operand regions (addr + strides; the matrix shape is global), the ``alpha`` / ``beta``
-scalars (direct immediate or indirect pointer+stride, scalar or per-column), the op flags
-(``b_one`` / ``c_zero`` / ``b_conj``), the reduction axis, the ``real`` | ``complex`` mode,
-and the numeric format/parameters (``IN_BW`` / ``int_bits`` / ``OUT_BW`` / ``SHIFT`` /
-``ACC_BW`` + round/saturate).  It is a plain :class:`DataList`, so it serializes /
-deserializes (encode/decode round-trips) like any schema.
+over a **strided** region of shared memory.  Parameters split into two tiers (see
+:class:`~examples.vmac.golden.VmacAccel`): the **structural** widths that size silicon
+(``mem_dwidth`` / ``mem_awidth`` / ``data_bw`` / ``acc_bw`` / ``out_bw``) live on the
+accelerator, and the **runtime** instruction lives here in ``VmacCmd``: the operand
+regions (addr + strides; the matrix shape is global), the ``alpha`` / ``beta`` scalars
+(direct immediate or indirect pointer+stride, scalar or per-column), the op flags
+(``b_one`` / ``c_zero`` / ``b_conj`` / ``reduce_rows``), the ``real`` | ``complex`` mode,
+the fractional split ``int_bits``, the output ``shift``, and the round / saturate flags.
 
-The Python golden that *executes* a ``VmacCmd`` lives in :mod:`examples.vmac.golden`.
+Because the command's field widths are set by the accelerator that produces/consumes it
+(``addr`` is ``mem_awidth`` bits; the immediate ``re`` / ``im`` are ``data_bw`` bits), the
+accelerator **specializes** the schema — the ``specialize`` parameterization pattern: params
+on the class, values on the instance.  ``VmacCmd`` stays a plain :class:`DataList`, so it
+serializes / deserializes and code-generates like any schema.
 """
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
-from waveflow.hw.dataschema import DataList, EnumField, IntField
+from waveflow.hw.dataschema import BooleanField, DataList, EnumField, IntField
+from waveflow.utils.fixputils import OMode, QMode
 
-# --- field aliases ------------------------------------------------------------
-U32 = IntField.specialize(32, signed=False)
-I32 = IntField.specialize(32, signed=True)
-U16 = IntField.specialize(16, signed=False)
-U8 = IntField.specialize(8, signed=False)
-U1 = IntField.specialize(1, signed=False)
+# --- field aliases (names match the auto-generated IntField subclass __name__) ----
+UInt32 = IntField.specialize(32, signed=False)
+Int32 = IntField.specialize(32, signed=True)
+UInt16 = IntField.specialize(16, signed=False)
+UInt8 = IntField.specialize(8, signed=False)
+
+# default structural widths for an unspecialized schema (the accelerator overrides these)
+_DEFAULT_AWIDTH = 32
+_DEFAULT_DATA_BW = 32
 
 
 class VmacMode(IntEnum):
@@ -37,53 +47,130 @@ class VmacMode(IntEnum):
 ModeField = EnumField.specialize(VmacMode)
 
 
-class Region(DataList):
-    """A strided operand region: ``M[i, j] = mem[addr + i·row_stride + j·col_stride]``."""
-    elements = {
-        "addr": {"schema": U32, "description": "base offset into shared memory"},
-        "row_stride": I32,
-        "col_stride": I32,
+# --- element builders (rebuilt from the structural widths) --------------------
+def _region_elements(mem_awidth: int) -> dict[str, Any]:
+    addr = IntField.specialize(mem_awidth, signed=False)
+    offset = IntField.specialize(mem_awidth, signed=True)
+    return {
+        "addr": {"schema": addr, "description": "base offset into shared memory"},
+        "row_stride": offset,
+        "col_stride": offset,
     }
 
 
+def _scalar_elements(mem_awidth: int, data_bw: int) -> dict[str, Any]:
+    addr = IntField.specialize(mem_awidth, signed=False)
+    offset = IntField.specialize(mem_awidth, signed=True)
+    imm = IntField.specialize(data_bw, signed=True)
+    return {
+        "direct": {"schema": BooleanField, "description": "True = immediate re/im; False = indirect addr/stride"},
+        "re": imm,                    # immediate stored integer (real part), data_bw bits
+        "im": imm,                    # immediate stored integer (imag part; complex mode)
+        "addr": addr,
+        "stride": offset,
+    }
+
+
+class Region(DataList):
+    """A strided operand region: ``M[i, j] = mem[addr + i·row_stride + j·col_stride]``."""
+    elements = _region_elements(_DEFAULT_AWIDTH)
+    _specializations: dict[tuple[Any, ...], type[Region]] = {}
+
+    @classmethod
+    def specialize(cls, mem_awidth: int) -> type[Region]:
+        """Return a cached ``Region`` whose ``addr`` / strides are ``mem_awidth`` bits."""
+        key = (cls, int(mem_awidth))
+        cached = cls._specializations.get(key)
+        if cached is not None:
+            return cached
+        sub = type(f"Region_a{mem_awidth}", (cls,), {
+            "elements": _region_elements(mem_awidth),
+            "__module__": cls.__module__,
+            "__doc__": cls.__doc__,
+        })
+        cls._specializations[key] = sub
+        return sub
+
+
 class Scalar(DataList):
-    """An ``alpha`` / ``beta`` operand: direct immediate (``re``/``im`` stored ints) or
-    indirect (per-column pointer ``addr`` + ``stride``; ``row_stride 0`` broadcasts)."""
-    elements = {
-        "direct": {"schema": U1, "description": "1 = immediate re/im; 0 = indirect addr/stride"},
-        "re": I32,                    # immediate stored integer (real part)
-        "im": I32,                    # immediate stored integer (imag part; complex mode)
-        "addr": U32,
-        "stride": I32,
+    """An ``alpha`` / ``beta`` operand: direct immediate (``re`` / ``im`` stored ints) or
+    indirect (per-column pointer ``addr`` + ``stride``; ``stride 0`` broadcasts)."""
+    elements = _scalar_elements(_DEFAULT_AWIDTH, _DEFAULT_DATA_BW)
+    _specializations: dict[tuple[Any, ...], type[Scalar]] = {}
+
+    @classmethod
+    def specialize(cls, mem_awidth: int, data_bw: int) -> type[Scalar]:
+        """Return a cached ``Scalar`` (``addr`` = ``mem_awidth`` bits; ``re`` / ``im`` =
+        ``data_bw`` bits)."""
+        key = (cls, int(mem_awidth), int(data_bw))
+        cached = cls._specializations.get(key)
+        if cached is not None:
+            return cached
+        sub = type(f"Scalar_a{mem_awidth}_w{data_bw}", (cls,), {
+            "elements": _scalar_elements(mem_awidth, data_bw),
+            "__module__": cls.__module__,
+            "__doc__": cls.__doc__,
+        })
+        cls._specializations[key] = sub
+        return sub
+
+
+def _cmd_elements(mem_awidth: int, data_bw: int) -> dict[str, Any]:
+    reg = Region.specialize(mem_awidth)
+    scalar = Scalar.specialize(mem_awidth, data_bw)
+    return {
+        # global matrix shape (operands share it; dst is (1, n_cols) when reduced)
+        "n_rows": UInt16,
+        "n_cols": UInt16,
+        # strided operand / destination regions
+        "a": reg,
+        "b": reg,
+        "c": reg,
+        "d": reg,
+        # scaling scalars
+        "alpha": scalar,
+        "beta": scalar,
+        # op flags
+        "b_one": {"schema": BooleanField, "description": "op(B) = 1 (skip the A·B multiply)"},
+        "c_zero": {"schema": BooleanField, "description": "drop the beta·C term"},
+        "b_conj": {"schema": BooleanField, "description": "op(B) = conj(B) (complex; no-op for real)"},
+        "reduce_rows": {"schema": BooleanField, "description": "sum the rows (per-column reduction)"},
+        # datapath mode + runtime numeric format
+        "mode": ModeField,
+        "int_bits": UInt8,            # I of the operand format (F = data_bw - int_bits)
+        "shift": UInt8,               # output right-shift (the single lossy step)
+        "q_rnd": {"schema": BooleanField, "description": "output rounding: False = AP_TRN, True = AP_RND"},
+        "o_sat": {"schema": BooleanField, "description": "output overflow: False = AP_WRAP, True = AP_SAT"},
     }
 
 
 class VmacCmd(DataList):
-    """The VMAC fused instruction (see module docstring)."""
-    elements = {
-        # global matrix shape (operands share it; dst is (1, n_cols) when reduced)
-        "n_rows": U16,
-        "n_cols": U16,
-        # strided operand / destination regions
-        "a": Region,
-        "b": Region,
-        "c": Region,
-        "d": Region,
-        # scaling scalars
-        "alpha": Scalar,
-        "beta": Scalar,
-        # op flags
-        "b_one": {"schema": U1, "description": "op(B) = 1 (skip the A·B multiply)"},
-        "c_zero": {"schema": U1, "description": "drop the beta·C term"},
-        "b_conj": {"schema": U1, "description": "op(B) = conj(B) (complex; no-op for real)"},
-        "reduce_rows": {"schema": U1, "description": "sum the rows (per-column reduction)"},
-        # datapath mode + numeric format / parameters
-        "mode": ModeField,
-        "in_bw": U8,
-        "int_bits": U8,               # I of the operand format (F = in_bw - int_bits)
-        "out_bw": U8,
-        "shift": U8,                  # output right-shift (the single lossy step)
-        "acc_bw": U8,                 # accumulator width budget (golden asserts no overflow)
-        "q_rnd": {"schema": U1, "description": "output rounding: 0 = AP_TRN, 1 = AP_RND"},
-        "o_sat": {"schema": U1, "description": "output overflow: 0 = AP_WRAP, 1 = AP_SAT"},
-    }
+    """The VMAC fused instruction — the runtime tier (see module docstring)."""
+    elements = _cmd_elements(_DEFAULT_AWIDTH, _DEFAULT_DATA_BW)
+    _specializations: dict[tuple[Any, ...], type[VmacCmd]] = {}
+
+    @classmethod
+    def specialize(cls, mem_awidth: int, data_bw: int) -> type[VmacCmd]:
+        """Return a cached ``VmacCmd`` whose region/scalar field widths track the
+        accelerator's ``mem_awidth`` (addresses) and ``data_bw`` (immediates)."""
+        key = (cls, int(mem_awidth), int(data_bw))
+        cached = cls._specializations.get(key)
+        if cached is not None:
+            return cached
+        sub = type(f"VmacCmd_a{mem_awidth}_w{data_bw}", (cls,), {
+            "elements": _cmd_elements(mem_awidth, data_bw),
+            "__module__": cls.__module__,
+            "__doc__": cls.__doc__,
+        })
+        cls._specializations[key] = sub
+        return sub
+
+    @property
+    def q_mode(self) -> QMode:
+        """The quantization mode this command selects (from its ``q_rnd`` flag)."""
+        return QMode.AP_RND if bool(self.q_rnd) else QMode.AP_TRN
+
+    @property
+    def o_mode(self) -> OMode:
+        """The overflow mode this command selects (from its ``o_sat`` flag)."""
+        return OMode.AP_SAT if bool(self.o_sat) else OMode.AP_WRAP

--- a/tests/examples/test_vmac_cmd.py
+++ b/tests/examples/test_vmac_cmd.py
@@ -127,12 +127,12 @@ def test_cmd_field_widths_track_mem_awidth_and_data_bw():
 
 
 def test_region_scalar_specialize_cached_and_sized():
-    assert Region.specialize(32) is Region.specialize(32)
-    assert Region.specialize(40) is not Region.specialize(32)
-    assert Region.specialize(40).get_element_schema("addr").get_bitwidth() == 40
-    assert Scalar.specialize(32, 16) is Scalar.specialize(32, 16)
-    assert Scalar.specialize(32, 16).get_element_schema("re").get_bitwidth() == 16
-    assert Scalar.specialize(32, 24).get_element_schema("re").get_bitwidth() == 24
+    assert Region.specialize(mem_awidth=32) is Region.specialize(mem_awidth=32)
+    assert Region.specialize(mem_awidth=40) is not Region.specialize(mem_awidth=32)
+    assert Region.specialize(mem_awidth=40).get_element_schema("addr").get_bitwidth() == 40
+    assert Scalar.specialize(mem_awidth=32, data_bw=16) is Scalar.specialize(mem_awidth=32, data_bw=16)
+    assert Scalar.specialize(mem_awidth=32, data_bw=16).get_element_schema("re").get_bitwidth() == 16
+    assert Scalar.specialize(mem_awidth=32, data_bw=24).get_element_schema("re").get_bitwidth() == 24
 
 
 def test_in_bw_out_bw_acc_bw_removed_from_cmd():

--- a/tests/examples/test_vmac_cmd.py
+++ b/tests/examples/test_vmac_cmd.py
@@ -1,16 +1,25 @@
-"""Phase-1 VMAC command tests — ``VmacCmd`` encode/decode round-trips.
+"""VMAC command/accelerator tests — encode/decode round-trips + the ``specialize`` cascade.
 
-``VmacCmd`` is a plain ``DataList`` (with nested ``Region`` / ``Scalar`` sub-lists and an
-``EnumField`` mode), so it must serialize and deserialize back to an identical value across
-word widths — the wire-format contract for the (Phase-3) HLS kernel.
+``VmacCmd`` is a plain ``DataList`` (nested ``Region`` / ``Scalar`` sub-lists, an
+``EnumField`` mode, ``BooleanField`` flags), so it must serialize / deserialize back to an
+identical value across word widths — the wire-format contract for the (Phase-3) HLS kernel.
+The structural widths live on ``VmacAccel``, which ``specialize``s the command schema so a
+command's field widths track the silicon (``addr`` = ``mem_awidth`` bits; immediate ``re`` /
+``im`` = ``data_bw`` bits); same params → same class object.
 """
 import pytest
 
+from examples.vmac.golden import VmacAccel
 from examples.vmac.vmac_cmd import Region, Scalar, VmacCmd, VmacMode
+from waveflow.utils.fixputils import OMode, QMode
+
+# a concrete accelerator: 32-bit addresses, 16-bit operands/immediates
+ACCEL = VmacAccel.specialize(mem_dwidth=512, mem_awidth=32, data_bw=16, acc_bw=48, out_bw=12)
+Cmd = ACCEL.Cmd
 
 
-def _full_cmd() -> VmacCmd:
-    cmd = VmacCmd()
+def _full_cmd():
+    cmd = Cmd()
     cmd.n_rows, cmd.n_cols = 6, 4
     cmd.a = {"addr": 0, "row_stride": 4, "col_stride": 1}
     cmd.b = {"addr": 24, "row_stride": 4, "col_stride": 1}
@@ -20,16 +29,16 @@ def _full_cmd() -> VmacCmd:
     cmd.beta = {"direct": 0, "re": 0, "im": 0, "addr": 96, "stride": 1}
     cmd.b_one, cmd.c_zero, cmd.b_conj, cmd.reduce_rows = 0, 1, 1, 1
     cmd.mode = VmacMode.COMPLEX
-    cmd.in_bw, cmd.int_bits, cmd.out_bw = 16, 8, 12
-    cmd.shift, cmd.acc_bw = 13, 48
+    cmd.int_bits, cmd.shift = 8, 13
     cmd.q_rnd, cmd.o_sat = 1, 1
     return cmd
 
 
+# --- encode / decode round-trips ----------------------------------------------
 @pytest.mark.parametrize("word_bw", [16, 32, 64])
 def test_vmac_cmd_roundtrip(word_bw):
     cmd = _full_cmd()
-    restored = VmacCmd().deserialize(cmd.serialize(word_bw), word_bw)
+    restored = Cmd().deserialize(cmd.serialize(word_bw), word_bw)
     assert restored.val == cmd.val
 
 
@@ -41,27 +50,92 @@ def test_nested_region_scalar_roundtrip():
     sc = Scalar(direct=1, re=-100, im=77, addr=5, stride=-1)
     s2 = Scalar().deserialize(sc.serialize(32), 32)
     assert s2.val == sc.val
+    assert s2.direct is True                                     # BooleanField -> Python bool
 
 
 def test_default_cmd_roundtrips():
-    cmd = VmacCmd()                                              # all defaults / zeros
-    restored = VmacCmd().deserialize(cmd.serialize(32), 32)
+    cmd = Cmd()                                                  # all defaults / zeros
+    restored = Cmd().deserialize(cmd.serialize(32), 32)
     assert restored.val == cmd.val
 
 
 def test_mode_enum_field_roundtrips_both_values():
     for mode in (VmacMode.REAL, VmacMode.COMPLEX):
-        cmd = VmacCmd()
+        cmd = Cmd()
         cmd.mode = mode
-        restored = VmacCmd().deserialize(cmd.serialize(32), 32)
+        restored = Cmd().deserialize(cmd.serialize(32), 32)
         assert int(restored.mode) == int(mode)
 
 
 def test_signed_fields_preserve_negatives():
     cmd = _full_cmd()
     cmd.a = {"addr": 10, "row_stride": -4, "col_stride": -1}
-    cmd.alpha = {"direct": 1, "re": -32768, "im": -1, "addr": 0, "stride": 0}
-    restored = VmacCmd().deserialize(cmd.serialize(32), 32)
+    cmd.alpha = {"direct": 1, "re": -32768, "im": -1, "addr": 0, "stride": 0}  # data_bw=16 range
+    restored = Cmd().deserialize(cmd.serialize(32), 32)
     assert restored.a.row_stride == -4 and restored.a.col_stride == -1
     assert restored.alpha.re == -32768 and restored.alpha.im == -1
     assert restored.val == cmd.val
+
+
+def test_flags_are_booleanfields():
+    cmd = _full_cmd()
+    for flag in (cmd.b_one, cmd.c_zero, cmd.b_conj, cmd.reduce_rows, cmd.q_rnd, cmd.o_sat):
+        assert isinstance(flag, bool)
+    assert cmd.c_zero is True and cmd.b_one is False
+
+
+def test_q_o_mode_properties():
+    cmd = Cmd()
+    cmd.q_rnd, cmd.o_sat = 0, 0
+    assert cmd.q_mode is QMode.AP_TRN and cmd.o_mode is OMode.AP_WRAP
+    cmd.q_rnd, cmd.o_sat = 1, 1
+    assert cmd.q_mode is QMode.AP_RND and cmd.o_mode is OMode.AP_SAT
+
+
+# --- the specialize cascade ---------------------------------------------------
+def test_accel_specialize_is_cached():
+    a = VmacAccel.specialize(mem_dwidth=512, mem_awidth=32, data_bw=16, acc_bw=48, out_bw=12)
+    b = VmacAccel.specialize(mem_dwidth=512, mem_awidth=32, data_bw=16, acc_bw=48, out_bw=12)
+    assert a is b is ACCEL                                       # same params -> same class
+    c = VmacAccel.specialize(mem_dwidth=512, mem_awidth=24, data_bw=12, acc_bw=48, out_bw=12)
+    assert c is not a
+
+
+def test_accel_carries_structural_params():
+    assert (ACCEL.mem_dwidth, ACCEL.mem_awidth, ACCEL.data_bw, ACCEL.acc_bw, ACCEL.out_bw) \
+        == (512, 32, 16, 48, 12)
+
+
+def test_cmd_specialize_cached_and_matches_accel():
+    assert ACCEL.Cmd is VmacCmd.specialize(mem_awidth=32, data_bw=16)
+    assert VmacCmd.specialize(mem_awidth=32, data_bw=16) is VmacCmd.specialize(mem_awidth=32, data_bw=16)
+    assert issubclass(ACCEL.Cmd, VmacCmd)
+
+
+def test_cmd_field_widths_track_mem_awidth_and_data_bw():
+    # addr (and strides) follow mem_awidth; immediate re/im follow data_bw
+    region = ACCEL.Cmd.get_element_schema("a")
+    scalar = ACCEL.Cmd.get_element_schema("alpha")
+    assert region.get_element_schema("addr").get_bitwidth() == 32
+    assert region.get_element_schema("row_stride").get_bitwidth() == 32
+    assert scalar.get_element_schema("re").get_bitwidth() == 16
+    assert scalar.get_element_schema("im").get_bitwidth() == 16
+
+    wide = VmacAccel.specialize(mem_dwidth=256, mem_awidth=40, data_bw=24, acc_bw=64, out_bw=24)
+    assert wide.Cmd.get_element_schema("a").get_element_schema("addr").get_bitwidth() == 40
+    assert wide.Cmd.get_element_schema("alpha").get_element_schema("re").get_bitwidth() == 24
+
+
+def test_region_scalar_specialize_cached_and_sized():
+    assert Region.specialize(32) is Region.specialize(32)
+    assert Region.specialize(40) is not Region.specialize(32)
+    assert Region.specialize(40).get_element_schema("addr").get_bitwidth() == 40
+    assert Scalar.specialize(32, 16) is Scalar.specialize(32, 16)
+    assert Scalar.specialize(32, 16).get_element_schema("re").get_bitwidth() == 16
+    assert Scalar.specialize(32, 24).get_element_schema("re").get_bitwidth() == 24
+
+
+def test_in_bw_out_bw_acc_bw_removed_from_cmd():
+    fields = set(VmacCmd.elements)
+    assert {"in_bw", "out_bw", "acc_bw"}.isdisjoint(fields)     # moved to the accelerator
+    assert {"int_bits", "shift", "q_rnd", "o_sat"} <= fields    # runtime params stay

--- a/tests/examples/test_vmac_cmd.py
+++ b/tests/examples/test_vmac_cmd.py
@@ -1,0 +1,67 @@
+"""Phase-1 VMAC command tests — ``VmacCmd`` encode/decode round-trips.
+
+``VmacCmd`` is a plain ``DataList`` (with nested ``Region`` / ``Scalar`` sub-lists and an
+``EnumField`` mode), so it must serialize and deserialize back to an identical value across
+word widths — the wire-format contract for the (Phase-3) HLS kernel.
+"""
+import pytest
+
+from examples.vmac.vmac_cmd import Region, Scalar, VmacCmd, VmacMode
+
+
+def _full_cmd() -> VmacCmd:
+    cmd = VmacCmd()
+    cmd.n_rows, cmd.n_cols = 6, 4
+    cmd.a = {"addr": 0, "row_stride": 4, "col_stride": 1}
+    cmd.b = {"addr": 24, "row_stride": 4, "col_stride": 1}
+    cmd.c = {"addr": 48, "row_stride": 1, "col_stride": 6}        # transposed access
+    cmd.d = {"addr": 72, "row_stride": 4, "col_stride": 1}
+    cmd.alpha = {"direct": 1, "re": -16, "im": 8, "addr": 0, "stride": 0}
+    cmd.beta = {"direct": 0, "re": 0, "im": 0, "addr": 96, "stride": 1}
+    cmd.b_one, cmd.c_zero, cmd.b_conj, cmd.reduce_rows = 0, 1, 1, 1
+    cmd.mode = VmacMode.COMPLEX
+    cmd.in_bw, cmd.int_bits, cmd.out_bw = 16, 8, 12
+    cmd.shift, cmd.acc_bw = 13, 48
+    cmd.q_rnd, cmd.o_sat = 1, 1
+    return cmd
+
+
+@pytest.mark.parametrize("word_bw", [16, 32, 64])
+def test_vmac_cmd_roundtrip(word_bw):
+    cmd = _full_cmd()
+    restored = VmacCmd().deserialize(cmd.serialize(word_bw), word_bw)
+    assert restored.val == cmd.val
+
+
+def test_nested_region_scalar_roundtrip():
+    reg = Region(addr=12, row_stride=-3, col_stride=2)           # negative stride survives
+    r2 = Region().deserialize(reg.serialize(32), 32)
+    assert r2.val == reg.val == {"addr": 12, "row_stride": -3, "col_stride": 2}
+
+    sc = Scalar(direct=1, re=-100, im=77, addr=5, stride=-1)
+    s2 = Scalar().deserialize(sc.serialize(32), 32)
+    assert s2.val == sc.val
+
+
+def test_default_cmd_roundtrips():
+    cmd = VmacCmd()                                              # all defaults / zeros
+    restored = VmacCmd().deserialize(cmd.serialize(32), 32)
+    assert restored.val == cmd.val
+
+
+def test_mode_enum_field_roundtrips_both_values():
+    for mode in (VmacMode.REAL, VmacMode.COMPLEX):
+        cmd = VmacCmd()
+        cmd.mode = mode
+        restored = VmacCmd().deserialize(cmd.serialize(32), 32)
+        assert int(restored.mode) == int(mode)
+
+
+def test_signed_fields_preserve_negatives():
+    cmd = _full_cmd()
+    cmd.a = {"addr": 10, "row_stride": -4, "col_stride": -1}
+    cmd.alpha = {"direct": 1, "re": -32768, "im": -1, "addr": 0, "stride": 0}
+    restored = VmacCmd().deserialize(cmd.serialize(32), 32)
+    assert restored.a.row_stride == -4 and restored.a.col_stride == -1
+    assert restored.alpha.re == -32768 and restored.alpha.im == -1
+    assert restored.val == cmd.val

--- a/tests/examples/test_vmac_golden.py
+++ b/tests/examples/test_vmac_golden.py
@@ -1,0 +1,351 @@
+"""Phase-1 VMAC golden tests — bit-level results for every config vs an independent oracle.
+
+The production golden (:func:`examples.vmac.golden.execute`) composes the integer-backed
+numpy ``FixedField`` / ``ComplexField`` operators.  The **oracle** here is independent: it
+works in exact rational (``Fraction``) space over ``(re, im)`` pairs, computes the
+accumulator value exactly (full precision), then quantizes once with the right-shift
+``SHIFT`` → round → saturate spec.  Two independent implementations of the same datapath
+must agree bit-for-bit.  A few literal hand-checked outputs anchor the oracle.
+
+Operands are supplied as **stored integers** at fractional scale ``F = in_bw - int_bits``;
+real value = ``stored · 2**-F`` (exact).  Real mode carries ``im = 0`` throughout, so one
+oracle covers both modes.
+"""
+import math
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+from examples.vmac.golden import execute
+from examples.vmac.vmac_cmd import VmacCmd, VmacMode
+from waveflow.utils import complexutils as cx
+from waveflow.utils.fixputils import Format
+
+
+# --- exact (re, im) Fraction complex arithmetic -------------------------------
+def _cmul(a, b):
+    (ar, ai), (br, bi) = a, b
+    return (ar * br - ai * bi, ar * bi + ai * br)
+
+
+def _cadd(a, b):
+    return (a[0] + b[0], a[1] + b[1])
+
+
+def _conj(a):
+    return (a[0], -a[1])
+
+
+def _q_real(value: Fraction, out_frac: int, W: int, q_rnd: bool, o_sat: bool) -> int:
+    """Quantize an exact real ``value`` to ``W`` bits at ``out_frac`` frac bits, signed."""
+    scaled = value * (Fraction(2) ** out_frac)
+    f = math.floor(scaled + Fraction(1, 2)) if q_rnd else math.floor(scaled)
+    if o_sat:
+        return max(-(1 << (W - 1)), min((1 << (W - 1)) - 1, f))
+    y = f & ((1 << W) - 1)
+    return y - (1 << W) if (y >> (W - 1)) & 1 else y
+
+
+# --- the oracle (independent of the production golden) ------------------------
+def oracle(cfg, a, b, c, alpha, beta):
+    """a/b/c: (n, m) stored-int pairs (re, im arrays); alpha/beta: (re, im) scalars or
+    per-column (m,) arrays.  Returns the expected dst stored ints — (n,m) or (m,) reduced —
+    as a pair (re, im) of int arrays (im all-zero for real mode)."""
+    F = cfg["in_bw"] - cfg["int_bits"]
+    scale = Fraction(2) ** F
+    n, m = a[0].shape
+
+    def fr(stored):
+        return Fraction(int(stored), 1) / scale
+
+    def at(operand, i, j):
+        return (fr(operand[0][i, j]), fr(operand[1][i, j]))
+
+    def scal(s, j):
+        if np.ndim(s[0]) == 0:
+            return (fr(s[0]), fr(s[1]))
+        return (fr(s[0][j]), fr(s[1][j]))
+
+    F_acc = (2 if cfg["b_one"] else 3) * F
+    out_frac = F_acc - cfg["shift"]
+
+    cols_re, cols_im = [], []
+    for j in range(m):
+        terms = []
+        for i in range(n):
+            av = at(a, i, j)
+            if cfg["b_one"]:
+                ab = av
+            else:
+                bv = at(b, i, j)
+                if cfg["b_conj"]:
+                    bv = _conj(bv)
+                ab = _cmul(av, bv)
+            t = _cmul(scal(alpha, j), ab)
+            if not cfg["c_zero"]:
+                t = _cadd(t, _cmul(scal(beta, j), at(c, i, j)))
+            terms.append(t)
+        acc = terms[0]
+        if cfg["reduce_rows"]:
+            for t in terms[1:]:
+                acc = _cadd(acc, t)
+            rows = [acc]
+        else:
+            rows = terms
+        col_re = [_q_real(r[0], out_frac, cfg["out_bw"], cfg["q_rnd"], cfg["o_sat"]) for r in rows]
+        col_im = [_q_real(r[1], out_frac, cfg["out_bw"], cfg["q_rnd"], cfg["o_sat"]) for r in rows]
+        cols_re.append(col_re)
+        cols_im.append(col_im)
+    re = np.array(cols_re, dtype=np.int64).T          # (rows, m)
+    im = np.array(cols_im, dtype=np.int64).T
+    if cfg["reduce_rows"]:
+        re, im = re[0], im[0]                          # (m,)
+    return re, im
+
+
+# --- harness: lay operands into mem + build the matching VmacCmd --------------
+def _flat(pair_or_arr, complex_mode):
+    """Flatten an operand to mem slots (row-major): structured for complex, int for real."""
+    re = np.asarray(pair_or_arr[0]).ravel()
+    if complex_mode:
+        im = np.asarray(pair_or_arr[1]).ravel()
+        return cx.make_complex(re, im, Format(8, 4, True))   # dtype only; format irrelevant here
+    return re.astype(np.int64)
+
+
+def build(cfg, a, b, c, alpha, beta):
+    """Lay a/b/c (+ per-column alpha/beta) into mem and build the VmacCmd. Returns (cmd, mem)."""
+    complex_mode = cfg["mode"] == VmacMode.COMPLEX
+    n, m = a[0].shape
+    nm = n * m
+    blocks, addr = [], {}
+    cur = 0
+    for name, op in (("a", a), ("b", b), ("c", c)):
+        addr[name] = cur
+        blocks.append(_flat(op, complex_mode))
+        cur += nm
+    alpha_pc = np.ndim(alpha[0]) > 0
+    beta_pc = np.ndim(beta[0]) > 0
+    if alpha_pc:
+        addr["alpha"] = cur
+        blocks.append(_flat((alpha[0], alpha[1] if complex_mode else np.zeros(m)), complex_mode))
+        cur += m
+    if beta_pc:
+        addr["beta"] = cur
+        blocks.append(_flat((beta[0], beta[1] if complex_mode else np.zeros(m)), complex_mode))
+        cur += m
+    addr["d"] = cur
+    cur += nm
+    if complex_mode:
+        mem = cx.make_complex(np.zeros(cur), np.zeros(cur), Format(8, 4, True))
+    else:
+        mem = np.zeros(cur, dtype=np.int64)
+    # write each block at its address (row-major)
+    order = ["a", "b", "c"] + (["alpha"] if alpha_pc else []) + (["beta"] if beta_pc else [])
+    for name, blk in zip(order, blocks):
+        mem[addr[name]:addr[name] + len(blk)] = blk
+
+    cmd = VmacCmd()
+    cmd.n_rows, cmd.n_cols = n, m
+    cmd.a = {"addr": addr["a"], "row_stride": m, "col_stride": 1}
+    cmd.b = {"addr": addr["b"], "row_stride": m, "col_stride": 1}
+    cmd.c = {"addr": addr["c"], "row_stride": m, "col_stride": 1}
+    cmd.d = {"addr": addr["d"], "row_stride": m, "col_stride": 1}
+    cmd.alpha = _scalar_field(alpha, addr.get("alpha"), complex_mode)
+    cmd.beta = _scalar_field(beta, addr.get("beta"), complex_mode)
+    for f in ("b_one", "c_zero", "b_conj", "reduce_rows", "mode", "in_bw", "int_bits",
+              "out_bw", "shift", "q_rnd", "o_sat"):
+        setattr(cmd, f, cfg[f])
+    cmd.acc_bw = cfg.get("acc_bw", 48)
+    return cmd, mem
+
+
+def _scalar_field(s, addr, complex_mode):
+    if np.ndim(s[0]) == 0:
+        return {"direct": 1, "re": int(s[0]), "im": int(s[1]) if complex_mode else 0,
+                "addr": 0, "stride": 0}
+    return {"direct": 0, "re": 0, "im": 0, "addr": int(addr), "stride": 1}
+
+
+def run(cfg, a, b, c, alpha, beta):
+    cmd, mem = build(cfg, a, b, c, alpha, beta)
+    dst = execute(cmd, mem)
+    exp_re, exp_im = oracle(cfg, a, b, c, alpha, beta)
+    if cfg["mode"] == VmacMode.COMPLEX:
+        got_re, got_im = np.asarray(dst.val["re"]), np.asarray(dst.val["im"])
+    else:
+        got_re = np.asarray(dst.val)
+        got_im = np.zeros_like(got_re)
+    return (got_re, got_im), (exp_re, exp_im)
+
+
+# --- operand helpers ----------------------------------------------------------
+def _pair(re, im=None):
+    re = np.asarray(re, dtype=np.int64)
+    im = np.zeros_like(re) if im is None else np.asarray(im, dtype=np.int64)
+    return (re, im)
+
+
+REAL = VmacMode.REAL
+CPLX = VmacMode.COMPLEX
+
+
+def _cfg(**kw):
+    base = dict(mode=REAL, in_bw=8, int_bits=4, out_bw=8, shift=4, acc_bw=48,
+                b_one=0, c_zero=0, b_conj=0, reduce_rows=0, q_rnd=0, o_sat=0)
+    base.update(kw)
+    return base
+
+
+# --- literal hand-checked anchors --------------------------------------------
+def test_scaled_copy_literal():
+    # dst = 1.0 * a, F=4: alpha=16 (=1.0); a=[1.5,2.0]=[24,32] -> dst=[24,32]
+    cfg = _cfg(b_one=1, c_zero=1, shift=4)
+    a = _pair([[24, 32]])
+    (gr, _), (er, _) = run(cfg, a, _pair([[0, 0]]), _pair([[0, 0]]), _pair(16), _pair(0))
+    np.testing.assert_array_equal(gr, [[24, 32]])
+    np.testing.assert_array_equal(gr, er)
+
+
+def test_hadamard_literal():
+    # dst = a*b, alpha=1.0, c_zero. a=[2.0]=32, b=[1.5]=24 -> 3.0; F_acc=3*4=12, shift=8 -> F_out=4
+    cfg = _cfg(c_zero=1, shift=8)
+    a, b = _pair([[32]]), _pair([[24]])
+    (gr, _), (er, _) = run(cfg, a, b, _pair([[0]]), _pair(16), _pair(0))
+    np.testing.assert_array_equal(gr, [[48]])      # 3.0 at F=4 = 48
+    np.testing.assert_array_equal(gr, er)
+
+
+def test_column_sum_literal():
+    # b_one, c_zero, alpha=1, reduce=rows: dst = sum_rows(a). a col=[1.0,2.0,0.5]=[16,32,8] -> 3.5=56
+    cfg = _cfg(b_one=1, c_zero=1, reduce_rows=1, shift=4)
+    a = _pair([[16], [32], [8]])
+    (gr, _), (er, _) = run(cfg, a, _pair(np.zeros((3, 1))), _pair(np.zeros((3, 1))),
+                           _pair(16), _pair(0))
+    np.testing.assert_array_equal(gr, [56])
+    np.testing.assert_array_equal(gr, er)
+
+
+# --- config sweep vs the oracle (real) ----------------------------------------
+@pytest.mark.parametrize("q_rnd,o_sat", [(0, 0), (1, 0), (0, 1), (1, 1)])
+def test_real_configs_vs_oracle(q_rnd, o_sat):
+    rng = np.random.default_rng(1)
+    n, m = 4, 3
+    a = _pair(rng.integers(-120, 121, (n, m)))
+    b = _pair(rng.integers(-120, 121, (n, m)))
+    c = _pair(rng.integers(-120, 121, (n, m)))
+    alpha_s, beta_s = _pair(20), _pair(-12)
+    alpha_pc = _pair(rng.integers(-40, 41, m))
+    beta_pc = _pair(rng.integers(-40, 41, m))
+    configs = [
+        _cfg(b_one=1, c_zero=1, shift=4, q_rnd=q_rnd, o_sat=o_sat),                  # scaled copy
+        _cfg(c_zero=1, shift=8, q_rnd=q_rnd, o_sat=o_sat),                           # hadamard
+        _cfg(shift=8, q_rnd=q_rnd, o_sat=o_sat),                                     # full MAC
+        _cfg(b_one=1, shift=4, q_rnd=q_rnd, o_sat=o_sat),                            # alpha*a + beta*c
+        _cfg(b_one=1, c_zero=1, reduce_rows=1, shift=4, q_rnd=q_rnd, o_sat=o_sat),   # column sum
+        _cfg(shift=8, reduce_rows=1, q_rnd=q_rnd, o_sat=o_sat),                      # reduced MAC
+    ]
+    for cfg in configs:
+        for al, be in [(alpha_s, beta_s), (alpha_pc, beta_pc)]:           # scalar + per-column
+            got, exp = run(cfg, a, b, c, al, be)
+            np.testing.assert_array_equal(got[0], exp[0], err_msg=f"{cfg} re")
+
+
+# --- config sweep vs the oracle (complex) -------------------------------------
+@pytest.mark.parametrize("q_rnd,o_sat", [(0, 0), (1, 1)])
+def test_complex_configs_vs_oracle(q_rnd, o_sat):
+    rng = np.random.default_rng(2)
+    n, m = 4, 3
+    def cop():
+        return _pair(rng.integers(-60, 61, (n, m)), rng.integers(-60, 61, (n, m)))
+    a, b, c = cop(), cop(), cop()
+    alpha_s = _pair(20, -8)
+    beta_s = _pair(-12, 5)
+    alpha_pc = _pair(rng.integers(-30, 31, m), rng.integers(-30, 31, m))
+    beta_pc = _pair(rng.integers(-30, 31, m), rng.integers(-30, 31, m))
+    configs = [
+        _cfg(mode=CPLX, b_one=1, c_zero=1, shift=4, q_rnd=q_rnd, o_sat=o_sat),
+        _cfg(mode=CPLX, c_zero=1, shift=8, q_rnd=q_rnd, o_sat=o_sat),
+        _cfg(mode=CPLX, b_conj=1, c_zero=1, shift=8, q_rnd=q_rnd, o_sat=o_sat),       # conj
+        _cfg(mode=CPLX, shift=8, q_rnd=q_rnd, o_sat=o_sat),                           # full MAC
+        _cfg(mode=CPLX, b_conj=1, c_zero=1, reduce_rows=1, shift=8, q_rnd=q_rnd, o_sat=o_sat),
+        _cfg(mode=CPLX, shift=8, reduce_rows=1, q_rnd=q_rnd, o_sat=o_sat),
+    ]
+    for cfg in configs:
+        for al, be in [(alpha_s, beta_s), (alpha_pc, beta_pc)]:
+            got, exp = run(cfg, a, b, c, al, be)
+            np.testing.assert_array_equal(got[0], exp[0], err_msg=f"{cfg} re")
+            np.testing.assert_array_equal(got[1], exp[1], err_msg=f"{cfg} im")
+
+
+# --- saturation + rounding are actually exercised -----------------------------
+def test_saturation_triggered():
+    # large product saturates at OUT_BW=8 signed: max=127. alpha=8.0, a=8.0 -> 64.0 >> ... saturates
+    cfg = _cfg(c_zero=1, shift=4, o_sat=1)               # F_acc=3*4=12, shift=4 -> F_out=8 (range +-8)
+    a, b = _pair([[112]]), _pair([[112]])               # 7.0 * 7.0 = 49 >> way over +-8 range
+    (gr, _), (er, _) = run(cfg, a, b, _pair([[0]]), _pair(16), _pair(0))
+    assert gr[0, 0] == 127                                # saturated to OUT_BW max
+    np.testing.assert_array_equal(gr, er)
+
+
+def test_rounding_triggered():
+    # a value landing between LSBs differs under TRN vs RND
+    rng = np.random.default_rng(9)
+    a = _pair(rng.integers(-120, 121, (3, 2)))
+    b = _pair(rng.integers(-120, 121, (3, 2)))
+    trn = run(_cfg(c_zero=1, shift=7, q_rnd=0), a, b, _pair(np.zeros((3, 2))), _pair(16), _pair(0))
+    rnd = run(_cfg(c_zero=1, shift=7, q_rnd=1), a, b, _pair(np.zeros((3, 2))), _pair(16), _pair(0))
+    np.testing.assert_array_equal(trn[0][0], trn[1][0])
+    np.testing.assert_array_equal(rnd[0][0], rnd[1][0])
+    assert not np.array_equal(trn[0][0], rnd[0][0])      # the two modes genuinely differ
+
+
+# --- CG op coverage (the configs the CG matrix inverse needs) ------------------
+def test_cg_real_axpy_steps():
+    # X = X - P·α[col]  and  P = R - P·β[col]:  a=P, b_one, α=-vec (per-col), c=X/R, β=1
+    rng = np.random.default_rng(11)
+    n, m = 5, 3
+    P = _pair(rng.integers(-100, 101, (n, m)))
+    X = _pair(rng.integers(-100, 101, (n, m)))
+    neg_alpha = _pair(-rng.integers(-30, 31, m))         # -α per column
+    beta_one = _pair(16)                                 # β = 1.0 in F4
+    cfg = _cfg(b_one=1, shift=4)                         # alpha·P + 1·X, no reduce
+    got, exp = run(cfg, P, _pair(np.zeros((n, m))), X, neg_alpha, beta_one)
+    np.testing.assert_array_equal(got[0], exp[0])
+
+
+def test_cg_real_r_eq_i_minus_qx():
+    # R = I - QX:  a=QX, b_one, α=-1, c=I, β=1
+    rng = np.random.default_rng(12)
+    n, m = 4, 4
+    QX = _pair(rng.integers(-100, 101, (n, m)))
+    Imat = _pair(rng.integers(-100, 101, (n, m)))
+    cfg = _cfg(b_one=1, shift=4)
+    got, exp = run(cfg, QX, _pair(np.zeros((n, m))), Imat, _pair(-16), _pair(16))  # α=-1, β=1
+    np.testing.assert_array_equal(got[0], exp[0])
+
+
+def test_cg_complex_inner_product_conj():
+    # ps = Σ conj(P)·S:  a=S, b=P, b_conj, c_zero, reduce=rows (complex)
+    rng = np.random.default_rng(13)
+    n, m = 6, 2
+    S = _pair(rng.integers(-50, 51, (n, m)), rng.integers(-50, 51, (n, m)))
+    P = _pair(rng.integers(-50, 51, (n, m)), rng.integers(-50, 51, (n, m)))
+    cfg = _cfg(mode=CPLX, b_conj=1, c_zero=1, reduce_rows=1, shift=8)
+    got, exp = run(cfg, S, P, _pair(np.zeros((n, m)), np.zeros((n, m))), _pair(16, 0), _pair(0, 0))
+    np.testing.assert_array_equal(got[0], exp[0])
+    np.testing.assert_array_equal(got[1], exp[1])
+
+
+def test_cg_rnorm_sum_abs_sq_is_real():
+    # rnorm = Σ |R|²:  a=R, b=R, b_conj, c_zero, reduce=rows -> result is REAL (im == 0)
+    rng = np.random.default_rng(14)
+    n, m = 6, 2
+    R = _pair(rng.integers(-50, 51, (n, m)), rng.integers(-50, 51, (n, m)))
+    # saturate so the (non-negative) magnitude clamps to OUT_BW max rather than wrapping
+    cfg = _cfg(mode=CPLX, b_conj=1, c_zero=1, reduce_rows=1, shift=8, out_bw=12, o_sat=1)
+    got, exp = run(cfg, R, R, _pair(np.zeros((n, m)), np.zeros((n, m))), _pair(16, 0), _pair(0, 0))
+    np.testing.assert_array_equal(got[0], exp[0])
+    np.testing.assert_array_equal(got[1], np.zeros_like(got[1]))   # |R|² is real
+    assert np.all(got[0] >= 0)                                     # and non-negative (no wrap)

--- a/tests/examples/test_vmac_golden.py
+++ b/tests/examples/test_vmac_golden.py
@@ -17,8 +17,8 @@ from fractions import Fraction
 import numpy as np
 import pytest
 
-from examples.vmac.golden import execute
-from examples.vmac.vmac_cmd import VmacCmd, VmacMode
+from examples.vmac.golden import VmacAccel
+from examples.vmac.vmac_cmd import VmacMode
 from waveflow.utils import complexutils as cx
 from waveflow.utils.fixputils import Format
 
@@ -114,8 +114,16 @@ def _flat(pair_or_arr, complex_mode):
     return re.astype(np.int64)
 
 
-def build(cfg, a, b, c, alpha, beta):
-    """Lay a/b/c (+ per-column alpha/beta) into mem and build the VmacCmd. Returns (cmd, mem)."""
+def _accel(cfg):
+    """The accelerator carrying the structural widths for this config."""
+    return VmacAccel.specialize(
+        mem_dwidth=512, mem_awidth=32,
+        data_bw=cfg["in_bw"], acc_bw=cfg.get("acc_bw", 48), out_bw=cfg["out_bw"],
+    )
+
+
+def build(accel, cfg, a, b, c, alpha, beta):
+    """Lay a/b/c (+ per-column alpha/beta) into mem and build the Cmd. Returns (cmd, mem)."""
     complex_mode = cfg["mode"] == VmacMode.COMPLEX
     n, m = a[0].shape
     nm = n * m
@@ -146,7 +154,7 @@ def build(cfg, a, b, c, alpha, beta):
     for name, blk in zip(order, blocks):
         mem[addr[name]:addr[name] + len(blk)] = blk
 
-    cmd = VmacCmd()
+    cmd = accel.Cmd()
     cmd.n_rows, cmd.n_cols = n, m
     cmd.a = {"addr": addr["a"], "row_stride": m, "col_stride": 1}
     cmd.b = {"addr": addr["b"], "row_stride": m, "col_stride": 1}
@@ -154,10 +162,10 @@ def build(cfg, a, b, c, alpha, beta):
     cmd.d = {"addr": addr["d"], "row_stride": m, "col_stride": 1}
     cmd.alpha = _scalar_field(alpha, addr.get("alpha"), complex_mode)
     cmd.beta = _scalar_field(beta, addr.get("beta"), complex_mode)
-    for f in ("b_one", "c_zero", "b_conj", "reduce_rows", "mode", "in_bw", "int_bits",
-              "out_bw", "shift", "q_rnd", "o_sat"):
+    # in_bw / out_bw / acc_bw are now structural (on the accelerator), not cmd fields
+    for f in ("b_one", "c_zero", "b_conj", "reduce_rows", "mode", "int_bits", "shift",
+              "q_rnd", "o_sat"):
         setattr(cmd, f, cfg[f])
-    cmd.acc_bw = cfg.get("acc_bw", 48)
     return cmd, mem
 
 
@@ -169,8 +177,9 @@ def _scalar_field(s, addr, complex_mode):
 
 
 def run(cfg, a, b, c, alpha, beta):
-    cmd, mem = build(cfg, a, b, c, alpha, beta)
-    dst = execute(cmd, mem)
+    accel = _accel(cfg)
+    cmd, mem = build(accel, cfg, a, b, c, alpha, beta)
+    dst = accel.execute(cmd, mem)
     exp_re, exp_im = oracle(cfg, a, b, c, alpha, beta)
     if cfg["mode"] == VmacMode.COMPLEX:
         got_re, got_im = np.asarray(dst.val["re"]), np.asarray(dst.val["im"])

--- a/tests/examples/test_vmac_numeric.py
+++ b/tests/examples/test_vmac_numeric.py
@@ -1,0 +1,298 @@
+"""Phase-2 VMAC numeric-model tests — the datapath format spec + requantize == ap_fixed.
+
+Two things are proven here, all in Python (no Vitis):
+
+1. **The datapath format derivation** — ``VmacAccel.accumulator_format`` / ``output_format``
+   match an *independent*, hand-derived format algebra (product widens; the β·C add grows an
+   integer bit; the row reduction adds ``⌈log₂ n_rows⌉``; complex's ``cmult`` / ``conj`` add
+   their extra bit in the *integer* part), and the binary-point relationship
+   ``F_out = F_acc − SHIFT`` (so ``I_out = out_bw − F_out``) holds.
+
+2. **requantize == an ap_fixed assignment** — the golden's requantize (a ``fixputils.quantize``
+   format conversion that drops ``SHIFT`` fractional bits) is bit-identical to the hardware
+   ``ap_fixed<out_bw, …, q_mode, o_mode> y = acc >> SHIFT`` (round + saturate), checked against
+   **two independent references**: an int-domain shift/round/saturate and a ``Fraction``
+   value-domain quantize — over rounding ties, saturation, negatives, signed, and ``SHIFT = 0``.
+
+Plus the fail-loud guards (SHIFT out of range, ACC_BW too small, out_bw too small) and a
+width × (q, o) × (real, complex) end-to-end sweep against the independent oracle.
+"""
+import math
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+from examples.vmac.golden import VmacAccel
+from waveflow.hw.dataschema import DataArray
+from waveflow.hw.fixpoint import FixedField
+from waveflow.utils import complexutils as cx
+from waveflow.utils.fixputils import Format
+from tests.examples.test_vmac_golden import CPLX, REAL, _cfg, _pair, run
+
+
+# --- independent ap_fixed references for the requantize ----------------------
+def hw_shift_round_sat(acc_stored, shift, out_bw, q_rnd, o_sat):
+    """Independent int-domain ``ap_fixed<out_bw,…> y = acc >> shift`` (round half up,
+    then saturate / wrap), signed — the literal hardware op the kernel must hit."""
+    acc_stored = int(acc_stored)
+    if shift == 0:
+        q = acc_stored
+    else:
+        q = acc_stored >> shift                          # arithmetic floor (toward -inf)
+        if q_rnd:
+            q += (acc_stored >> (shift - 1)) & 1         # round half up (tie -> +inf)
+    lo, hi = -(1 << (out_bw - 1)), (1 << (out_bw - 1)) - 1
+    if o_sat:
+        return max(lo, min(hi, q))
+    y = q & ((1 << out_bw) - 1)                          # two's-complement wrap
+    return y - (1 << out_bw) if (y >> (out_bw - 1)) & 1 else y
+
+
+def frac_value_quant(acc_stored, acc_frac, out_frac, out_bw, q_rnd, o_sat):
+    """Independent value-domain reference: quantize the exact real value
+    ``acc_stored·2^-acc_frac`` into ``Format(out_bw, out_bw - out_frac)``."""
+    value = Fraction(int(acc_stored), 1) / (Fraction(2) ** acc_frac)
+    scaled = value * (Fraction(2) ** out_frac)
+    q = math.floor(scaled + Fraction(1, 2)) if q_rnd else math.floor(scaled)
+    lo, hi = -(1 << (out_bw - 1)), (1 << (out_bw - 1)) - 1
+    if o_sat:
+        return max(lo, min(hi, q))
+    y = q & ((1 << out_bw) - 1)
+    return y - (1 << out_bw) if (y >> (out_bw - 1)) & 1 else y
+
+
+def _craft_values(acc_W, shift):
+    """Stored-int accumulator values that stress the requantize: rounding ties (and ±1
+    around them), negatives, and large magnitudes that overflow out_bw into saturation."""
+    half = (1 << (shift - 1)) if shift > 0 else 0
+    vals = set()
+    for base in range(-6, 7):
+        v = base << shift
+        vals.update([v, v + half, v - half, v + half - 1, v + half + 1, v + 1, v - 1])
+    lo, hi = -(1 << (acc_W - 1)), (1 << (acc_W - 1)) - 1
+    vals.update([lo, hi, lo // 2, hi // 2, 0, -1, 1])    # extremes -> saturation
+    return np.array(sorted(v for v in vals if lo <= v <= hi), dtype=np.int64)
+
+
+# (acc_W, acc_I, out_bw, shift) — all valid: 0 <= out_frac = (acc_W-acc_I)-shift <= out_bw
+_REQUANT_CONFIGS = [
+    (16, 8, 12, 0),     # SHIFT = 0 (no rounding; pure narrow + saturate)
+    (16, 8, 8, 4),
+    (16, 8, 8, 8),      # out_frac = 0 (integer output)
+    (24, 12, 8, 8),
+    (24, 12, 10, 4),
+    (12, 6, 8, 6),      # out_frac = 0
+    (20, 4, 8, 12),
+    (32, 16, 12, 10),
+]
+
+
+@pytest.mark.parametrize("acc_W,acc_I,out_bw,shift", _REQUANT_CONFIGS)
+@pytest.mark.parametrize("q_rnd,o_sat", [(0, 0), (1, 0), (0, 1), (1, 1)])
+def test_requantize_real_equals_ap_fixed(acc_W, acc_I, out_bw, shift, q_rnd, o_sat):
+    acc_cls = FixedField.specialize(acc_W, acc_I, True)
+    acc_frac = acc_cls.get_format().frac_bits
+    out_frac = acc_frac - shift
+    out_cls = FixedField.specialize(out_bw, out_bw - out_frac, True,
+                                    *(_qo(q_rnd, o_sat)))
+    stored = _craft_values(acc_W, shift)
+    t = DataArray.specialize(acc_cls, max_shape=(len(stored),))(stored)
+
+    got = np.asarray(VmacAccel._requantize(t, out_cls, complex_mode=False).val)
+    hw = [hw_shift_round_sat(s, shift, out_bw, q_rnd, o_sat) for s in stored]
+    frac = [frac_value_quant(s, acc_frac, out_frac, out_bw, q_rnd, o_sat) for s in stored]
+    np.testing.assert_array_equal(got, hw)               # golden == int-domain shift/round/sat
+    np.testing.assert_array_equal(got, frac)             # golden == value-domain quantize
+
+
+@pytest.mark.parametrize("acc_W,acc_I,out_bw,shift", _REQUANT_CONFIGS)
+@pytest.mark.parametrize("q_rnd,o_sat", [(0, 0), (1, 1)])
+def test_requantize_complex_equals_ap_fixed(acc_W, acc_I, out_bw, shift, q_rnd, o_sat):
+    acc_fmt = Format(acc_W, acc_I, True)
+    acc_frac = acc_fmt.frac_bits
+    out_frac = acc_frac - shift
+    out_cls = FixedField.specialize(out_bw, out_bw - out_frac, True, *(_qo(q_rnd, o_sat)))
+    re = _craft_values(acc_W, shift)
+    im = np.roll(re, 3)
+    from waveflow.hw.complexfield import ComplexField
+    t = DataArray.specialize(ComplexField.specialize(FixedField.specialize(acc_W, acc_I, True)),
+                             max_shape=(len(re),))(cx.make_complex(re, im, acc_fmt))
+    out = VmacAccel._requantize(t, out_cls, complex_mode=True).val
+    for comp, src in (("re", re), ("im", im)):
+        hw = [hw_shift_round_sat(s, shift, out_bw, q_rnd, o_sat) for s in src]
+        np.testing.assert_array_equal(np.asarray(out[comp]), hw)
+
+
+def _qo(q_rnd, o_sat):
+    from waveflow.utils.fixputils import OMode, QMode
+    return (QMode.AP_RND if q_rnd else QMode.AP_TRN, OMode.AP_SAT if o_sat else OMode.AP_WRAP)
+
+
+# --- format derivation: independent hand-derived algebra ----------------------
+def _expected_acc(data_bw, int_bits, complex_mode, b_one, b_conj, c_zero, reduce_rows, n_rows):
+    """Independent (W, I) accumulator-format derivation, the rules spelled out by hand."""
+    def mul(A, B):                                       # product
+        w, ib = A[0] + B[0], A[1] + B[1]
+        return (w + 1, ib + 1) if complex_mode else (w, ib)   # cmult: +1 int bit (sub_format)
+
+    def add(A, B):                                       # aligned add (+1 int bit)
+        frac = max(A[0] - A[1], B[0] - B[1])
+        ints = max(A[1], B[1]) + 1
+        return (ints + frac, ints)
+
+    in_f = (data_bw, int_bits)
+    if b_one:
+        ab = in_f
+    else:
+        op_b = in_f
+        if b_conj and complex_mode:
+            op_b = (data_bw + 1, int_bits + 1)           # conj = sub_format(in, in)
+        ab = mul(in_f, op_b)
+    acc = mul(in_f, ab)
+    if not c_zero:
+        acc = add(acc, mul(in_f, in_f))
+    if reduce_rows:
+        growth = (n_rows - 1).bit_length()               # ceil(log2 n_rows)
+        acc = (acc[0] + growth, acc[1] + growth)
+    return acc
+
+
+_FLAG_COMBOS = [
+    dict(b_one=0, b_conj=0, c_zero=0, reduce_rows=0),
+    dict(b_one=1, b_conj=0, c_zero=0, reduce_rows=0),
+    dict(b_one=0, b_conj=0, c_zero=1, reduce_rows=0),
+    dict(b_one=1, b_conj=0, c_zero=1, reduce_rows=1),
+    dict(b_one=0, b_conj=1, c_zero=1, reduce_rows=1),
+    dict(b_one=0, b_conj=1, c_zero=0, reduce_rows=0),
+    dict(b_one=0, b_conj=0, c_zero=0, reduce_rows=1),
+]
+
+
+@pytest.mark.parametrize("mode", [REAL, CPLX])
+@pytest.mark.parametrize("flags", _FLAG_COMBOS)
+@pytest.mark.parametrize("data_bw,int_bits,n_rows", [(8, 4, 5), (12, 8, 8), (6, 3, 4)])
+def test_accumulator_format_matches_hand_derivation(mode, flags, data_bw, int_bits, n_rows):
+    accel = VmacAccel.specialize(mem_dwidth=512, mem_awidth=32, data_bw=data_bw,
+                                 acc_bw=128, out_bw=data_bw)
+    cmd = accel.Cmd()
+    cmd.n_rows, cmd.n_cols = n_rows, 2
+    cmd.mode, cmd.int_bits = mode, int_bits
+    for k, v in flags.items():
+        setattr(cmd, k, v)
+    acc = accel.accumulator_format(cmd)
+    exp_W, exp_I = _expected_acc(data_bw, int_bits, mode == CPLX, **flags, n_rows=n_rows)
+    assert (acc.W, acc.int_bits) == (exp_W, exp_I)
+    assert acc.signed is True
+    assert acc.frac_bits == (2 if flags["b_one"] else 3) * (data_bw - int_bits)  # F = depth·F_in
+
+
+def test_output_format_binary_point_and_codegen_target():
+    accel = VmacAccel.specialize(mem_dwidth=512, mem_awidth=32, data_bw=8, acc_bw=64, out_bw=12)
+    cmd = accel.Cmd()
+    cmd.n_rows, cmd.n_cols = 4, 2
+    cmd.mode, cmd.int_bits, cmd.shift = REAL, 4, 8
+    cmd.b_one, cmd.c_zero = 0, 1                          # F_acc = 3·4 = 12
+    acc = accel.accumulator_format(cmd)
+    out = accel.output_format(cmd)
+    assert out.get_format().frac_bits == acc.frac_bits - int(cmd.shift)      # F_out = F_acc - SHIFT
+    assert out.int_bits == accel.out_bw - (acc.frac_bits - int(cmd.shift))   # I_out from SHIFT
+    assert out.get_bitwidth() == accel.out_bw
+    assert out.cpp_type == f"ap_fixed<12, {out.int_bits}, AP_TRN, AP_WRAP>"   # Phase-3 target
+
+
+def test_accumulator_format_matches_execute_invariant():
+    # execute() asserts (and would raise) if the derived accumulator format disagrees with
+    # the operator-composed actual; a passing real+complex run proves the two coincide.
+    for mode in (REAL, CPLX):
+        got, exp = run(_cfg(mode=mode, in_bw=8, int_bits=4, out_bw=8, shift=8, b_conj=1, reduce_rows=1),
+                       _pair([[3, -4]], [[1, 2]]), _pair([[2, 1]], [[-1, 1]]),
+                       _pair([[0, 0]], [[0, 0]]), _pair(16, 0), _pair(0, 0))
+        np.testing.assert_array_equal(got[0], exp[0])
+
+
+# --- width × (q, o) × (real, complex) end-to-end sweep vs the oracle ----------
+def _rand(rng, data_bw, shape):
+    hi = (1 << (data_bw - 1)) - 1
+    return rng.integers(-hi, hi + 1, shape, dtype=np.int64)
+
+
+# (data_bw, int_bits, out_bw, shift, acc_bw)
+_WIDTHS = [(8, 4, 8, 8, 64), (10, 5, 10, 10, 64), (12, 8, 12, 6, 80), (6, 3, 8, 5, 48)]
+
+
+@pytest.mark.parametrize("data_bw,int_bits,out_bw,shift,acc_bw", _WIDTHS)
+@pytest.mark.parametrize("q_rnd,o_sat", [(0, 0), (1, 1)])
+@pytest.mark.parametrize("mode", [REAL, CPLX])
+def test_width_sweep_matches_oracle(data_bw, int_bits, out_bw, shift, acc_bw, q_rnd, o_sat, mode):
+    rng = np.random.default_rng(hash((data_bw, shift, q_rnd, o_sat, int(mode))) & 0xFFFF)
+    n, m = 4, 3
+    cplx = mode == CPLX
+
+    def op():
+        re = _rand(rng, data_bw, (n, m))
+        im = _rand(rng, data_bw, (n, m)) if cplx else None
+        return _pair(re, im)
+
+    # immediates must fit data_bw; use modest magnitudes near +-2^(int_bits) scale
+    aimm = (8, -4) if cplx else (8, 0)
+    bimm = (-6, 3) if cplx else (-6, 0)
+    base = dict(mode=mode, in_bw=data_bw, int_bits=int_bits, out_bw=out_bw, shift=shift,
+                acc_bw=acc_bw, q_rnd=q_rnd, o_sat=o_sat)
+    for flags in ({"c_zero": 1}, {}, {"b_one": 1}, {"reduce_rows": 1, "c_zero": 1},
+                  {"b_conj": 1, "c_zero": 1, "reduce_rows": 1}):
+        cfg = _cfg(**base, **flags)
+        got, exp = run(cfg, op(), op(), op(), _pair(*aimm), _pair(*bimm))
+        np.testing.assert_array_equal(got[0], exp[0], err_msg=f"re {cfg} {flags}")
+        if cplx:
+            np.testing.assert_array_equal(got[1], exp[1], err_msg=f"im {cfg} {flags}")
+
+
+# --- fail-loud guards ---------------------------------------------------------
+def _accel(**kw):
+    base = dict(mem_dwidth=512, mem_awidth=32, data_bw=8, acc_bw=64, out_bw=8)
+    base.update(kw)
+    return VmacAccel.specialize(**base)
+
+
+def _cmd(accel, *, int_bits=4, shift=4, b_one=0, c_zero=1, reduce_rows=0, n_rows=4):
+    cmd = accel.Cmd()
+    cmd.n_rows, cmd.n_cols = n_rows, 2
+    cmd.mode, cmd.int_bits, cmd.shift = REAL, int_bits, shift
+    cmd.b_one, cmd.c_zero, cmd.reduce_rows = b_one, c_zero, reduce_rows
+    return cmd
+
+
+def test_failloud_shift_out_of_range():
+    accel = _accel(data_bw=8, out_bw=8)
+    cmd = _cmd(accel, int_bits=4, b_one=1, shift=20)     # F_acc = 8, shift 20 > 8
+    with pytest.raises(ValueError, match="SHIFT.*out of range|exceeds accumulator"):
+        accel.output_format(cmd)
+
+
+def test_failloud_acc_bw_too_small():
+    accel = _accel(data_bw=8, acc_bw=10, out_bw=8)       # b-path acc ~ 25 bits > 10
+    cmd = _cmd(accel, int_bits=4, b_one=0, c_zero=0, shift=8)
+    with pytest.raises(ValueError, match="exceeds acc_bw"):
+        accel.output_format(cmd)
+
+
+def test_failloud_out_bw_too_small_for_integer_part():
+    accel = _accel(data_bw=8, out_bw=4)                  # F_acc = 8, shift 0 -> out_frac 8 > 4
+    cmd = _cmd(accel, int_bits=4, b_one=1, shift=0)
+    with pytest.raises(ValueError, match="too small for the integer part"):
+        accel.output_format(cmd)
+
+
+def test_failloud_propagates_through_execute():
+    accel = _accel(data_bw=8, acc_bw=10, out_bw=8)
+    cmd = _cmd(accel, int_bits=4, b_one=0, c_zero=0, shift=8)
+    mem = np.zeros(256, dtype=np.int64)
+    cmd.a = {"addr": 0, "row_stride": 2, "col_stride": 1}
+    cmd.b = {"addr": 8, "row_stride": 2, "col_stride": 1}
+    cmd.c = {"addr": 16, "row_stride": 2, "col_stride": 1}
+    cmd.d = {"addr": 24, "row_stride": 2, "col_stride": 1}
+    cmd.alpha = {"direct": 1, "re": 1, "im": 0, "addr": 0, "stride": 0}
+    cmd.beta = {"direct": 1, "re": 1, "im": 0, "addr": 0, "stride": 0}
+    with pytest.raises(ValueError, match="exceeds acc_bw"):
+        accel.execute(cmd, mem)

--- a/tests/hw/test_complexfield.py
+++ b/tests/hw/test_complexfield.py
@@ -8,7 +8,7 @@ derivation, and the unsigned/mixed-kind guards.
 import numpy as np
 import pytest
 
-from waveflow.hw.complexfield import ComplexField, cadd, cmult, conj, csub
+from waveflow.hw.complexfield import ComplexField, cadd, cmult, conj, csub, csum
 from waveflow.hw.dataschema import DataArray, FloatField, IntField
 from waveflow.hw.fixpoint import FixedField
 from waveflow.utils import complexutils as cx
@@ -142,6 +142,24 @@ def test_cadd_csub_int_match_core():
     np.testing.assert_array_equal(csub(a, b).val["im"], d["im"])
     assert cadd(a, b).element_type.kind == "int"
     assert cadd(a, b).element_type.inner_type.get_bitwidth() == 9   # max+1
+
+
+def test_csum_real_and_complex_full_precision():
+    # real: sum 3 rows of ap_fixed<8,4> -> grows int bits by ceil(log2 3)=2 -> <10,6>
+    F = FixedField.specialize(8, 4, True)
+    a = DataArray.specialize(F, max_shape=(3, 2))(np.array([[1, 2], [3, 4], [5, 6]], dtype=np.int64))
+    r = csum(a, axis=0)
+    assert r.element_type.get_format() == Format(10, 6, True)
+    np.testing.assert_array_equal(np.asarray(r.val), [9, 12])     # exact, no overflow
+
+    # complex: per-component reduction, re/im share the grown format
+    v = cx.make_complex(np.array([[1, 2], [3, 4], [5, 6]]),
+                        np.array([[10, 20], [30, 40], [50, 60]]), Format(8, 4, True))
+    ca = DataArray.specialize(ComplexField.specialize(F), max_shape=(3, 2))(v)
+    cr = csum(ca, axis=0)
+    assert cr.element_type.inner_format() == Format(10, 6, True)
+    np.testing.assert_array_equal(cr.val["re"], [9, 12])
+    np.testing.assert_array_equal(cr.val["im"], [90, 120])
 
 
 def test_conj_fixed_negates_imag():

--- a/waveflow/hw/complexfield.py
+++ b/waveflow/hw/complexfield.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from waveflow.hw.dataschema import DataArray, DataField, FloatField, IntField, _elem_kind
 from waveflow.utils import complexutils as cx
+from waveflow.utils import fixputils
 from waveflow.utils.complexutils import complex_dtype, int_format
 from waveflow.utils.fixputils import Format
 
@@ -245,3 +246,24 @@ def conj(a: DataArray) -> DataArray:
         return _wrap_float(cx.conj_float(np.asarray(a.val)))
     out, r = cx.conj(np.asarray(a.val), ea.inner_format())
     return _wrap_complex(out, _result_inner(ea.kind, r))
+
+
+def csum(a: DataArray, axis: int = 0) -> DataArray:
+    """Wide-accumulator column reduction (full precision), real **or** complex.
+
+    Reduces over ``axis`` (default 0 -> sum the rows, one value per column), integer
+    bits growing by ``ceil(log2 N)`` (``sum_format``).  Real ``FixedField`` / ``IntField``
+    delegates to ``fixpoint.fixed_sum``; complex sums the re/im stored-int components with
+    the same integer reduction and recombines (so re and im share the grown format).
+    Vectorized -- no per-element loop."""
+    ea = a.element_type
+    if getattr(ea, "is_complex_field", False):
+        if ea.kind == "float":
+            return _wrap_float(np.asarray(a.val).sum(axis=axis))
+        fmt = ea.inner_format()
+        v = np.asarray(a.val)
+        re, r = fixputils.fixed_sum(cx.re_of(v), fmt, axis=axis)
+        im, _ = fixputils.fixed_sum(cx.im_of(v), fmt, axis=axis)
+        return _wrap_complex(cx.make_complex(re, im, r), _result_inner(ea.kind, r))
+    from waveflow.hw.fixpoint import fixed_sum as _fixed_sum
+    return _fixed_sum(a, axis=axis)


### PR DESCRIPTION
The accumulating VMAC PR (the *VPU* beside the systolic GEMM). **Phase 1** — Python schema + bit-exact golden; later phases (1.5 accel/command split, 2 numeric model, 3 Vitis conformance, 4 throughput, 5 CG example) land as further commits here. See `plans/vmac.md`.

**Phase 1 contents:**
- `VmacCmd` schema (strided `Region`/`Scalar`, direct/indirect per-column α/β, op flags, real|complex mode, numeric params).
- `execute(cmd, mem)` Python golden for `D = α·A·op(B) + β·C [, reduce_rows]` — composes the merged `FixedField`/`ComplexField` operators + wide-accumulator `csum` reduction + right-shift requantize. Fully vectorized.
- `csum` (in `waveflow/hw/complexfield.py`) — wide-accumulator column reduction, real + complex.
- **41 non-vitis tests** green: every config + the 5 CG ops, bit-level vs an independent Fraction-space oracle; encode/decode round-trips.

Depends on ComplexField (merged). **WIP** — keep open; Phase 1.5+ to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)