### PR TITLE
ComplexField: first-class C++ serialization + complex_utils.hpp

### DIFF
--- a/examples/schemas/complex/complex_build.py
+++ b/examples/schemas/complex/complex_build.py
@@ -1,23 +1,29 @@
 """Complex conformance harness -- Python ``ComplexField`` vs Vitis complex, bit-exact.
 
-The Phase-4 milestone: for each curated case, run the complex op in Vitis C-sim (the
-:mod:`kernels` complex kernels) and assert the emitted stored bits equal the bits the
-Python ``DataArray[ComplexField]`` model produces -- **bit-for-bit, zero LSB
-disagreement** -- per inner:
+For each curated case, run the complex op in Vitis C-sim and assert the emitted **packed
+words** equal the words the Python ``DataArray[ComplexField]`` model produces -- bit-for-bit,
+zero LSB disagreement -- per inner:
 
-- **fixed** -> ``std::complex<ap_fixed>``  (the headline; signed cmult/cadd/csub/conj,
-  unsigned cadd; round-trip quantization).
+- **fixed** -> ``std::complex<ap_fixed>``  (signed cmult/cadd/csub/conj, unsigned cadd; the
+  serialization round-trip).
 - **int**   -> the Waveflow ``wf_cint`` struct (s8 / s16: cmult/cadd/csub/conj + round-trip).
 - **float** -> ``std::complex<float>`` / ``std::complex<double>``  (round-trip + the
-  complex-multiply **edge** confirmed empirically + cadd/csub/conj).
+  complex-multiply edge + cadd/csub/conj).
 
-If Python and Vitis ever differ the Python model is wrong, not Vitis: fix it, never loosen.
-Built on the shared ``BuildDag`` + :func:`run_dag_cli` rig (reused from the FixedField
-harness), so this is the same gen -> csim -> compare-bits flow.
+This is the **migrated** harness (plans/complex_serialization.md Phase 3): the operand /
+result vectors are the **generated serialization** (:func:`arrayutils.write_array` /
+:func:`read_array` over ``DataArray[ComplexField]``, replacing the old hand-interleaving), and
+the kernel arithmetic is **``complex_utils.hpp``** (replacing the inline formula).  Each
+operand / result is (de)serialized at ``word_bw = its element bitwidth`` (<=64) so the packing
+is one element per word -- exactly what ``write_array`` produces -- and the kernel uses the
+generated ``<type>_array_utils::read_array`` / ``write_array`` to match it on the C++ side.
+
+If Python and Vitis ever differ the Python model is the spec: fix the codegen / kernel, never
+loosen the compare.  Built on the shared ``BuildDag`` + :func:`run_dag_cli` rig.
 
 CLI::
 
-    python complex_build.py --through gen_conformance   # write kernels + vectors (no Vitis)
+    python complex_build.py --through gen_conformance   # write kernels + headers + vectors
     python complex_build.py --through run_conformance    # the full csim conformance (Vitis)
     python complex_build.py --list-steps
 """
@@ -25,30 +31,31 @@ from __future__ import annotations
 
 import json
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
 
 from waveflow.build.build import BuildConfig, BuildDag, BuildStep, SourceStep
 from waveflow.build.cli import run_dag_cli
+from waveflow.build.streamutils import StreamUtilsStep
+from waveflow.hw.arrayutils import (
+    _array_utils_filename, _array_utils_namespace, gen_array_utils, get_nwords, write_array,
+)
 from waveflow.hw.complexfield import ComplexField, cadd, cmult, conj, csub
 from waveflow.hw.dataschema import DataArray, FloatField, IntField
 from waveflow.hw.fixpoint import FixedField
 from waveflow.toolchain import toolchain
 from waveflow.utils import complexutils as cx
-from waveflow.utils.fixputils import OMode, QMode, quantize_real, to_bits
+from waveflow.utils.fixputils import OMode, QMode, quantize_real
 
 try:
-    from examples.schemas.complex.kernels import (
-        render_caddsub, render_cmult, render_conj, render_load_real,
-    )
+    from examples.schemas.complex.kernels import render_kernel
 except ModuleNotFoundError:  # direct execution from the example dir
-    from kernels import (  # type: ignore[no-redef]
-        render_caddsub, render_cmult, render_conj, render_load_real,
-    )
+    from kernels import render_kernel  # type: ignore[no-redef]
 
 _SOURCE_DIR = Path(__file__).resolve().parent
+_BUILD_DIR = Path(__file__).resolve().parents[3] / "waveflow" / "build"   # complex_utils.hpp / wf_cint.h
 
 
 # --- config -------------------------------------------------------------------
@@ -75,12 +82,8 @@ class ComplexConfig:
     def complex_cls(self):
         return ComplexField.specialize(self.inner_cls)
 
-    @property
-    def inner_W(self) -> int:
-        return self.fbw if self.kind == "float" else self.W
 
-
-# curated signed fixed configs (the FixedField set; 2W+1 <= 64 for all -> cmult ok)
+# curated signed fixed configs (2W+1 <= 64 for all -> cmult ok)
 FIXED_SIGNED = [
     ComplexConfig("s4_2", "fixed", 4, 2), ComplexConfig("s8_4", "fixed", 8, 4),
     ComplexConfig("s16_8", "fixed", 16, 8), ComplexConfig("s8_8", "fixed", 8, 8),
@@ -114,163 +117,8 @@ def _float_operand(cfg: ComplexConfig, vals) -> DataArray:
     return _da(cfg.complex_cls, np.asarray(vals, dtype=dt))
 
 
-def _interleave_stored_bits(struct, W: int) -> list[int]:
-    re = np.atleast_1d(to_bits(np.asarray(struct["re"]), W))
-    im = np.atleast_1d(to_bits(np.asarray(struct["im"]), W))
-    return [int(x) for pair in zip(re, im) for x in pair]
-
-
-def _interleave_float_bits(arr, bw: int) -> list[int]:
-    dt = np.uint32 if bw == 32 else np.uint64
-    ft = np.float32 if bw == 32 else np.float64
-    out: list[int] = []
-    for z in np.atleast_1d(arr):
-        out.append(int(np.asarray(ft(z.real)).view(dt)))
-        out.append(int(np.asarray(ft(z.imag)).view(dt)))
-    return out
-
-
-def _text(ints) -> str:
-    return "\n".join(str(int(x)) for x in ints) + "\n"
-
-
-def _reals_text(pairs) -> str:
-    """Interleaved re, im doubles (one per line)."""
-    out: list[str] = []
-    for re, im in pairs:
-        out.append(f"{float(re):.17g}")
-        out.append(f"{float(im):.17g}")
-    return "\n".join(out) + "\n"
-
-
-def _case(name, kernel, in_a, in_b, expected) -> dict:
-    return {"name": name, "kernel": kernel, "in_a": in_a, "in_b": in_b, "expected": expected}
-
-
-# --- per-op golden + kernel ---------------------------------------------------
-def _arith_inputs(cfg, a, b):
-    if cfg.kind == "float":
-        return _text(_interleave_float_bits(a.val, cfg.fbw)), _text(_interleave_float_bits(b.val, cfg.fbw))
-    return _text(_interleave_stored_bits(a.val, cfg.W)), _text(_interleave_stored_bits(b.val, cfg.W))
-
-
-def _arith_expected(cfg, out):
-    ri = out.element_type.inner_type
-    if cfg.kind == "float":
-        return _interleave_float_bits(out.val, ri.get_bitwidth()), ri
-    return _interleave_stored_bits(out.val, ri.get_bitwidth()), ri
-
-
-def _add_binary_case(cases, cfg, a, b, op_name, fn, render_fn):
-    out = fn(a, b)
-    exp, ri = _arith_expected(cfg, out)
-    in_a, in_b = _arith_inputs(cfg, a, b)
-    kernel = render_fn(cfg.inner_cls.cpp_type, cfg.inner_W, ri.cpp_type, ri.get_bitwidth())
-    cases.append(_case(f"{op_name}_{cfg.name}", kernel, in_a, in_b, exp))
-
-
-def build_cases() -> list[dict]:  # noqa: C901 — flat enumeration of curated cases
-    cases: list[dict] = []
-    ctype_of = lambda cfg: cfg.inner_cls.cpp_type  # noqa: E731
-
-    # ---- fixed (signed): round-trip + cmult/cadd/csub/conj ----
-    for cfg in FIXED_SIGNED:
-        a = _fixed_int_operand(cfg, 2)
-        b = _fixed_int_operand(cfg, 4)
-        # round-trip: quantize reals (exact + rounding-midpoint + overflow sweep)
-        pairs = _roundtrip_pairs(cfg)
-        gold = []
-        for re, im in pairs:
-            gold.append(int(to_bits(quantize_real(np.array([re]), cfg.inner_cls.get_format()), cfg.W)[0]))
-            gold.append(int(to_bits(quantize_real(np.array([im]), cfg.inner_cls.get_format()), cfg.W)[0]))
-        cases.append(_case(f"roundtrip_{cfg.name}",
-                           render_load_real("fixed", ctype_of(cfg), cfg.W),
-                           _reals_text(pairs), "", gold))
-        _add_binary_case(cases, cfg, a, b, "cmult", cmult,
-                         lambda ct, w, rt, rw, c=cfg: render_cmult("fixed", c.inner_cls.cpp_type, c.W, rt, rw))
-        _add_binary_case(cases, cfg, a, b, "cadd", cadd,
-                         lambda ct, w, rt, rw, c=cfg: render_caddsub("+", "fixed", c.inner_cls.cpp_type, c.W, rt, rw))
-        _add_binary_case(cases, cfg, a, b, "csub", csub,
-                         lambda ct, w, rt, rw, c=cfg: render_caddsub("-", "fixed", c.inner_cls.cpp_type, c.W, rt, rw))
-        oc = conj(a)
-        ri = oc.element_type.inner_type
-        cases.append(_case(f"conj_{cfg.name}",
-                           render_conj("fixed", ctype_of(cfg), cfg.W, ri.cpp_type, ri.get_bitwidth()),
-                           _text(_interleave_stored_bits(a.val, cfg.W)), "",
-                           _interleave_stored_bits(oc.val, ri.get_bitwidth())))
-
-    # ---- fixed (unsigned): round-trip + cadd only (cmult/conj are signed-only) ----
-    cfg = FIXED_UNSIGNED
-    a = _fixed_int_operand(cfg, 2)
-    b = _fixed_int_operand(cfg, 4)
-    pairs = _roundtrip_pairs(cfg)
-    gold = []
-    for re, im in pairs:
-        gold.append(int(to_bits(quantize_real(np.array([re]), cfg.inner_cls.get_format()), cfg.W)[0]))
-        gold.append(int(to_bits(quantize_real(np.array([im]), cfg.inner_cls.get_format()), cfg.W)[0]))
-    cases.append(_case(f"roundtrip_{cfg.name}",
-                       render_load_real("fixed", ctype_of(cfg), cfg.W), _reals_text(pairs), "", gold))
-    _add_binary_case(cases, cfg, a, b, "cadd", cadd,
-                     lambda ct, w, rt, rw, c=cfg: render_caddsub("+", "fixed", c.inner_cls.cpp_type, c.W, rt, rw))
-
-    # ---- int (signed s8 / s16): round-trip + cmult/cadd/csub/conj ----
-    for cfg in INTS:
-        a = _fixed_int_operand(cfg, 2)
-        b = _fixed_int_operand(cfg, 4)
-        # round-trip is an identity over stored ints (validates the wf_cint layout)
-        rt_bits = _interleave_stored_bits(a.val, cfg.W)
-        cases.append(_case(f"roundtrip_{cfg.name}",
-                           render_load_real("int", f"ap_int<{cfg.W}>", cfg.W),
-                           _text(rt_bits), "", rt_bits))
-        _add_binary_case(cases, cfg, a, b, "cmult", cmult,
-                         lambda ct, w, rt, rw, c=cfg: render_cmult("int", f"ap_int<{c.W}>", c.W, rt, rw))
-        _add_binary_case(cases, cfg, a, b, "cadd", cadd,
-                         lambda ct, w, rt, rw, c=cfg: render_caddsub("+", "int", f"ap_int<{c.W}>", c.W, rt, rw))
-        _add_binary_case(cases, cfg, a, b, "csub", csub,
-                         lambda ct, w, rt, rw, c=cfg: render_caddsub("-", "int", f"ap_int<{c.W}>", c.W, rt, rw))
-        oc = conj(a)
-        ri = oc.element_type.inner_type
-        cases.append(_case(f"conj_{cfg.name}",
-                           render_conj("int", f"ap_int<{cfg.W}>", cfg.W,
-                                       f"ap_int<{ri.get_bitwidth()}>", ri.get_bitwidth()),
-                           _text(_interleave_stored_bits(a.val, cfg.W)), "",
-                           _interleave_stored_bits(oc.val, ri.get_bitwidth())))
-
-    # ---- float (f32 / f64): round-trip + cmult (the edge) + cadd/csub/conj ----
-    # Rounding-TRIGGERING random operands (fixed seed): products are non-exact, so this
-    # genuinely exercises the complex-multiply edge (numpy's FMA `*` would diverge from
-    # std::complex on ~25% of these; the naive cmult_float model matches Vitis bit-exact).
-    _rng = np.random.default_rng(20240607)
-    fa_vals = _rng.standard_normal(64) + 1j * _rng.standard_normal(64)
-    fb_vals = _rng.standard_normal(64) + 1j * _rng.standard_normal(64)
-    for cfg in FLOATS:
-        a = _float_operand(cfg, fa_vals)
-        b = _float_operand(cfg, fb_vals)
-        # round-trip: doubles -> float type (double->float quantization for f32; exact for f64)
-        pairs = [(z.real, z.imag) for z in [complex(1.1, -2.2), complex(3.3, 0.4),
-                                            complex(-5.5, 6.6), complex(0.0, -1.0)]]
-        gold = _interleave_float_bits(
-            np.asarray([complex(re, im) for re, im in pairs],
-                       dtype=np.complex128 if cfg.fbw == 64 else np.complex64), cfg.fbw)
-        cases.append(_case(f"roundtrip_{cfg.name}",
-                           render_load_real("float", ctype_of(cfg), cfg.fbw), _reals_text(pairs), "", gold))
-        _add_binary_case(cases, cfg, a, b, "cmult", cmult,
-                         lambda ct, w, rt, rw, c=cfg: render_cmult("float", c.inner_cls.cpp_type, c.fbw, c.inner_cls.cpp_type, c.fbw))
-        _add_binary_case(cases, cfg, a, b, "cadd", cadd,
-                         lambda ct, w, rt, rw, c=cfg: render_caddsub("+", "float", c.inner_cls.cpp_type, c.fbw, c.inner_cls.cpp_type, c.fbw))
-        _add_binary_case(cases, cfg, a, b, "csub", csub,
-                         lambda ct, w, rt, rw, c=cfg: render_caddsub("-", "float", c.inner_cls.cpp_type, c.fbw, c.inner_cls.cpp_type, c.fbw))
-        oc = conj(a)
-        cases.append(_case(f"conj_{cfg.name}",
-                           render_conj("float", ctype_of(cfg), cfg.fbw, ctype_of(cfg), cfg.fbw),
-                           _text(_interleave_float_bits(a.val, cfg.fbw)), "",
-                           _interleave_float_bits(oc.val, cfg.fbw)))
-
-    return cases
-
-
 def _roundtrip_pairs(cfg: ComplexConfig):
-    """(re, im) real pairs for the quantization round-trip: exact, rounding midpoints, overflow."""
+    """(re, im) real pairs for the round-trip: exact, rounding midpoints, overflow."""
     lsb = 2.0 ** (-(cfg.W - cfg.int_bits))
     if cfg.signed:
         hi, lo = ((1 << (cfg.W - 1)) - 1) * lsb, -(1 << (cfg.W - 1)) * lsb
@@ -280,16 +128,154 @@ def _roundtrip_pairs(cfg: ComplexConfig):
     return [(vals[i], vals[-1 - i]) for i in range(len(vals))]
 
 
-# --- single-case driver (reused by the step loop AND the conformance test) ----
-def gen_case_sources(case: dict, work_dir: Path) -> Path:
+def _roundtrip_operand(cfg: ComplexConfig) -> DataArray:
+    """The round-trip operand: the curated quantization-edge values, **quantized** into the
+    inner format (so the serialization round-trip carries the exact stored representation)."""
+    if cfg.kind == "float":
+        pairs = [(1.1, -2.2), (3.3, 0.4), (-5.5, 6.6), (0.0, -1.0)]
+        dt = np.complex128 if cfg.fbw == 64 else np.complex64
+        return _da(cfg.complex_cls, np.asarray([complex(r, i) for r, i in pairs], dtype=dt))
+    if cfg.kind == "int":
+        return _fixed_int_operand(cfg, 2)
+    fmt = cfg.inner_cls.get_format()
+    pairs = _roundtrip_pairs(cfg)
+    re_q = quantize_real(np.array([r for r, _ in pairs]), fmt)
+    im_q = quantize_real(np.array([i for _, i in pairs]), fmt)
+    return _da(cfg.complex_cls, cx.make_complex(re_q, im_q, fmt))
+
+
+# --- one case -----------------------------------------------------------------
+def _wbw(cf) -> int:
+    """word_bw = element bitwidth (<=64) so pf=1, one element per word -- the layout
+    ``write_array`` produces; 64 for the 128-bit float64 element (2 words/element)."""
+    bw = cf.get_bitwidth()
+    return bw if bw <= 64 else 64
+
+
+@dataclass
+class Case:
+    name: str
+    op: str                          # roundtrip | cmult | cadd | csub | conj
+    a: DataArray
+    golden: DataArray
+    b: DataArray | None = None
+    expected: list = field(default_factory=list)
+
+    @property
+    def in_cf(self):
+        return type(self.a).element_type
+
+    @property
+    def out_cf(self):
+        return type(self.golden).element_type
+
+    @property
+    def binary(self) -> bool:
+        return self.op in ("cmult", "cadd", "csub")
+
+
+_OPS = {"cmult": cmult, "cadd": cadd, "csub": csub, "conj": conj}
+
+
+def _mk_case(name: str, op: str, a: DataArray, b: DataArray | None = None) -> Case:
+    if op == "roundtrip":
+        golden = a
+    elif op == "conj":
+        golden = conj(a)
+    else:
+        golden = _OPS[op](a, b)
+    wbo = _wbw(type(golden).element_type)
+    expected = [int(w) for w in np.asarray(write_array(golden, word_bw=wbo)).ravel()]
+    return Case(name=name, op=op, a=a, b=b, golden=golden, expected=expected)
+
+
+def build_cases() -> list[dict]:
+    cases: list[Case] = []
+
+    # ---- fixed (signed): round-trip + cmult/cadd/csub/conj ----
+    for cfg in FIXED_SIGNED:
+        a, b = _fixed_int_operand(cfg, 2), _fixed_int_operand(cfg, 4)
+        cases.append(_mk_case(f"roundtrip_{cfg.name}", "roundtrip", _roundtrip_operand(cfg)))
+        for op in ("cmult", "cadd", "csub"):
+            cases.append(_mk_case(f"{op}_{cfg.name}", op, a, b))
+        cases.append(_mk_case(f"conj_{cfg.name}", "conj", a))
+
+    # ---- fixed (unsigned): round-trip + cadd only (cmult/conj are signed-only) ----
+    cfg = FIXED_UNSIGNED
+    a, b = _fixed_int_operand(cfg, 2), _fixed_int_operand(cfg, 4)
+    cases.append(_mk_case(f"roundtrip_{cfg.name}", "roundtrip", _roundtrip_operand(cfg)))
+    cases.append(_mk_case(f"cadd_{cfg.name}", "cadd", a, b))
+
+    # ---- int (signed s8 / s16): round-trip + cmult/cadd/csub/conj ----
+    for cfg in INTS:
+        a, b = _fixed_int_operand(cfg, 2), _fixed_int_operand(cfg, 4)
+        cases.append(_mk_case(f"roundtrip_{cfg.name}", "roundtrip", _roundtrip_operand(cfg)))
+        for op in ("cmult", "cadd", "csub"):
+            cases.append(_mk_case(f"{op}_{cfg.name}", op, a, b))
+        cases.append(_mk_case(f"conj_{cfg.name}", "conj", a))
+
+    # ---- float (f32 / f64): round-trip + cmult (the edge) + cadd/csub/conj ----
+    # Rounding-TRIGGERING random operands (fixed seed): products are non-exact, so this
+    # genuinely exercises the complex-multiply edge (the explicit naive formula in
+    # complex_utils.hpp, bit-exact with cmult_float; numpy's FMA `*` would diverge).
+    rng = np.random.default_rng(20240607)
+    fa_vals = rng.standard_normal(64) + 1j * rng.standard_normal(64)
+    fb_vals = rng.standard_normal(64) + 1j * rng.standard_normal(64)
+    for cfg in FLOATS:
+        a, b = _float_operand(cfg, fa_vals), _float_operand(cfg, fb_vals)
+        cases.append(_mk_case(f"roundtrip_{cfg.name}", "roundtrip", _roundtrip_operand(cfg)))
+        for op in ("cmult", "cadd", "csub"):
+            cases.append(_mk_case(f"{op}_{cfg.name}", op, a, b))
+        cases.append(_mk_case(f"conj_{cfg.name}", "conj", a))
+
+    return [_case_dict(c) for c in cases]
+
+
+def _case_dict(c: Case) -> dict:
+    return {"name": c.name, "case": c, "expected": c.expected}
+
+
+# --- per-case source generation (headers + kernel + vectors) ------------------
+def _words_text(da: DataArray, word_bw: int) -> str:
+    words = np.asarray(write_array(da, word_bw=word_bw)).ravel()
+    return "\n".join(str(int(w)) for w in words) + "\n"
+
+
+def gen_case_sources(case_dict: dict, work_dir: Path) -> Path:
+    """Generate one case's dir: the generated headers (streamutils + wf_cint + complex_utils
+    + the in/out array-utils), the kernel, the packed-word input vectors, the golden bits."""
+    c: Case = case_dict["case"]
     work_dir = Path(work_dir)
     work_dir.mkdir(parents=True, exist_ok=True)
-    (work_dir / "kernel.cpp").write_text(case["kernel"], encoding="utf-8")
-    (work_dir / "in_a.txt").write_text(case["in_a"], encoding="utf-8")
-    (work_dir / "in_b.txt").write_text(case["in_b"], encoding="utf-8")
+
+    in_cf, out_cf = c.in_cf, c.out_cf
+    wbi, wbo = _wbw(in_cf), _wbw(out_cf)
+    n = int(np.asarray(c.a.val).shape[0])
+
+    # generated support headers
+    cfg = BuildConfig(root_dir=work_dir)
+    dag = BuildDag()
+    dag.add(StreamUtilsStep(output_dir="include"))
+    dag.run(cfg)
+    gen_array_utils(in_cf, [wbi], cfg=cfg, streamutils_dir="include")
+    if out_cf is not in_cf:
+        gen_array_utils(out_cf, [wbo], cfg=cfg, streamutils_dir="include")
+    for h in ("complex_utils.hpp", "wf_cint.h"):
+        shutil.copy(_BUILD_DIR / h, work_dir / h)
+
+    kernel = render_kernel(
+        op=c.op, in_cpp=in_cf.cpp_type, out_cpp=out_cf.cpp_type,
+        in_ns=_array_utils_namespace(in_cf), out_ns=_array_utils_namespace(out_cf),
+        in_hdr=_array_utils_filename(in_cf), out_hdr=_array_utils_filename(out_cf),
+        wbi=wbi, wbo=wbo, n=n,
+        nwa=get_nwords(in_cf, wbi, n), nwy=get_nwords(out_cf, wbo, n), binary=c.binary,
+    )
+    (work_dir / "kernel.cpp").write_text(kernel, encoding="utf-8")
+    (work_dir / "in_a.txt").write_text(_words_text(c.a, wbi), encoding="utf-8")
+    (work_dir / "in_b.txt").write_text(
+        _words_text(c.b, wbi) if c.binary else "0\n", encoding="utf-8")
     (work_dir / "expected.json").write_text(
-        json.dumps({"name": case["name"], "expected": case["expected"]}, indent=2),
-        encoding="utf-8")
+        json.dumps({"name": c.name, "expected": c.expected}, indent=2), encoding="utf-8")
     shutil.copy(_SOURCE_DIR / "run.tcl", work_dir / "run.tcl")
     return work_dir
 
@@ -307,18 +293,18 @@ def csim_and_compare(work_dir: Path, *, live_output: bool = False) -> dict:
             "exact": len(vitis) == len(exp) and not mism}
 
 
-def conformance_for_case(case: dict, work_dir: Path, *, live_output: bool = False) -> dict:
-    gen_case_sources(case, work_dir)
+def conformance_for_case(case_dict: dict, work_dir: Path, *, live_output: bool = False) -> dict:
+    gen_case_sources(case_dict, work_dir)
     return csim_and_compare(work_dir, live_output=live_output)
 
 
 # --- BuildDag steps -----------------------------------------------------------
 @dataclass(kw_only=True)
 class GenConformanceStep(BuildStep):
-    description = "Generate the per-case complex kernels + interleaved-I/Q vectors + Python golden bits."
+    description = "Generate the per-case headers (generated serialization) + complex_utils kernel + vectors."
     consumes = ["complex_source", "run_tcl", "kernels_source"]
     produces = {"conformance_gen": Path("gen")}
-    params = {}
+    params: dict = field(default_factory=dict)
 
     def run(self, config: BuildConfig, **_) -> dict:
         gen = config.root_dir / "gen"
@@ -330,10 +316,10 @@ class GenConformanceStep(BuildStep):
 
 @dataclass(kw_only=True)
 class RunConformanceStep(BuildStep):
-    description = "Per case: Vitis csim, assert Vitis bits == Python bits exactly (round-trip + arithmetic)."
+    description = "Per case: Vitis csim, assert Vitis words == Python write_array words exactly."
     consumes = ["conformance_gen"]
     produces = {"conformance_report": Path("results/conformance_report.json")}
-    params = {"live_output": False}
+    params: dict = field(default_factory=lambda: {"live_output": False})
 
     def run(self, config: BuildConfig, live_output, **_) -> dict:
         gen = config.root_dir / "gen"
@@ -350,7 +336,7 @@ class RunConformanceStep(BuildStep):
         if failed:
             raise RuntimeError(
                 f"STOP — Vitis disagreed with the Python model on {len(failed)}/{len(results)} "
-                "cases. The Python model is wrong, not Vitis; fix it, do not loosen the "
+                "cases. The Python model is the spec; fix the codegen/kernel, do not loosen the "
                 f"comparison. First failure: {failed[0]}")
         return {"conformance_report": report_path}
 
@@ -368,7 +354,7 @@ def build_complex_dag() -> BuildDag:
 def main() -> None:
     run_dag_cli(
         build_complex_dag,
-        description="Complex (ComplexField) Python-vs-Vitis bit-exact conformance (round-trip + arithmetic).",
+        description="Complex (ComplexField) Python-vs-Vitis bit-exact conformance (generated serialization + complex_utils.hpp).",
         default_through="gen_conformance",
         root_dir=_SOURCE_DIR,
         extra_args=[(("--live-output",), {"action": "store_true"})],

--- a/examples/schemas/complex/kernels.py
+++ b/examples/schemas/complex/kernels.py
@@ -1,185 +1,79 @@
-"""Generated complex C++ kernels for the ComplexField conformance harness.
+"""Complex conformance kernel renderer — the thin C-sim wrapper around the *generated*
+serialization + ``complex_utils.hpp`` arithmetic.
 
-Per inner type, a kernel reads interleaved-I/Q operand vectors (``re`` then ``im`` per
-element, one stored-int / double per line), reconstructs the complex value bit-for-bit,
-performs a v1 op, and writes the result stored bits (again interleaved ``re`` then
-``im``).  The Python ``DataArray[ComplexField]`` ops must produce identical bits.
+The kernel no longer hand-rolls component reconstruction / interleaving or inline complex
+arithmetic.  It:
 
-C++ mapping per inner (Phase-0 reference):
+1. reads packed words for the operand(s) (produced by ``arrayutils.write_array``),
+2. unpacks them into element buffers with the **generated** ``<type>_array_utils::read_array``
+   (the ``ComplexField`` C++ codegen from Phase 1),
+3. applies the op via **``complex_utils.hpp``** (``cmult`` / ``cadd`` / ``csub`` / ``conj``;
+   round-trip is the identity), and
+4. packs the result with the generated ``write_array`` and writes the words back.
 
-- **float**  -> ``std::complex<float>`` / ``std::complex<double>``; arithmetic uses
-  ``std::complex`` ``operator*``/``+`` directly -- the *float-complex-multiply edge* we
-  verify empirically.  Components (de)serialize as raw IEEE bits (``memcpy``).
-- **fixed**  -> ``std::complex<ap_fixed<W,I,Q,O>>``; arithmetic uses the **explicit
-  component formula** at the grown result format (``std::complex::operator*`` would
-  quantize the product back to the inner format -- see the reference), so the
-  full-precision growth matches the composed Python model bit-for-bit.
-- **int**    -> a Waveflow-emitted ``wf_cint`` struct (``std::complex<ap_int>`` is
-  non-standard); explicit component formula.
-
-All kernels share one ``argv`` signature ``(in_a, in_b, out_bits)`` so a single
-``run.tcl`` drives them (round-trip / conj ignore ``in_b``).
+Each operand / result is (de)serialized at ``word_bw = its element bitwidth`` (<=64), so the
+packing is one element per word -- exactly the layout ``arrayutils.write_array`` produces --
+making the Python golden and the kernel bit-identical by construction.  All kernels share the
+``argv`` signature ``(in_a, in_b, out_bits)`` (round-trip / conj ignore ``in_b``).
 """
 from __future__ import annotations
 
-_PREAMBLE = """#include <ap_fixed.h>
-#include <ap_int.h>
-#include <complex>
-#include <cstring>
-#include <fstream>
-#include <vector>
-
-static std::vector<unsigned long long> read_bits(const char* path) {
-    std::ifstream f(path);
-    std::vector<unsigned long long> v;
-    unsigned long long x;
-    while (f >> x) v.push_back(x);
-    return v;
+_OPCALL = {
+    "roundtrip": "a[i]",
+    "conj": "complex_utils::conj(a[i])",
+    "cmult": "complex_utils::cmult(a[i], b[i])",
+    "cadd": "complex_utils::cadd(a[i], b[i])",
+    "csub": "complex_utils::csub(a[i], b[i])",
 }
-"""
-
-# A Waveflow complex-int struct: std::complex<ap_int> is non-standard, so int-complex
-# is Waveflow's own struct (two ap_int<W>).
-_CINT_STRUCT = """
-template <int W> struct wf_cint { ap_int<W> re; ap_int<W> im; };
-"""
 
 
-# --- per-kind component reconstruct (from a stored-int / double) ---------------
-def _recon(kind: str, ctype: str, W: int, name: str, src: str) -> str:
-    """C++ declaring ``name`` of the inner type, set from operand expression ``src``."""
-    if kind == "float":
-        ute, ity = ("unsigned int", 4) if W == 32 else ("unsigned long long", 8)
-        return (f"        {ctype} {name}; {{ {ute} _t = ({ute}){src}; "
-                f"std::memcpy(&{name}, &_t, {ity}); }}")
-    if kind == "int":
-        return f"        ap_int<{W}> {name}; {name}.range({W} - 1, 0) = (ap_uint<{W}>){src};"
-    return f"        {ctype} {name}; {name}.range({W} - 1, 0) = (ap_uint<{W}>){src};"
+def render_kernel(
+    op: str, in_cpp: str, out_cpp: str, in_ns: str, out_ns: str,
+    in_hdr: str, out_hdr: str, wbi: int, wbo: int, n: int, nwa: int, nwy: int, binary: bool,
+) -> str:
+    """Render the C-sim kernel for one conformance case (see module docstring)."""
+    incs = [f'#include "{in_hdr}"']
+    if out_hdr != in_hdr:
+        incs.append(f'#include "{out_hdr}"')
+    nl = chr(10)
 
-
-# --- per-kind component emit (stored bits of a typed var) ----------------------
-def _emit(kind: str, W: int, name: str) -> str:
-    if kind == "float":
-        ute, ity = ("unsigned int", 4) if W == 32 else ("unsigned long long", 8)
-        return (f"        {{ {ute} _t; std::memcpy(&_t, &{name}, {ity}); "
-                f'out << (unsigned long long)_t << "\\n"; }}')
-    if kind == "int":
-        return f'        out << (unsigned long long)(ap_uint<{W}>){name}.range({W} - 1, 0) << "\\n";'
-    return f'        out << (unsigned long long){name}.range({W} - 1, 0) << "\\n";'
-
-
-def _main(body_decls: str, loop_body: str, reads_b: bool = True) -> str:
-    reads = "    auto A = read_bits(argv[1]);\n"
-    if reads_b:
-        reads += "    auto B = read_bits(argv[2]);\n"
-    return _PREAMBLE + _CINT_STRUCT + f"""
-int main(int argc, char** argv) {{
-{reads}    std::ofstream out(argv[3]);
-{body_decls}    for (size_t i = 0; i < A.size(); i += 2) {{
-{loop_body}    }}
-    return 0;
-}}
-"""
-
-
-# --- round-trip (load reals re, im into the complex type) ----------------------
-def render_load_real(kind: str, ctype: str, W: int) -> str:
-    """``y = complex(re, im)`` from interleaved doubles -> emit the stored bits.
-
-    fixed/float quantize on assignment into the inner type; int reads stored ints."""
-    if kind == "int":
-        loop = "\n".join([
-            _recon("int", ctype, W, "yr", "A[i]"),
-            _recon("int", ctype, W, "yi", "A[i + 1]"),
-            _emit("int", W, "yr"), _emit("int", W, "yi"),
+    b_block = ""
+    if binary:
+        b_block = nl.join([
+            f"  auto WB = rw(argv[2]);",
+            f"  static ap_uint<{wbi}> bw[{nwa}]; static {in_cpp} b[{n}];",
+            f"  for (int i = 0; i < {nwa}; ++i) bw[i] = ap_uint<{wbi}>(WB[i]);",
+            f"  {in_ns}::read_array<{wbi}>(bw, b, N);",
         ])
-        return _main("", loop + "\n", reads_b=False)
-    # float / fixed: read doubles, quantize on assignment
-    decl = "    double re, im;\n"
-    loop = "\n".join([
-        f"        {ctype} yr = re; {ctype} yi = im;",
-        _emit(kind, W, "yr"), _emit(kind, W, "yi"),
-    ])
-    body = (_PREAMBLE + f"""
-int main(int argc, char** argv) {{
-    std::ifstream fin(argv[1]);
-    std::ofstream out(argv[3]);
-{decl}    while (fin >> re >> im) {{
-{loop}
-    }}
-    return 0;
-}}
-""")
-    return body
 
-
-# --- cmult: (ar*br - ai*bi) + j(ar*bi + ai*br) --------------------------------
-def render_cmult(kind: str, ctype: str, W: int, rtype: str, Wr: int) -> str:
-    """Complex multiply; fixed/int use the explicit component formula at the grown
-    format ``rtype`` (``Wr`` bits); float uses ``std::complex`` ``operator*`` (the edge)."""
-    recon = "\n".join([
-        _recon(kind, ctype, W, "ar", "A[i]"), _recon(kind, ctype, W, "ai", "A[i + 1]"),
-        _recon(kind, ctype, W, "br", "B[i]"), _recon(kind, ctype, W, "bi", "B[i + 1]"),
-    ])
-    if kind == "float":
-        loop = "\n".join([
-            recon,
-            f"        std::complex<{ctype}> a(ar, ai), b(br, bi);",
-            f"        std::complex<{ctype}> y = a * b;",
-            f"        {ctype} yr = y.real(); {ctype} yi = y.imag();",
-            _emit(kind, Wr, "yr"), _emit(kind, Wr, "yi"),
-        ])
-    else:
-        loop = "\n".join([
-            recon,
-            f"        {rtype} yr = ar * br - ai * bi;",
-            f"        {rtype} yi = ar * bi + ai * br;",
-            _emit(kind, Wr, "yr"), _emit(kind, Wr, "yi"),
-        ])
-    return _main("", loop + "\n")
-
-
-# --- cadd / csub: componentwise -----------------------------------------------
-def render_caddsub(op: str, kind: str, ctype: str, W: int, rtype: str, Wr: int) -> str:
-    """``a +/- b`` componentwise; result components at the grown format ``rtype``."""
-    recon = "\n".join([
-        _recon(kind, ctype, W, "ar", "A[i]"), _recon(kind, ctype, W, "ai", "A[i + 1]"),
-        _recon(kind, ctype, W, "br", "B[i]"), _recon(kind, ctype, W, "bi", "B[i + 1]"),
-    ])
-    if kind == "float":
-        loop = "\n".join([
-            recon,
-            f"        std::complex<{ctype}> a(ar, ai), b(br, bi);",
-            f"        std::complex<{ctype}> y = a {op} b;",
-            f"        {ctype} yr = y.real(); {ctype} yi = y.imag();",
-            _emit(kind, Wr, "yr"), _emit(kind, Wr, "yi"),
-        ])
-    else:
-        loop = "\n".join([
-            recon,
-            f"        {rtype} yr = ar {op} br;",
-            f"        {rtype} yi = ai {op} bi;",
-            _emit(kind, Wr, "yr"), _emit(kind, Wr, "yi"),
-        ])
-    return _main("", loop + "\n")
-
-
-# --- conj: ar - j(ai) ---------------------------------------------------------
-def render_conj(kind: str, ctype: str, W: int, rtype: str, Wr: int) -> str:
-    """Conjugate; imag negated, result components at the grown format ``rtype``."""
-    recon = "\n".join([
-        _recon(kind, ctype, W, "ar", "A[i]"), _recon(kind, ctype, W, "ai", "A[i + 1]"),
-    ])
-    if kind == "float":
-        loop = "\n".join([
-            recon,
-            f"        {ctype} yr = ar; {ctype} yi = -ai;",
-            _emit(kind, Wr, "yr"), _emit(kind, Wr, "yi"),
-        ])
-    else:
-        loop = "\n".join([
-            recon,
-            f"        {rtype} yr = ar; {rtype} yi = -ai;",
-            _emit(kind, Wr, "yr"), _emit(kind, Wr, "yi"),
-        ])
-    return _main("", loop + "\n", reads_b=False)
+    lines = [
+        "// Generated complex conformance kernel (C-sim): generated serialization +",
+        "// complex_utils.hpp arithmetic.  argv = (in_a, in_b, out_bits).",
+        "#include <ap_int.h>",
+        "#include <fstream>",
+        "#include <vector>",
+        '#include "complex_utils.hpp"',
+        *incs,
+        "",
+        "static std::vector<unsigned long long> rw(const char* p) {",
+        "    std::ifstream f(p); std::vector<unsigned long long> v; unsigned long long x;",
+        "    while (f >> x) v.push_back(x); return v;",
+        "}",
+        "",
+        "int main(int argc, char** argv) {",
+        f"  const int N = {n};",
+        "  auto WA = rw(argv[1]);",
+        f"  static ap_uint<{wbi}> aw[{nwa}]; static {in_cpp} a[{n}];",
+        f"  for (int i = 0; i < {nwa}; ++i) aw[i] = ap_uint<{wbi}>(WA[i]);",
+        f"  {in_ns}::read_array<{wbi}>(aw, a, N);",
+        b_block,
+        f"  static {out_cpp} y[{n}];",
+        f"  for (int i = 0; i < N; ++i) y[i] = {_OPCALL[op]};",
+        f"  static ap_uint<{wbo}> yw[{nwy}];",
+        f"  {out_ns}::write_array<{wbo}>(y, yw, N);",
+        "  std::ofstream out(argv[3]);",
+        f"  for (int i = 0; i < {nwy}; ++i) out << (unsigned long long)yw[i] << char(10);",
+        "  return 0;",
+        "}",
+    ]
+    return nl.join(lines) + nl

--- a/tests/examples/test_complex_kernels.py
+++ b/tests/examples/test_complex_kernels.py
@@ -1,138 +1,70 @@
-"""Phase-3 codegen tests for the ComplexField C++ kernel renderers.
+"""Structure tests for the migrated ComplexField conformance kernel renderer.
 
-Structure tests (always run) lock the per-inner C++ contract: ``std::complex`` for
-float/fixed, the Waveflow ``wf_cint`` struct for int, the explicit component formula for
-fixed/int arithmetic, ``std::complex`` ``operator*`` for float (the edge), interleaved
-I/Q, and IEEE ``memcpy`` (de)serialization for float.  A ``@pytest.mark.vitis`` smoke
-test then confirms each inner's ``cmult`` kernel **csim-compiles and runs** on real Vitis.
+The kernel is now the thin C-sim wrapper around the **generated serialization** (the
+``<type>_array_utils::read_array`` / ``write_array`` from the ComplexField C++ codegen) and
+**``complex_utils.hpp``** arithmetic -- it no longer hand-rolls interleaving or the inline
+complex formula.  These tests lock that contract: the right includes, the
+``complex_utils::`` op calls, the generated ``read_array`` / ``write_array`` with the per-type
+word widths, and that round-trip is the identity / conj ignores ``in_b``.
+
+The end-to-end **bit-exact** Vitis conformance lives in ``test_complex_conformance.py``.
 """
-import shutil
-import sys
-from pathlib import Path
-
-import numpy as np
-import pytest
-
-_ROOT = Path(__file__).resolve().parents[2]
-if str(_ROOT) not in sys.path:
-    sys.path.insert(0, str(_ROOT))
-
-from examples.schemas.complex import kernels as K  # noqa: E402
-from waveflow.hw.complexfield import ComplexField, cmult  # noqa: E402
-from waveflow.hw.dataschema import DataArray, FloatField, IntField  # noqa: E402
-from waveflow.hw.fixpoint import FixedField  # noqa: E402
-from waveflow.toolchain import toolchain  # noqa: E402
-from waveflow.utils import complexutils as cx  # noqa: E402
-from waveflow.utils.fixputils import Format, to_bits  # noqa: E402
-
-_RUN_TCL = _ROOT / "examples" / "schemas" / "complex" / "run.tcl"
+from examples.schemas.complex.kernels import render_kernel
 
 
-# --- structure tests (no Vitis) -----------------------------------------------
-def test_cmult_fixed_uses_explicit_formula_at_grown_format():
-    k = K.render_cmult("fixed", "ap_fixed<8, 4, AP_TRN, AP_WRAP>", 8,
-                       "ap_fixed<17, 9, AP_TRN, AP_WRAP>", 17)
-    assert "ar * br - ai * bi" in k and "ar * bi + ai * br" in k
-    assert "ap_fixed<17, 9, AP_TRN, AP_WRAP> yr" in k
-    assert "std::complex" not in k.split("int main")[1]   # no operator* in the loop
-    assert ".range(8 - 1, 0) = (ap_uint<8>)A[i]" in k     # reconstruct from interleaved bits
-    assert 'out << (unsigned long long)yr.range(17 - 1, 0)' in k
+def _k(op, *, in_cpp="std::complex<ap_fixed<8, 4, AP_TRN, AP_WRAP>>",
+       out_cpp="std::complex<ap_fixed<17, 9, AP_TRN, AP_WRAP>>",
+       in_ns="complex__fixed8_4_array_utils", out_ns="complex__fixed17_9_array_utils",
+       in_hdr="complex__fixed8_4_array_utils.h", out_hdr="complex__fixed17_9_array_utils.h",
+       wbi=16, wbo=34, n=5, nwa=5, nwy=5, binary=True):
+    return render_kernel(op, in_cpp, out_cpp, in_ns, out_ns, in_hdr, out_hdr,
+                         wbi, wbo, n, nwa, nwy, binary)
 
 
-def test_cmult_int_emits_wf_cint_and_explicit_formula():
-    k = K.render_cmult("int", "ap_int<8>", 8, "ap_int<17>", 17)
-    assert "struct wf_cint" in k
-    assert "ar * br - ai * bi" in k and "ap_int<17> yr" in k
-    assert "(unsigned long long)(ap_uint<17>)yr.range(17 - 1, 0)" in k
+def test_kernel_uses_complex_utils_and_generated_serialization():
+    k = _k("cmult")
+    assert '#include "complex_utils.hpp"' in k
+    assert '#include "complex__fixed8_4_array_utils.h"' in k          # input serialization
+    assert '#include "complex__fixed17_9_array_utils.h"' in k         # result serialization
+    assert "complex_utils::cmult(a[i], b[i])" in k                    # arithmetic via the header
+    assert "complex__fixed8_4_array_utils::read_array<16>(aw, a, N)" in k
+    assert "complex__fixed17_9_array_utils::write_array<34>(y, yw, N)" in k
+    # no hand-rolled interleaving / inline formula
+    assert "ar * br - ai * bi" not in k and "memcpy" not in k
 
 
-def test_cmult_float_uses_std_complex_operator_and_memcpy():
-    k = K.render_cmult("float", "float", 32, "float", 32)
-    assert "std::complex<float> a(ar, ai), b(br, bi);" in k
-    assert "std::complex<float> y = a * b;" in k          # the float edge
-    assert "std::memcpy" in k
+def test_op_call_dispatch():
+    assert "complex_utils::cadd(a[i], b[i])" in _k("cadd")
+    assert "complex_utils::csub(a[i], b[i])" in _k("csub")
+    assert "complex_utils::conj(a[i])" in _k("conj", binary=False, out_cpp=None or
+                                            "std::complex<ap_fixed<9, 5, AP_TRN, AP_WRAP>>",
+                                            out_ns="complex__fixed9_5_array_utils",
+                                            out_hdr="complex__fixed9_5_array_utils.h", wbo=18)
+    assert "y[i] = a[i];" in _k("roundtrip", binary=False, out_cpp=None or
+                                "std::complex<ap_fixed<8, 4, AP_TRN, AP_WRAP>>",
+                                out_ns="complex__fixed8_4_array_utils",
+                                out_hdr="complex__fixed8_4_array_utils.h", wbo=16)
 
 
-def test_load_real_quantizes_fixed_and_reads_stored_int():
-    kf = K.render_load_real("fixed", "ap_fixed<8, 4, AP_TRN, AP_WRAP>", 8)
-    assert "while (fin >> re >> im)" in kf
-    assert "ap_fixed<8, 4, AP_TRN, AP_WRAP> yr = re;" in kf
-    ki = K.render_load_real("int", "ap_int<8>", 8)
-    assert "read_bits(argv[1])" in ki and ">> re >> im" not in ki
+def test_binary_reads_in_b_unary_does_not():
+    binary = _k("cadd")
+    assert "rw(argv[2])" in binary and "read_array<16>(bw, b, N)" in binary
+    unary = _k("conj", binary=False)
+    assert "rw(argv[2])" not in unary and " b[" not in unary
 
 
-def test_caddsub_and_conj_structure():
-    ka = K.render_caddsub("+", "fixed", "ap_fixed<8, 4, AP_TRN, AP_WRAP>", 8,
-                          "ap_fixed<9, 5, AP_TRN, AP_WRAP>", 9)
-    assert "ar + br" in ka and "ai + bi" in ka
-    kc = K.render_conj("fixed", "ap_fixed<8, 4, AP_TRN, AP_WRAP>", 8,
-                       "ap_fixed<9, 5, AP_TRN, AP_WRAP>", 9)
-    assert "yi = -ai" in kc and "read_bits(argv[2])" not in kc   # conj ignores in_b
+def test_roundtrip_same_type_single_include():
+    # round-trip in/out types coincide -> only one array-utils include
+    k = _k("roundtrip", binary=False, out_cpp="std::complex<ap_fixed<8, 4, AP_TRN, AP_WRAP>>",
+           out_ns="complex__fixed8_4_array_utils", out_hdr="complex__fixed8_4_array_utils.h",
+           wbo=16)
+    assert k.count("complex__fixed8_4_array_utils.h") == 1
 
 
-# --- Vitis smoke: cmult csim-compiles & runs per inner ------------------------
-def _da(cf, val):
-    arr = np.asarray(val)
-    return DataArray.specialize(cf, max_shape=(arr.shape[0],))(arr)
-
-
-def _interleave(struct, W):
-    re = np.atleast_1d(to_bits(np.asarray(struct["re"]), W))
-    im = np.atleast_1d(to_bits(np.asarray(struct["im"]), W))
-    return [int(x) for pair in zip(re, im) for x in pair]
-
-
-def _float_bits(arr):
-    return [int(x) for z in np.atleast_1d(arr) for x in
-            (np.asarray(np.float32(z.real)).view(np.uint32),
-             np.asarray(np.float32(z.imag)).view(np.uint32))]
-
-
-def _csim(tmp_path, kernel, in_a, in_b):
-    (tmp_path / "kernel.cpp").write_text(kernel, encoding="utf-8")
-    (tmp_path / "in_a.txt").write_text("\n".join(map(str, in_a)) + "\n", encoding="utf-8")
-    (tmp_path / "in_b.txt").write_text("\n".join(map(str, in_b)) + "\n", encoding="utf-8")
-    shutil.copy(_RUN_TCL, tmp_path / "run.tcl")
-    toolchain.run_vitis_hls(tmp_path / "run.tcl", work_dir=tmp_path, capture_output=True)
-    return [int(t) for t in (tmp_path / "out_bits.txt").read_text().split()]
-
-
-@pytest.mark.vitis
-def test_cmult_csim_compiles_and_runs_fixed(tmp_path):
-    if not toolchain.find_vitis_path():
-        pytest.skip("Vitis installation not found.")
-    inner = FixedField.specialize(8, 4, True)
-    a = _da(ComplexField.specialize(inner), cx.make_complex([1, -2], [3, 4], Format(8, 4, True)))
-    b = _da(ComplexField.specialize(inner), cx.make_complex([2, 1], [-1, 2], Format(8, 4, True)))
-    out = cmult(a, b)
-    ri = out.element_type.inner_type
-    k = K.render_cmult("fixed", inner.cpp_type, 8, ri.cpp_type, ri.get_bitwidth())
-    got = _csim(tmp_path, k, _interleave(a.val, 8), _interleave(b.val, 8))
-    assert len(got) == 4   # 2 elements x (re, im) — compiles and runs
-
-
-@pytest.mark.vitis
-def test_cmult_csim_compiles_and_runs_int(tmp_path):
-    if not toolchain.find_vitis_path():
-        pytest.skip("Vitis installation not found.")
-    inner = IntField.specialize(8, True)
-    fmt = cx.int_format(8, True)
-    a = _da(ComplexField.specialize(inner), cx.make_complex([1, -2], [3, 4], fmt))
-    b = _da(ComplexField.specialize(inner), cx.make_complex([2, 1], [-1, 2], fmt))
-    out = cmult(a, b)
-    ri = out.element_type.inner_type
-    k = K.render_cmult("int", "ap_int<8>", 8, f"ap_int<{ri.get_bitwidth()}>", ri.get_bitwidth())
-    got = _csim(tmp_path, k, _interleave(a.val, 8), _interleave(b.val, 8))
-    assert len(got) == 4
-
-
-@pytest.mark.vitis
-def test_cmult_csim_compiles_and_runs_float(tmp_path):
-    if not toolchain.find_vitis_path():
-        pytest.skip("Vitis installation not found.")
-    cf = ComplexField.specialize(FloatField.specialize(32))
-    a = _da(cf, np.array([1 + 2j, -3 + 0.5j], dtype=np.complex64))
-    b = _da(cf, np.array([0.5 - 1j, 4 + 2j], dtype=np.complex64))
-    k = K.render_cmult("float", "float", 32, "float", 32)
-    got = _csim(tmp_path, k, _float_bits(a.val), _float_bits(b.val))
-    assert len(got) == 4
+def test_int_kernel_uses_wf_cint():
+    k = _k("cmult", in_cpp="wf_cint<8>", out_cpp="wf_cint<17>",
+           in_ns="complex__int8_array_utils", out_ns="complex__int17_array_utils",
+           in_hdr="complex__int8_array_utils.h", out_hdr="complex__int17_array_utils.h",
+           wbi=16, wbo=34)
+    assert "static wf_cint<8> a[5]" in k and "static wf_cint<17> y[5]" in k
+    assert "complex_utils::cmult(a[i], b[i])" in k

--- a/tests/hw/test_complex_utils_hpp.py
+++ b/tests/hw/test_complex_utils_hpp.py
@@ -1,0 +1,113 @@
+"""complex_utils.hpp — standalone host-compile sanity check (no Vitis synthesis).
+
+Phase 2 of plans/complex_serialization.md adds ``waveflow/build/complex_utils.hpp``: the Vitis
+complex arithmetic (``cmult`` / ``cadd`` / ``csub`` / ``conj``) over the element ``cpp_type``,
+the **explicit re/im formula at full precision** (NOT ``std::complex`` ``operator*``), mirroring
+``waveflow/utils/complexutils.py``'s result growth.
+
+This test compiles a small program that ``#include``s the header against the **real Vitis
+``ap_int`` / ``ap_fixed`` headers** with a host C++ compiler (g++), then runs it.  It does NOT
+invoke Vitis HLS synthesis (that bit-exact conformance is Phase 3).  ``static_assert``s pin the
+result component widths to the Python ``*_format`` growth; runtime checks pin a few values.
+
+Skipped when a host C++ compiler or the Vitis include dir is not found.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from waveflow.toolchain import toolchain
+
+_HEADER_DIR = Path(__file__).resolve().parents[2] / "waveflow" / "build"
+
+
+def _vitis_include_dir() -> Path | None:
+    """Locate the Vitis include dir (holding ap_int.h / ap_fixed.h) from the toolchain path."""
+    vitis = toolchain.find_vitis_path()
+    if not vitis:
+        return None
+    # find_vitis_path -> .../Vitis/bin/vitis-run(.bat); the headers live in .../Vitis/include
+    for parent in Path(vitis).resolve().parents:
+        cand = parent / "include" / "ap_int.h"
+        if cand.exists():
+            return cand.parent
+    return None
+
+
+_CXX = next((c for c in ("g++", "c++") if shutil.which(c)), None)
+_VITIS_INC = _vitis_include_dir()
+
+_PROGRAM = r"""
+#include "complex_utils.hpp"
+#include <type_traits>
+#include <cstdio>
+
+template <typename A, typename B> struct same { static const bool ok = false; };
+template <typename A> struct same<A, A> { static const bool ok = true; };
+template <typename Z> struct comp {
+    typedef typename std::decay<decltype(std::declval<Z>().real())>::type type;
+};
+
+int main() {
+    // fixed inner ap_fixed<8,4>: cmult -> (17,9); cadd/csub/conj -> (9,5)
+    typedef ap_fixed<8,4,AP_TRN,AP_WRAP> F;
+    std::complex<F> a(F(1.5), F(-2.25)), b(F(0.75), F(3.0));
+    static_assert(comp<decltype(complex_utils::cmult(a,b))>::type::width  == 17, "cmult fixed W");
+    static_assert(comp<decltype(complex_utils::cmult(a,b))>::type::iwidth ==  9, "cmult fixed I");
+    static_assert(comp<decltype(complex_utils::cadd(a,b))>::type::width   ==  9, "cadd fixed W");
+    static_assert(comp<decltype(complex_utils::csub(a,b))>::type::width   ==  9, "csub fixed W");
+    static_assert(comp<decltype(complex_utils::conj(a))>::type::width     ==  9, "conj fixed W");
+    static_assert(comp<decltype(complex_utils::conj(a))>::type::iwidth    ==  5, "conj fixed I");
+
+    // unsigned cadd stays unsigned, grows to (9,5)
+    typedef ap_ufixed<8,4,AP_TRN,AP_WRAP> UF;
+    std::complex<UF> ua(UF(1.5),UF(2.25)), ub(UF(0.75),UF(3.0));
+    static_assert(comp<decltype(complex_utils::cadd(ua,ub))>::type::width == 9, "cadd ufixed W");
+
+    // int inner wf_cint<8>: cmult -> wf_cint<17>; cadd/csub/conj -> wf_cint<9>
+    wf_cint<8> ia(ap_int<8>(3), ap_int<8>(-4)), ib(ap_int<8>(2), ap_int<8>(5));
+    static_assert(same<decltype(complex_utils::cmult(ia,ib)), wf_cint<17> >::ok, "cmult int");
+    static_assert(same<decltype(complex_utils::cadd(ia,ib)),  wf_cint<9>  >::ok, "cadd int");
+    static_assert(same<decltype(complex_utils::csub(ia,ib)),  wf_cint<9>  >::ok, "csub int");
+    static_assert(same<decltype(complex_utils::conj(ia)),     wf_cint<9>  >::ok, "conj int");
+
+    // float inner: no growth (std::complex<float>); explicit naive formula
+    std::complex<float> fa(1.0f, 2.0f), fb(3.0f, -4.0f);
+    static_assert(same<decltype(complex_utils::cmult(fa,fb)), std::complex<float> >::ok, "cmult f32");
+
+    int rc = 0;
+    auto fm = complex_utils::cmult(fa, fb);  // (1+2i)(3-4i) = 11 + 2i
+    if (!(fm.real() == 11.0f && fm.imag() == 2.0f)) { printf("FAIL f cmult\n"); rc = 1; }
+    auto fc = complex_utils::conj(fa);       // conj(1+2i) = 1 - 2i
+    if (!(fc.real() == 1.0f && fc.imag() == -2.0f)) { printf("FAIL f conj\n"); rc = 1; }
+    auto im = complex_utils::cmult(ia, ib);  // (3-4i)(2+5i) = 26 + 7i
+    if (!((int)im.re == 26 && (int)im.im == 7)) { printf("FAIL i cmult\n"); rc = 1; }
+    auto ic = complex_utils::conj(ia);       // conj(3-4i) = 3 + 4i
+    if (!((int)ic.re == 3 && (int)ic.im == 4)) { printf("FAIL i conj\n"); rc = 1; }
+    if (rc == 0) printf("OK\n");
+    return rc;
+}
+"""
+
+
+@pytest.mark.skipif(_CXX is None, reason="no host C++ compiler (g++) found")
+@pytest.mark.skipif(_VITIS_INC is None, reason="Vitis include dir (ap_int.h) not found")
+def test_complex_utils_hpp_compiles_and_runs(tmp_path):
+    src = tmp_path / "cu_check.cpp"
+    src.write_text(_PROGRAM, encoding="utf-8")
+    exe = tmp_path / "cu_check.exe"
+    compile_cmd = [
+        _CXX, "-std=c++14",
+        "-I", str(_HEADER_DIR),
+        "-I", str(_VITIS_INC),
+        str(src), "-o", str(exe),
+    ]
+    cp = subprocess.run(compile_cmd, capture_output=True, text=True)
+    assert cp.returncode == 0, (
+        "complex_utils.hpp failed to compile (static_asserts pin the result widths to the "
+        f"Python *_format growth):\n{cp.stderr}")
+    run = subprocess.run([str(exe)], capture_output=True, text=True)
+    assert run.returncode == 0 and "OK" in run.stdout, (
+        f"complex_utils.hpp value checks failed:\n{run.stdout}\n{run.stderr}")

--- a/tests/hw/test_complexfield_codegen.py
+++ b/tests/hw/test_complexfield_codegen.py
@@ -1,0 +1,124 @@
+"""ComplexField C++ codegen protocol — the generated serialization mirrors the Python one.
+
+``ComplexField`` packs interleaved I/Q (``inner.serialize(re)`` then ``inner.serialize(im)``,
+``im`` in the high ``inner_bw`` bits) via ``_serialize_recursive``.  Phase 1 adds the matching
+**C++ codegen protocol** (``to_uint_expr`` / ``from_uint_expr`` / ``_gen_read_recursive`` /
+``_gen_write_recursive`` + include handling) so the general ``array_utils`` packs complex
+directly.  These non-vitis tests prove:
+
+1. the Python ``read_array`` / ``write_array`` round-trip over ``DataArray[ComplexField]`` is
+   bit-exact (int / fixed / float inners, word_bw 32 & 64);
+2. the Python serialization layout is *re in the low ``inner_bw`` bits, im in the high* — the
+   exact layout the generated ``to_uint_expr`` (``re | (im << inner_bw)``) reproduces;
+3. ``gen_array_utils`` generates a well-formed header for a complex element (the packed,
+   single-per-word, and wide multi-word paths), with the right ``cpp_type`` construction and
+   ``<complex>`` / ``wf_cint`` include.
+
+Bit-exactness against real Vitis is the Phase-3 gate; here it is the Python spec + structure.
+"""
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from waveflow.build.build import BuildConfig, BuildDag
+from waveflow.build.streamutils import StreamUtilsStep
+from waveflow.hw.arrayutils import gen_array_utils, read_array, write_array
+from waveflow.hw.complexfield import ComplexField
+from waveflow.hw.dataschema import DataArray, FloatField, IntField
+from waveflow.hw.fixpoint import FixedField
+from waveflow.utils import complexutils as cx
+
+
+def _inner(kind: str):
+    return {
+        "int": IntField.specialize(16, signed=True),
+        "fixed": FixedField.specialize(8, 4, True),
+        "float": FloatField.specialize(32),
+    }[kind]
+
+
+def _operand(kind: str) -> DataArray:
+    inner = _inner(kind)
+    cf = ComplexField.specialize(inner)
+    n = 5
+    if kind == "float":
+        rng = np.random.default_rng(7)
+        val = (rng.standard_normal(n) + 1j * rng.standard_normal(n)).astype(np.complex64)
+    else:
+        fmt = inner.get_format() if kind == "fixed" else cx.int_format(16, True)
+        re = np.array([-128, -1, 0, 7, 127], dtype=np.int64) if kind == "fixed" else \
+            np.array([-32768, -1, 0, 12345, 32767], dtype=np.int64)
+        im = np.roll(re, 2)
+        val = cx.make_complex(re, im, fmt)
+    return DataArray.specialize(cf, max_shape=(n,))(val)
+
+
+# --- 1. Python read_array/write_array round-trip is bit-exact ------------------
+@pytest.mark.parametrize("kind", ["int", "fixed", "float"])
+@pytest.mark.parametrize("word_bw", [32, 64])
+def test_read_write_array_roundtrip_bit_exact(kind, word_bw):
+    da = _operand(kind)
+    cf = type(da).element_type
+    words = write_array(da, word_bw=word_bw)
+    back = read_array(words, cf, word_bw=word_bw, shape=(np.asarray(da.val).shape[0],))
+    a, b = np.asarray(da.val), np.asarray(back.val)
+    if kind == "float":
+        # identical bits (the values round-trip exactly through the IEEE bit view)
+        assert np.array_equal(a.real, b.real) and np.array_equal(a.imag, b.imag)
+    else:
+        assert np.array_equal(a["re"], b["re"]) and np.array_equal(a["im"], b["im"])
+
+
+# --- 2. the Python layout is re-low / im-high (what to_uint_expr reproduces) ----
+@pytest.mark.parametrize("kind", ["int", "fixed", "float"])
+def test_serialize_layout_is_re_low_im_high(kind):
+    inner = _inner(kind)
+    cf = ComplexField.specialize(inner)
+    bw = inner.get_bitwidth()
+    # one element, in a single wide word so the bit layout is directly inspectable
+    word_bw = 2 * bw
+    da = _operand(kind)
+    one = DataArray.specialize(cf, max_shape=(1,))(np.asarray(da.val)[:1])
+    word = int(np.asarray(write_array(one, word_bw=word_bw)).ravel()[0])
+    re_bits, im_bits = word & ((1 << bw) - 1), (word >> bw) & ((1 << bw) - 1)
+
+    # the inner field serialized for the same re / im must equal the low / high halves
+    rf, imf = inner(), inner()
+    v = np.asarray(da.val)[0]
+    if kind == "float":
+        rf.val, imf.val = float(v.real), float(v.imag)
+    else:
+        rf.val, imf.val = int(v["re"]), int(v["im"])
+    assert int(np.asarray(rf.serialize(word_bw=bw)).ravel()[0]) == re_bits
+    assert int(np.asarray(imf.serialize(word_bw=bw)).ravel()[0]) == im_bits
+
+    # the generated to_uint_expr mirrors this: re unshifted, im shifted by inner_bw
+    expr = cf.to_uint_expr("v")
+    assert cf._cpp_re("v") in expr and f"<< {bw}" in expr
+
+
+# --- 3. gen_array_utils produces a well-formed header for a complex element -----
+@pytest.mark.parametrize("kind", ["int", "fixed", "float"])
+def test_gen_array_utils_generates_complex_header(kind):
+    inner = _inner(kind)
+    cf = ComplexField.specialize(inner)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        cfg = BuildConfig(root_dir=root)
+        dag = BuildDag()
+        dag.add(StreamUtilsStep(output_dir="include"))
+        dag.run(cfg)
+        path = gen_array_utils(cf, [32, 64], cfg=cfg, streamutils_dir="include")
+        hdr = Path(path).read_text(encoding="utf-8")
+
+    expected_include = "#include \"wf_cint.h\"" if kind == "int" else "#include <complex>"
+    assert expected_include in hdr
+    # both read/write specializations construct the cpp_type from (re, im) halves
+    assert f"value_type = {cf.cpp_type}" in hdr
+    assert "read_array<32>" in hdr and "read_array<64>" in hdr
+    assert "write_array<32>" in hdr and "write_array<64>" in hdr
+    # the wide (multi-word, word_bw=32 for a >32-bit element) path declares re/im temps
+    if cf.get_bitwidth() > 32:
+        assert "__wf_re" in hdr and "__wf_im" in hdr

--- a/waveflow/build/complex_utils.hpp
+++ b/waveflow/build/complex_utils.hpp
@@ -1,0 +1,107 @@
+#ifndef WAVEFLOW_COMPLEX_UTILS_HPP
+#define WAVEFLOW_COMPLEX_UTILS_HPP
+
+// Self-contained Vitis HLS complex arithmetic for Waveflow ComplexField elements.
+//
+// Mirrors waveflow/utils/complexutils.py exactly: the **explicit re/im formula at FULL
+// PRECISION** (ar*br - ai*bi, ar*bi + ai*br) -- NOT std::complex operator*, which
+// FMA-contracts (float) / quantizes the product back to the input format (ap_fixed).  Works
+// for both the std::complex<T> element (float / ap_fixed inner) and the wf_cint<W> element
+// (ap_int inner; std::complex<ap_int> is non-standard).
+//
+// The result component type is computed by the native ap_int / ap_fixed / float operators,
+// which widen exactly as the Python *_format rules do, so the result grows identically:
+//
+//   cmult -> (2W+1, 2I+1, signed)     conj -> (W+1, I+1, signed)
+//   cadd  -> add_format (int bits +1)  csub -> sub_format (always signed)
+//
+// The result type is always wide enough to hold the full-precision value, so no rounding /
+// overflow occurs -- the Q/O modes are irrelevant to the produced bits, hence bit-exact with
+// the composed Python model.
+
+#include <ap_fixed.h>
+#include <ap_int.h>
+#include <complex>
+
+#include "wf_cint.h"
+
+// Keep the float explicit formula as three IEEE-rounded ops (ar*br, ai*bi, then subtract) --
+// no fused-multiply-add contraction -- so it is bit-exact with cmult_float's naive formula.
+#pragma STDC FP_CONTRACT OFF
+
+namespace complex_utils {
+
+// --- element component accessors: std::complex<T> .real()/.imag() vs wf_cint<W> .re/.im ---
+template <typename T>
+static inline T cu_re(const std::complex<T>& z) { return z.real(); }
+template <typename T>
+static inline T cu_im(const std::complex<T>& z) { return z.imag(); }
+template <int W>
+static inline ap_int<W> cu_re(const wf_cint<W>& z) { return z.re; }
+template <int W>
+static inline ap_int<W> cu_im(const wf_cint<W>& z) { return z.im; }
+
+// --- result element type: same family as the input C, with component type Comp ---
+template <typename C, typename Comp>
+struct cu_result;
+template <typename T, typename Comp>
+struct cu_result<std::complex<T>, Comp> { typedef std::complex<Comp> type; };
+template <int W, typename Comp>
+struct cu_result<wf_cint<W>, Comp> { typedef wf_cint<Comp::width> type; };
+
+template <typename C, typename Comp>
+static inline typename cu_result<C, Comp>::type cu_make(const Comp& re, const Comp& im) {
+    return typename cu_result<C, Comp>::type(re, im);
+}
+
+// The return type of each op is deduced (C++14 `auto`) from its body, so it follows the
+// native ap_int / ap_fixed / float operator widening exactly -- the same growth the Python
+// *_format rules apply.  (A trailing `decltype(...)` return type is both redundant and, for
+// ap_fixed subtraction, mis-deduced -- so the body is the single source of truth.)
+
+// --- cmult: (ar*br - ai*bi) + j(ar*bi + ai*br), full precision ------------------
+// Named products (matching cmult's p_rr / p_ii / p_ri / p_ir) keep the op order explicit.
+template <typename C>
+static inline auto cmult(const C& a, const C& b) {
+#pragma HLS INLINE
+    auto p_rr = cu_re(a) * cu_re(b);
+    auto p_ii = cu_im(a) * cu_im(b);
+    auto p_ri = cu_re(a) * cu_im(b);
+    auto p_ir = cu_im(a) * cu_re(b);
+    auto re = p_rr - p_ii;   // sub_format(P, P) -> (2W+1, 2I+1, signed)
+    auto im = p_ri + p_ir;   // add_format(P, P) -> same format
+    return cu_make<C>(re, im);
+}
+
+// --- cadd: (ar+br) + j(ai+bi) (add_format: int bits +1; inner signedness rule) --
+template <typename C>
+static inline auto cadd(const C& a, const C& b) {
+#pragma HLS INLINE
+    auto re = cu_re(a) + cu_re(b);
+    auto im = cu_im(a) + cu_im(b);
+    return cu_make<C>(re, im);
+}
+
+// --- csub: (ar-br) + j(ai-bi) (sub_format: always signed) -----------------------
+template <typename C>
+static inline auto csub(const C& a, const C& b) {
+#pragma HLS INLINE
+    auto re = cu_re(a) - cu_re(b);
+    auto im = cu_im(a) - cu_im(b);
+    return cu_make<C>(re, im);
+}
+
+// --- conj: ar - j(ai) (result (W+1, I+1, signed); im = 0 - ai, re widened to match) --
+template <typename C>
+static inline auto conj(const C& a) {
+#pragma HLS INLINE
+    auto im_in = cu_im(a);
+    decltype(im_in) zero = 0;
+    auto im = zero - im_in;        // 0 - ai (sub widens to (W+1, I+1, signed)) == cx.conj
+    decltype(im) re = cu_re(a);    // widen re losslessly into the same format
+    return cu_make<C>(re, im);
+}
+
+}  // namespace complex_utils
+
+#endif  // WAVEFLOW_COMPLEX_UTILS_HPP

--- a/waveflow/build/streamutils_hls.h
+++ b/waveflow/build/streamutils_hls.h
@@ -54,6 +54,31 @@ namespace streamutils {
     }
 
     /**
+     * Reinterprets the 64 bits of a double as an unsigned integer
+     * (bit pattern, no value conversion) -- the double analogue of float_to_uint.
+     */
+    inline uint64_t double_to_uint(double d) {
+        union {
+            double d_val;
+            uint64_t u_val;
+        } converter;
+        converter.d_val = d;
+        return converter.u_val;
+    }
+
+    /**
+     * Reinterprets a 64-bit unsigned integer as a double.
+     */
+    inline double uint_to_double(uint64_t u) {
+        union {
+            uint64_t u_val;
+            double d_val;
+        } converter;
+        converter.u_val = u;
+        return converter.d_val;
+    }
+
+    /**
      * Reinterprets the raw bits of an ap_fixed/ap_ufixed value as an unsigned
      * integer of the same width (the .range() bit pattern) — a bit-reinterpret,
      * NOT a value conversion. Templated on the fixed-point type T (uses T::width),

--- a/waveflow/build/wf_cint.h
+++ b/waveflow/build/wf_cint.h
@@ -1,0 +1,19 @@
+#ifndef WAVEFLOW_WF_CINT_H
+#define WAVEFLOW_WF_CINT_H
+
+// Waveflow complex-integer element.  std::complex<ap_int> is non-standard, so an
+// integer-inner ComplexField maps to this two-ap_int struct (interleaved re/im),
+// providing the same (re, im) two-arg construction and .re/.im access the generated
+// serialization / arithmetic codegen emits for std::complex<T>.
+
+#include <ap_int.h>
+
+template <int W>
+struct wf_cint {
+    ap_int<W> re;
+    ap_int<W> im;
+    wf_cint() : re(0), im(0) {}
+    wf_cint(ap_int<W> r, ap_int<W> i) : re(r), im(i) {}
+};
+
+#endif  // WAVEFLOW_WF_CINT_H

--- a/waveflow/hw/arrayutils.py
+++ b/waveflow/hw/arrayutils.py
@@ -1318,6 +1318,11 @@ def _gen_array_utils_content(
         f'#include "{_relative_streamutils_include(elem_type, root_dir, su_dir)}"',
     ]
 
+    # Raw type includes the element's cpp_type needs (e.g. <complex> / the wf_cint header
+    # for a ComplexField element); the body carries its own <…> / "…" delimiters.
+    for inc in elem_type.get_codegen_includes():
+        lines.append(f"#include {inc}")
+
     if elem_include is not None:
         lines.append(f'#include "{elem_include}"')
 

--- a/waveflow/hw/arrayutils.py
+++ b/waveflow/hw/arrayutils.py
@@ -447,6 +447,47 @@ def _get_write_recursive_lines(
     return [str(line) for line in lines]
 
 
+def _wide_stream_elem_body(
+    elem_type: type[DataSchema], bw: int, i3: str, kind: str,
+) -> list[str]:
+    """Body of a stream-elem helper's wide-element branch (``elem_bw > word_bw``).
+
+    ``DataList`` elements use their generated stream member methods (``read_stream`` etc.);
+    every other element (scalar / ``ComplexField``) composes the **recursive serialization**
+    over the stream, so a wide element (e.g. ``std::complex<double>`` at word_bw 64) packs in
+    streams the same way it does in m_axi arrays -- no assumed member method.
+    """
+    if issubclass(elem_type, DataList):
+        member = {
+            "read_stream": f"out[0].template read_stream<{bw}>(s);",
+            "read_axi4": f"out[0].template read_axi4_stream<{bw}>(s, tl);",
+            "write_stream": f"in[0].template write_stream<{bw}>(s);",
+            "write_axi4": f"in[0].template write_axi4_stream<{bw}>(s, tlast);",
+        }[kind]
+        return [f"{i3}{member}"]
+
+    if kind in ("read_stream", "read_axi4"):
+        src_type = "stream" if kind == "read_stream" else "axi4_stream"
+        decls = [f"{i3}ap_uint<{bw}> w;"]
+        if kind == "read_axi4":
+            decls.append(f"{i3}bool last = false;")
+        rec = elem_type._gen_read_recursive(
+            word_bw=bw, src_type=src_type, source="s", prefix="", member_name="out[0]")[0]
+    else:
+        dst_type = "stream" if kind == "write_stream" else "axi4_stream"
+        decls = [f"{i3}ap_uint<{bw}> w = 0;"]
+        if kind == "write_axi4":
+            decls.append(f"{i3}(void)tlast;")
+        rec = elem_type._gen_write_recursive(
+            word_bw=bw, dst_type=dst_type, target="s", prefix="", member_name="in[0]")[0]
+
+    body = list(decls)
+    for line in rec:
+        stripped = line[4:] if line.startswith("    ") else line
+        body.append(f"{i3}{stripped}" if stripped else "")
+    return body
+
+
 def _gen_reader_body(elem_type: type[DataSchema], word_bw: int, indent_level: int = 1) -> str:
     indent = elem_type._get_indent(indent_level)
     i1 = elem_type._get_indent(indent_level + 1)
@@ -702,7 +743,7 @@ def _gen_read_axi4_stream_elem_specializations(
                 lines.append(f"{i2}}}")
             else:
                 lines.append(f"{i2}if (n > 0) {{")
-                lines.append(f"{i3}out[0].template read_axi4_stream<{bw}>(s, tl);")
+                lines.extend(_wide_stream_elem_body(elem_type, bw, i3, "read_axi4"))
                 lines.append(f"{i2}}}")
         lines.extend([
             f"{i1}}}",
@@ -932,7 +973,7 @@ def _gen_read_stream_elem_specializations(
                 lines.append(f"{i2}}}")
             else:
                 lines.append(f"{i2}if (n > 0) {{")
-                lines.append(f"{i3}out[0].template read_stream<{bw}>(s);")
+                lines.extend(_wide_stream_elem_body(elem_type, bw, i3, "read_stream"))
                 lines.append(f"{i2}}}")
         lines.extend([
             f"{i1}}}",
@@ -1000,7 +1041,7 @@ def _gen_write_stream_elem_specializations(
                 lines.append(f"{i2}}}")
             else:
                 lines.append(f"{i2}if (n > 0) {{")
-                lines.append(f"{i3}in[0].template write_stream<{bw}>(s);")
+                lines.extend(_wide_stream_elem_body(elem_type, bw, i3, "write_stream"))
                 lines.append(f"{i2}}}")
         lines.extend([
             f"{i1}}}",
@@ -1069,7 +1110,7 @@ def _gen_write_axi4_stream_elem_specializations(
                 lines.append(f"{i2}}}")
             else:
                 lines.append(f"{i2}if (n > 0) {{")
-                lines.append(f"{i3}in[0].template write_axi4_stream<{bw}>(s, tlast);")
+                lines.extend(_wide_stream_elem_body(elem_type, bw, i3, "write_axi4"))
                 lines.append(f"{i2}}}")
         lines.extend([
             f"{i1}}}",

--- a/waveflow/hw/complexfield.py
+++ b/waveflow/hw/complexfield.py
@@ -160,6 +160,109 @@ class ComplexField(DataField):
             self.val = (int(re_field.val), int(im_field.val))
         return pos, word
 
+    # --- C++ codegen protocol (mirrors the interleaved Python serialization) -------
+    # Each method delegates to the *inner field's* C++ codegen for re then im, interleaved,
+    # ``im`` in the high ``inner_bw`` bits -- exactly as ``_serialize_recursive`` composes the
+    # inner's Python serialization.  ``array_utils`` consumes these to pack ``ComplexField``
+    # like any other element (``read_array_elem`` / ``write_array_elem`` / ``pf<>``).
+    @classmethod
+    def _cpp_re(cls, value_expr: str) -> str:
+        """C++ accessor for the real component of a ``cpp_type`` value expression."""
+        return f"({value_expr}).re" if cls.kind == "int" else f"({value_expr}).real()"
+
+    @classmethod
+    def _cpp_im(cls, value_expr: str) -> str:
+        """C++ accessor for the imag component of a ``cpp_type`` value expression."""
+        return f"({value_expr}).im" if cls.kind == "int" else f"({value_expr}).imag()"
+
+    @classmethod
+    def to_uint_expr(cls, value_expr: str) -> str:
+        """Pack a complex value into ``2*inner_bw`` bits: ``re | (im << inner_bw)`` (delegating
+        each component to the inner field's pack)."""
+        inner = cls.inner_type
+        bw = inner.get_bitwidth()
+        bw2 = 2 * bw
+        re = inner.to_uint_value_expr(cls._cpp_re(value_expr))
+        im = inner.to_uint_value_expr(cls._cpp_im(value_expr))
+        return f"((ap_uint<{bw2}>)({re}) | ((ap_uint<{bw2}>)({im}) << {bw}))"
+
+    @classmethod
+    def to_uint_value_expr(cls, value_expr: str) -> str:
+        return cls.to_uint_expr(value_expr)
+
+    @classmethod
+    def from_uint_expr(cls, uint_expr: str) -> str:
+        """Construct ``cpp_type(re, im)`` from the low / high ``inner_bw`` halves of the packed
+        bits (the ``std::complex<…>`` / ``wf_cint`` two-arg ``(re, im)`` constructor)."""
+        inner = cls.inner_type
+        bw = inner.get_bitwidth()
+        bw2 = 2 * bw
+        w = f"(ap_uint<{bw2}>)({uint_expr})"
+        re = inner.from_uint_expr(f"(ap_uint<{bw}>)({w})")
+        im = inner.from_uint_expr(f"(ap_uint<{bw}>)(({w}) >> {bw})")
+        return f"{cls.cpp_type}({re}, {im})"
+
+    @classmethod
+    def _gen_write_recursive(
+        cls,
+        word_bw: int,
+        dst_type: str = "array",
+        target: str = "x",
+        ipos0: int = 0,
+        iword0: int = 0,
+        prefix: str = "",
+        member_name: str | None = None,
+    ) -> tuple[list[str], int, int]:
+        """Multi-word write: emit re then im via the inner field's ``_gen_write_recursive``."""
+        if member_name is None:
+            raise ValueError(f"{cls.__name__} write generation requires a member_name.")
+        inner = cls.inner_type
+        value_expr = f"{prefix}{member_name}"
+        re_lines, ipos, iword = inner._gen_write_recursive(
+            word_bw=word_bw, dst_type=dst_type, target=target, ipos0=ipos0, iword0=iword0,
+            prefix="", member_name=cls._cpp_re(value_expr))
+        im_lines, ipos, iword = inner._gen_write_recursive(
+            word_bw=word_bw, dst_type=dst_type, target=target, ipos0=ipos, iword0=iword,
+            prefix="", member_name=cls._cpp_im(value_expr))
+        return re_lines + im_lines, ipos, iword
+
+    @classmethod
+    def _gen_read_recursive(
+        cls,
+        word_bw: int,
+        src_type: str = "array",
+        source: str = "x",
+        ipos0: int = 0,
+        iword0: int = 0,
+        prefix: str = "",
+        member_name: str | None = None,
+    ) -> tuple[list[str], int, int]:
+        """Multi-word read: read re then im into inner temps via the inner field's
+        ``_gen_read_recursive``, then assign ``cpp_type(re, im)``."""
+        if member_name is None:
+            raise ValueError(f"{cls.__name__} read generation requires a member_name.")
+        inner = cls.inner_type
+        inner_cpp = inner.cpp_class_name()
+        dst_expr = f"{prefix}{member_name}"
+        lines = [f"    {inner_cpp} __wf_re;", f"    {inner_cpp} __wf_im;"]
+        re_lines, ipos, iword = inner._gen_read_recursive(
+            word_bw=word_bw, src_type=src_type, source=source, ipos0=ipos0, iword0=iword0,
+            prefix="", member_name="__wf_re")
+        im_lines, ipos, iword = inner._gen_read_recursive(
+            word_bw=word_bw, src_type=src_type, source=source, ipos0=ipos, iword0=iword,
+            prefix="", member_name="__wf_im")
+        lines.extend(re_lines)
+        lines.extend(im_lines)
+        lines.append(f"    {dst_expr} = {cls.cpp_type}(__wf_re, __wf_im);")
+        return cls._scope_local_lines(lines), ipos, iword
+
+    @classmethod
+    def get_codegen_includes(cls) -> list[str]:
+        """Raw ``#include`` bodies the generated C++ needs for ``cpp_type``:
+        ``<complex>`` for the ``std::complex<…>`` (float / fixed) inner, the ``wf_cint``
+        header for the integer inner (``std::complex<ap_int>`` is non-standard)."""
+        return ['"wf_cint.h"'] if cls.kind == "int" else ["<complex>"]
+
 
 def _extract_re_im(value: Any) -> tuple[Any, Any]:
     """Pull (re, im) out of a structured scalar / complex / (re, im) pair / real number."""

--- a/waveflow/hw/complexfield.py
+++ b/waveflow/hw/complexfield.py
@@ -178,12 +178,18 @@ class ComplexField(DataField):
     @classmethod
     def to_uint_expr(cls, value_expr: str) -> str:
         """Pack a complex value into ``2*inner_bw`` bits: ``re | (im << inner_bw)`` (delegating
-        each component to the inner field's pack)."""
+        each component to the inner field's pack).
+
+        Each component's packed bits are first truncated to ``ap_uint<inner_bw>`` so a signed
+        integer inner (``wf_cint`` over ``ap_int``) is **zero-extended** -- not sign-extended --
+        when widened to the ``2*inner_bw`` word (otherwise a negative ``re`` would bleed into
+        the ``im`` slot).  ``fixed_to_bits`` / ``float_to_uint`` already return the raw bits, so
+        the truncation is a no-op for the float / fixed inner."""
         inner = cls.inner_type
         bw = inner.get_bitwidth()
         bw2 = 2 * bw
-        re = inner.to_uint_value_expr(cls._cpp_re(value_expr))
-        im = inner.to_uint_value_expr(cls._cpp_im(value_expr))
+        re = f"(ap_uint<{bw}>)({inner.to_uint_value_expr(cls._cpp_re(value_expr))})"
+        im = f"(ap_uint<{bw}>)({inner.to_uint_value_expr(cls._cpp_im(value_expr))})"
         return f"((ap_uint<{bw2}>)({re}) | ((ap_uint<{bw2}>)({im}) << {bw}))"
 
     @classmethod

--- a/waveflow/hw/dataschema.py
+++ b/waveflow/hw/dataschema.py
@@ -1657,16 +1657,20 @@ class FloatField(DataField):
 
     @classmethod
     def to_uint_expr(cls, value_expr: str) -> str:
+        if cls.get_bitwidth() == 64:
+            return f"streamutils::double_to_uint({value_expr})"
         return f"streamutils::float_to_uint({value_expr})"
 
     @classmethod
     def to_uint_value_expr(cls, value_expr: str) -> str:
-        return f"streamutils::float_to_uint({value_expr})"
+        return cls.to_uint_expr(value_expr)
 
     @classmethod
     def from_uint_expr(cls, uint_expr: str) -> str:
+        if cls.get_bitwidth() == 64:
+            return f"streamutils::uint_to_double((uint64_t)({uint_expr}))"
         if cls.get_bitwidth() != 32:
-            raise ValueError("FloatField unpack currently supports only bitwidth=32.")
+            raise ValueError("FloatField unpack supports only bitwidth 32 or 64.")
         return f"streamutils::uint_to_float((uint32_t)({uint_expr}))"
 
     def _value_to_field_bits(self, current_val: Any) -> int:

--- a/waveflow/hw/dataschema.py
+++ b/waveflow/hw/dataschema.py
@@ -94,6 +94,16 @@ class DataSchema(ABC):
         """
         return []
 
+    @classmethod
+    def get_codegen_includes(cls) -> list[str]:
+        """Return raw ``#include`` directive bodies the generated C++ for this element type
+        needs for its ``cpp_type`` (e.g. ``"<complex>"`` for a ``std::complex<…>`` element).
+
+        Each entry is emitted verbatim as ``#include <body>`` in the generated array-utils
+        header (the body carries its own ``<…>`` / ``"…"`` delimiters).  Default: empty
+        (scalar fields get their types from the always-included ``streamutils_hls.h``)."""
+        return []
+
     @staticmethod
     def _get_indent(level: int) -> str:
         """Return consistent indentation for generated C++ code."""


### PR DESCRIPTION
Makes `ComplexField` a first-class **C++-serializable** element so the (already general) `array_utils` packs complex directly — no more hand-interleaving re/im — plus a `complex_utils.hpp` for the Vitis-side arithmetic. The Python vectorization / value / serialization / arithmetic are **untouched** (pure additions).

## Phases
- **Phase 1 — codegen protocol** (`891fb3b`): `to_uint_expr` / `from_uint_expr` / `_gen_read_recursive` / `_gen_write_recursive` on `ComplexField`, each delegating to the inner field (re-low/im-high), mirroring the existing Python `_serialize_recursive`. New general `DataSchema.get_codegen_includes()` hook (emits `<complex>` / `"wf_cint.h"`), and `wf_cint.h` (the int-complex struct, since `std::complex<ap_int>` is non-standard).
- **Phase 2 — `complex_utils.hpp`** (`2690b06`): `cmult`/`cadd`/`csub`/`conj` over the element `cpp_type` via the **explicit re/im formula at full precision** (not `std::complex operator*`), with `FP_CONTRACT OFF` for the float path. Body-deduced result widths reproduce the Python `*_format` growth exactly.
- **Phase 3 — migrate `examples/schemas/complex`** (`6d0f5c7`): drop `_interleave_stored_bits`/`_interleave_float_bits` for the generated serialization (`write_array`/`read_array` over `DataArray[ComplexField]`) and `complex_utils.hpp`. Net code reduction.

## Verification
- **47 passed, 0 failed, 0 skipped on real Vitis** (288s — genuine HLS), bit-exact across `cmult`/`cadd`/`csub`/`conj` × {fixed, int, float}.
- Phase 1's 12 codegen tests (Python↔C++ round-trip bit-exact + layout proof) and Phase 2's compiled `static_assert` width checks pass.
- Non-vitis suite: only the pre-existing 15 baseline failures (zero new).

Unblocks: the Vitis vectorization docs (`vitis_raw`/`vitis_struct`/`vitis_complex`), then VMAC Phase 3 (kernel onto `read_array_elem<ComplexField>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)