### PR TITLE
docs: Vitis vectorization guide (serialization + raw/struct/complex)

### DIFF
--- a/docs/guide/schema/codegen.md
+++ b/docs/guide/schema/codegen.md
@@ -22,7 +22,23 @@ For array element helpers, `ArrayUtilsStep` generates:
 
 ## Current build flow (`DataSchemaStep` + `ArrayUtilsStep`)
 
-Schema headers and array helpers are generated through `BuildDag` steps:
+Schema headers and array helpers are generated through `BuildDag` steps. For example, suppose we have a simple [DataList](./datalists.md) schema like:
+
+```python
+class PolyCmdHdr(DataList):
+    """Command header: ...
+    """
+    elements = {
+        "cmd_type": {"schema": PolyCmdTypeField, 
+            "description": "DATA or END"},
+        "tx_id":    {"schema": TxIdField,
+            "description": "Transaction ID"},
+        "nsamp":    {"schema": NsampField,       
+             "description": "Sample count (0 for END)"},
+    }
+```
+
+Then we create the include files in Python with these `BuildStep`s:
 
 ```python
 from waveflow.build.build import BuildConfig, BuildDag
@@ -38,27 +54,35 @@ dag.add(ArrayUtilsStep(Float32, [32, 64]))
 dag.run(cfg)
 ```
 
-`BuildConfig(root_dir=...)` is the build-root entry point. `ArrayUtilsStep` and `DataSchemaStep` both integrate with DAG dependency resolution.
+The two steps have distinct jobs: **`DataSchemaStep`** generates the header for a schema *class* (here `PolyCmdHdr`), while **`ArrayUtilsStep`** generates the packing helpers for a `DataArray` *element type* (here `Float32`) — see [Serialization](./serialization.md). `BuildConfig(root_dir=...)` sets the build root, and both steps resolve their shared dependency on `StreamUtilsStep` automatically through the DAG.
 
-## Using generated headers in kernel code
+Running these commands will generate header files: `poly_cmd_hdr.h` and `poly_cmd_hdr_tb.h`.  In the file `poly_cmd_hdr.h`, you will find a structure:
 
-```cpp
-#include "include/poly_cmd_hdr.h"
-#include "include/streamutils_hls.h"
-
-static const int WORD_BW = 32;
-using axis_word_t = streamutils::axi4s_word<WORD_BW>;
-
-void poly(hls::stream<axis_word_t>& in_stream,
-          hls::stream<axis_word_t>& out_stream) {
-#pragma HLS INTERFACE axis port=in_stream
-#pragma HLS INTERFACE axis port=out_stream
-#pragma HLS INTERFACE ap_ctrl_none port=return
-
-    PolyCmdHdr cmd_hdr;
-    streamutils::tlast_status cmd_hdr_tlast;
-    cmd_hdr.read_axi4_stream<WORD_BW>(in_stream, cmd_hdr_tlast);
+```c
+struct PolyCmdHdr {
+    PolyCmdType cmd_type;  // DATA or END
+    ap_uint<16> tx_id;  // Transaction ID
+    ap_uint<16> nsamp;  // Sample count (0 for END)
+    
+    ...
 }
 ```
 
-Serialization helpers are templated on `word_bw`, so switching bus width typically changes only one constant.
+In this way, the Python data structure is faithfully translated to the Vitis HLS code — the field types (`PolyCmdType`, `ap_uint<16>`) and even the descriptive comments come straight from the schema. Now any other Vitis C++ file can `#include` the header and declare an instance:
+
+```cpp
+#include "include/poly_cmd_hdr.h"
+
+PolyCmdHdr hdr;
+hdr.cmd_type = PolyCmdType::DATA;   // the generated enum
+hdr.tx_id    = 42;
+hdr.nsamp    = 1024;
+```
+
+The struct stays in lock-step with its Python definition: change a field there and the regenerated header changes with it, so the kernel can never drift from the source of truth.
+
+
+
+## Reading and writing over a channel
+
+Beyond its data members, each generated header also carries **serialization** methods — templated on the channel width `word_bw` — for moving the schema in and out of an AXI-Stream or `m_axi` port. Because they are templated, switching bus width is usually a one-constant change. These methods, and the packing model behind them, are covered in [Serialization & Deserialization](./serialization.md).

--- a/docs/guide/schema/serialization.md
+++ b/docs/guide/schema/serialization.md
@@ -1,0 +1,107 @@
+---
+title: Serialization
+parent: Data Schemas
+nav_order: 8
+---
+
+# Serialization & Deserialization
+
+A central property of Waveflow is that every schema knows how to **serialize** itself — to convert
+its value to and from a flat sequence of fixed-width words — and that the *same* packing rule is
+generated for Python (simulation, golden vectors) and for C++ (the synthesizable kernel). Because
+both sides are generated from one definition, they agree bit-for-bit.
+
+This page explains the packing model and the generated methods. For *what files and classes* are
+generated, see [Code Generation](./codegen.md); for *vectorized arrays* in a kernel — the packing
+factor, lanes, and the throughput loop — see the Vitis vectorization guide
+([raw](../vectorization/vitis_raw.md) / [struct](../vectorization/vitis_struct.md) /
+[complex](../vectorization/vitis_complex.md)).
+
+## The channel and the word width
+
+Hardware moves data over a **channel** — an AXI-Stream, an `m_axi` memory port, a FIFO — whose data
+path is some fixed width `word_bw` (e.g. 32, 64, 512). Serialization lays a schema value out into
+`ap_uint<word_bw>` words for that channel; deserialization reads it back.
+
+Crucially, `word_bw` is a property of the **channel**, not of the data: it may be **larger or
+smaller** than the schema. Bits are packed **least-significant-bit first, with no padding**, so the
+layout is independent of `word_bw` — only where the word *boundaries* fall changes. The number of
+words a value of `B` bits occupies is:
+
+```
+n_words = ceil(B / word_bw)
+```
+
+## Serializing a schema over an interface
+
+Take the `PolyCmdHdr` command header from [Code Generation](./codegen.md):
+
+```python
+class PolyCmdHdr(DataList):
+    elements = {
+        "cmd_type": {"schema": PolyCmdTypeField, "description": "DATA or END"},   #  1 bit
+        "tx_id":    {"schema": TxIdField,         "description": "Transaction ID"}, # 16 bits
+        "nsamp":    {"schema": NsampField,        "description": "Sample count"},   # 16 bits
+    }
+```
+
+The generated `poly_cmd_hdr.h` gives the struct a set of **templated serialize/deserialize methods**,
+one pair per kind of interface. Each is templated on the channel width `word_bw`:
+
+| Interface | Serialize / Deserialize | Backing channel |
+|---|---|---|
+| Packed integer | `pack_to_uint` / `unpack_from_uint` | the whole schema as one `ap_uint<bitwidth>` |
+| Memory (`m_axi`) | `write_array<word_bw>` / `read_array<word_bw>` | an `ap_uint<word_bw>` array in external memory |
+| FIFO stream | `write_stream<word_bw>` / `read_stream<word_bw>` | an `hls::stream<ap_uint<word_bw>>` |
+| AXI4-Stream | `write_axi4_stream<word_bw>` / `read_axi4_stream<word_bw>` | a stream with `TLAST` framing |
+
+For example, a producer serializes a header onto an AXI-Stream and a consumer deserializes it back —
+bit-for-bit identical, and identical to what the Python model produces:
+
+```cpp
+#include "include/poly_cmd_hdr.h"
+static const int WORD_BW = 32;
+
+// producer: serialize a header onto the stream
+PolyCmdHdr hdr;
+hdr.cmd_type = PolyCmdType::DATA;
+hdr.tx_id    = 42;
+hdr.nsamp    = 1024;
+hdr.write_axi4_stream<WORD_BW>(out_stream, /*tlast=*/false);
+
+// consumer: deserialize it back off the stream
+PolyCmdHdr rx;
+streamutils::tlast_status tl;
+rx.read_axi4_stream<WORD_BW>(in_stream, tl);   // rx == hdr
+```
+
+Switching the channel to a different width is a one-constant change to `WORD_BW`; the packing rule
+(and the agreement with the Python golden) is invariant.
+
+### How `word_bw` sets the transfer time
+
+Because a stream moves one word per cycle, the channel width directly sets how long a value takes to
+transfer. `PolyCmdHdr` is `B = 33` bits (1 + 16 + 16), so:
+
+| `word_bw` | `n_words = ⌈33 / word_bw⌉` | cycles to transfer |
+|---|---|---|
+| 32 | 2 | 2 |
+| 64 | 1 | 1 |
+
+The 33rd bit spills past a 32-bit word, so a 32-bit channel needs two words while a 64-bit channel
+fits the header in one — halving the transfer time. For wider schemas (or arrays) the saving scales
+with the word count.
+
+## Arrays add a second dimension: lanes
+
+When the schema is a [`DataArray`](./dataarrays.md), serialization packs **multiple elements per
+word** — `pf = word_bw / element_bits` of them, each a *lane*. That turns the channel width into a
+*parallelism* knob, not just a transfer-time knob: a kernel can process all `pf` lanes per cycle. The
+packing factor, the lane loop, and the unrolling pragmas are covered in the Vitis vectorization guide,
+starting with [raw arrays](../vectorization/vitis_raw.md).
+
+## See also
+
+- [Code Generation](./codegen.md) — the files and classes that get generated.
+- [Data Arrays](./dataarrays.md) — declaring arrays and the `struct` vs `raw` storage modes.
+- [Vitis: raw arrays](../vectorization/vitis_raw.md) — the packing factor, lanes, and throughput loop.

--- a/docs/guide/vectorization/index.md
+++ b/docs/guide/vectorization/index.md
@@ -24,6 +24,16 @@ pages drill in:
   `quantize`, bit-exact with `ap_fixed`. (The fixed-point *type* itself is on the
   [FixedField](../schema/fixpoint.md) page.)
 
+The **Vitis C++** pages cover the generated array helpers in a synthesizable kernel
+(the schema-level packing model is in [Serialization](../schema/serialization.md)):
+
+- [Vitis: raw arrays](./vitis_raw.md) — the flat array, packing factor, lanes, and the
+  throughput lane loop.
+- [Vitis: struct arrays](./vitis_struct.md) — the generated wrapper struct's whole-array
+  methods.
+- [Vitis: complex arrays](./vitis_complex.md) — complex elements end-to-end (the wireless
+  vertical).
+
 ## Why vectorization is the differentiator
 
 The Waveflow thesis is bit-exact *and* fast. The speed comes from keeping data

--- a/docs/guide/vectorization/vitis_complex.md
+++ b/docs/guide/vectorization/vitis_complex.md
@@ -1,0 +1,94 @@
+---
+title: "Vitis: complex arrays"
+parent: Vectorization
+nav_order: 12
+---
+
+# Vectorized arrays in Vitis — complex
+
+Complex samples are the workhorse of wireless signal processing — IQ data, channel estimates, beamforming
+weights. Waveflow's `ComplexField` is a first-class element type, which means **a complex array serializes
+and vectorizes through exactly the same machinery as a scalar array** — the `<type>_array_utils` helpers
+from [raw](./vitis_raw.md) / [struct](./vitis_struct.md) — with complex arithmetic supplied by a generated
+`complex_utils.hpp`. This page is the complex-specific walkthrough; for the Python-side numpy model see
+[Complex vectorization](./complex.md).
+
+## The complex element type
+
+A `ComplexField` over a scalar inner field maps to a C++ element type:
+
+| inner | C++ `cpp_type` |
+|---|---|
+| `FloatField` | `std::complex<float>` / `std::complex<double>` |
+| `FixedField` | `std::complex<ap_fixed<…>>` |
+| `IntField`   | `wf_cint<W>` — a 2-`ap_int` struct (`std::complex<ap_int>` is non-standard) |
+
+Each element is an interleaved `(re, im)` pair of `data_bw`-bit components, so its width is `2·data_bw` and
+its packing factor over a `WORD_BW` channel is `pf = WORD_BW / (2·data_bw)`.
+
+## Code generation
+
+Generate the complex element's packing the same way as any element — name the `ComplexField` type:
+
+```python
+from waveflow.hw.complexfield import ComplexField
+from waveflow.hw.fixpoint import FixedField
+
+CFixed = ComplexField.specialize(FixedField.specialize(16, 4, signed=True))
+
+dag.add(ArrayUtilsStep(CFixed, [64, 128]))    # generates <type>_array_utils.h for the complex element
+```
+
+This emits the usual `<type>_array_utils::` namespace (`pf<>`, `read_array`/`read_array_elem`,
+`write_array`/`write_array_elem`, …) — complex elements pack/unpack like any other, re in the low
+`data_bw` bits and im in the high `data_bw` bits of each slot. The arithmetic comes from two headers shipped
+with Waveflow:
+
+- **`complex_utils.hpp`** — `cmult` / `cadd` / `csub` / `conj` over the complex `cpp_type`, the explicit
+  re/im formula at full precision (not `std::complex operator*`, which would FMA-contract / requantize).
+- **`wf_cint.h`** — the integer-inner complex struct.
+
+## Reading, computing, writing
+
+Because the element is first-class, the kernel is the same shape as the scalar [raw](./vitis_raw.md) case —
+just a complex element type and `complex_utils::` arithmetic. A complex multiply over two arrays:
+
+```cpp
+#include "cfixed_array_utils.h"
+#include "complex_utils.hpp"
+namespace au = cfixed_array_utils;
+
+au::value_type a[N], b[N], y[N];           // complex elements (std::complex<ap_fixed>)
+au::read_array<WORD_BW>(a_words, a, N);
+au::read_array<WORD_BW>(b_words, b, N);
+
+for (int i = 0; i < N; ++i) {
+#pragma HLS PIPELINE II=1
+    y[i] = complex_utils::cmult(a[i], b[i]);   // full-precision complex multiply
+}
+
+au::write_array<WORD_BW>(y, y_words, N);
+```
+
+`conj` / `cadd` / `csub` follow the same shape (`complex_utils::conj(a[i])`, etc.). Call them **qualified**
+(`complex_utils::conj`): an unqualified `conj` on a `std::complex` argument resolves to `std::conj` via ADL,
+which is not the full-precision Waveflow operator.
+
+For lane-level throughput, the [raw lane loop](./vitis_raw.md#serialization-and-deserialization-of-a-lane)
+works unchanged — `read_array_elem<WORD_BW>` delivers `pf` complex lanes per word and you unroll
+`complex_utils::cmult` across them. Note that because a complex element is `2·data_bw` bits, a *real* array
+of the same `data_bw` packs **twice** the lanes per word — the real-vs-complex throughput difference is just
+the packing factor.
+
+## Worked example
+
+`examples/schemas/complex` is the bit-exact conformance: it lays operands out with `arrayutils.write_array`,
+runs `cmult` / `cadd` / `csub` / `conj` kernels built from `<type>_array_utils::read_array` +
+`complex_utils.hpp`, and checks the C++ words against the Python `DataArray[ComplexField]` model —
+bit-for-bit, on real Vitis.
+
+## See also
+
+- [Complex vectorization](./complex.md) — the Python-side numpy complex model.
+- [`vitis_raw.md`](./vitis_raw.md) — the packing factor and lane loop (apply to complex unchanged).
+- [Serialization](../schema/serialization.md) — the schema-level packing model.

--- a/docs/guide/vectorization/vitis_raw.md
+++ b/docs/guide/vectorization/vitis_raw.md
@@ -1,0 +1,223 @@
+---
+title: "Vitis: raw arrays"
+parent: Vectorization
+nav_order: 10
+---
+
+# Vectorized arrays in Vitis — `raw` storage
+
+Just as each [data schema](../schema/codegen.md) has a bit-exact Vitis C++ counterpart, so does each
+`DataArray`: Waveflow generates the include files and helper methods that let a synthesizable kernel
+manipulate the array — pack it, unpack it, process it lane-by-lane — using the *same* layout the Python
+model uses.
+
+A `DataArray` lowers to C++ in one of two **storage modes** (see [Data Arrays](../schema/dataarrays.md)).
+This page covers **`raw` mode** — a flat C array — the one you reach for when you want explicit, per-cycle
+control of the vectorized loop. The [`struct`](./vitis_struct.md) mode (a wrapper with methods) and the
+[`complex`](./vitis_complex.md) element are covered separately.
+
+## Code generation in `raw` mode
+
+The packing helpers are generated from the array's **element type** — and that element can be *any*
+`DataSchema` scalar (`IntField`, `FixedField`, `FloatField`, `ComplexField`). You name the element type
+and the channel widths you intend to support; everything else follows. For a 32-bit float element:
+
+```python
+from waveflow.build.build import BuildConfig, BuildDag
+from waveflow.build.streamutils import StreamUtilsStep
+from waveflow.hw.arrayutils import ArrayUtilsStep
+from waveflow.hw.dataschema import FloatField
+
+Float32 = FloatField.specialize(32)
+
+cfg = BuildConfig(root_dir=project_dir)
+dag = BuildDag()
+dag.add(StreamUtilsStep(output_dir="include"))      # ArrayUtilsStep depends on this
+dag.add(ArrayUtilsStep(Float32, [32, 64]))          # element type, supported word widths
+dag.run(cfg)
+```
+
+**Artifact:**  The above code builds two files:
+-  `include/float32_array_utils.h` containing the class definition and helpers to be used in synthesizable code
+- `float32_array_utils_tb.h` for helpers that may not be synthesizable (like file I/O) that can the testbench. 
+
+The first file declares the `float32_array_utils::` namespace with `pf<>`, the bulk `read_array`/`write_array`, the
+per-word `read_array_elem`/`write_array_elem`, and the stream variants.
+
+The defining property of `raw` mode: **the generated code is keyed on the element type, not on a particular
+array.** There is no per-array struct — the same `float32_array_utils` helpers serve *every* `raw` array of
+`float` elements, of any length. (The [`struct`](./vitis_struct.md) mode is the opposite: it generates a
+wrapper type per array.)
+
+## Declaring vectors in C++
+
+Once the header files are generated, any Vitis C++ function can write code using these helpers.
+Th Vitis HLS equivalent of the `raw` array is simply a flat C array of the element's `value_type`. (On the Python side this is
+`cpp_storage="raw"`, which requires `static=True` and a 1-D shape — see
+[Data Arrays](../schema/dataarrays.md).) In a kernel you declare it directly:
+
+```cpp
+#include "float32_array_utils.h"
+namespace au = float32_array_utils;
+
+static const int N = 256;
+au::value_type x[N];     // == float x[256]
+```
+
+Using `au::value_type` rather than a hard-coded `float` keeps the declaration tied to the schema: change the
+element type in Python, regenerate, and the C++ follows.
+
+## Packing factors
+
+As discussed in the section on [serialization](../schema/serialization.md),  arrays must be transferred over **channels**, such as AXI4-streams, or memory-mapped interfaces.  These channels may have **word bitwidth**, typically denoted `word_bw`, that may be larger or smaller than the bitwidth of each element of the array.  The generated include files provide methods to **serialize** and **deserialize** arrays of elements over channels of any width. 
+
+Given a `word_bw`, two dual quantities describe how the elements line up with the words:
+
+- the **packing factor** — `pf = ⌊word_bw / element_bits⌋` — how many whole elements fit in one word; and
+- the **words per element** — `words_per_elem = ⌈element_bits / word_bw⌉` — how many words one element spans.
+
+Exactly one of them exceeds 1 (both are 1 when `word_bw == element_bits`). A **wide channel**
+(`word_bw ≥ element_bits`) packs `pf` elements per word — the vectorized case below — while a **narrow
+channel** (`word_bw < element_bits`) spreads each element across `words_per_elem` words.
+
+As an example, suppose a data structure is a 2D point:
+
+```python
+Float32 = FloatField.specialize(bitwidth=32)
+class Point2D(DataList):
+    elements = {
+        "x":  {"schema": Float32},
+        "y":  {"schema": Float32}
+    }
+```
+
+This structure will have a `bitwidth = 64`.
+After we generate the include file `point_2d.hpp`:  We can obtain the parameters:
+
+
+```cpp
+#include "point_2d_array_utils.h"
+namespace point2d = point2d_array_utils;
+static constexpr int PF      = point2d::pf<WORD_BW>();           // WORD_BW / 64 (0 if WORD_BW < 64)
+static constexpr int elem_bw = point2d::value_bitwidth;         // 64
+static constexpr int wpe     = point2d::get_nwords<WORD_BW>(1);  // ceil(64 / WORD_BW): words per element
+```
+
+Each `pf` element slot in a word is a **lane**. When `pf ≥ 1`, a loop that touches all `pf` lanes per cycle
+does `pf` elements of work per cycle — so **`WORD_BW` is the throughput lever**. For the 64-bit `Point2D`:
+
+| `WORD_BW` | `pf = ⌊WORD_BW/64⌋` | `words_per_elem = ⌈64/WORD_BW⌉` |
+|---|---|---|
+| 32  | 0 — element spans 2 words | 2 |
+| 64  | 1 | 1 |
+| 128 | 2 | 1 |
+| 256 | 4 | 1 |
+| 512 | 8 | 1 |
+
+At `WORD_BW = 32` the element is wider than the word, so `pf` is 0 and each `Point2D` occupies two words;
+from `WORD_BW = 64` up, whole elements fit per word. (For the schema-level view — `n_words` and the
+per-transfer cycle cost — see [Serialization](../schema/serialization.md).)
+
+
+
+## Serialization and deserialization of a full vector
+
+Conceptually this is the same serialization described for [data schemas](../schema/serialization.md): bits
+to and from `ap_uint<WORD_BW>` words. For an array, the **bulk** helpers move the whole array in one call:
+
+```cpp
+static const int NWORDS = au::get_nwords<WORD_BW>(N);   // packed words for N elements
+ap_uint<WORD_BW> words[NWORDS];  
+float x[N];
+au::read_array<WORD_BW>(words, x, N);    // words: const ap_uint<WORD_BW>*  → x[0..N)
+// ... compute on x ...
+au::write_array<WORD_BW>(x, words, N);   // x → words
+```
+
+The packed word count is `get_nwords<WORD_BW>(N) = ⌈N · element_bits / WORD_BW⌉` — the array-utils helper
+that mirrors the schema-level `n_words`. The whole-array helpers are pipelined: they retire `pf` elements
+per cycle when `WORD_BW ≥ element_bits`, and one element per `words_per_elem` cycles when the element is
+wider than the word.
+
+Random access into the packed words depends on how the element lines up with the word, so there is no
+single index formula:
+
+- **`WORD_BW ≥ element_bits`** (and a multiple of it): element `i` is lane `i % pf` of word `⌊i / pf⌋`. A
+  slice that starts on a word boundary (`start % pf == 0`) is then just a pointer offset:
+
+  ```cpp
+  const int pf = au::pf<WORD_BW>();
+  au::read_array<WORD_BW>(words + start / pf, x, len);   // elements [start, start+len), start % pf == 0
+  ```
+
+- **`element_bits > WORD_BW`**: element `i` occupies words `[i · words_per_elem, (i+1) · words_per_elem)`.
+
+When `WORD_BW` is not a multiple of `element_bits`, elements straddle word boundaries — compute the bit
+offset `i · element_bits` and locate the word yourself rather than relying on a per-element word index.
+
+Use the whole-array helpers when you want the array resident and don't need cycle-level scheduling (a
+coefficient table loaded once, say). When you *do* want throughput, drop to the lane primitives below.
+
+## Serialization and deserialization of a lane
+
+The lane primitives expose one word — `pf` lanes — at a time, which is what you unroll over. This is the
+pattern for the **vectorized regime** (`WORD_BW ≥ element_bits`, so `pf ≥ 1`); for a wide element (`pf = 0`)
+the loop below is invalid — use the bulk `read_array` above. Walk the array in steps of `pf`, read a word
+into a **partitioned** lane array, `UNROLL` the compute across the lanes, and write the word back. Here the
+kernel computes `y[i] = x[i] * x[i]`:
+
+```cpp
+#include "float32_array_utils.h"
+namespace au = float32_array_utils;
+static const int PF = au::pf<WORD_BW>();   // >= 1 in this regime (WORD_BW >= element_bits)
+
+int iword = 0;                             // word index — incremented, so no per-iteration divide
+for (int i = 0; i < N; i += PF) {
+#pragma HLS PIPELINE II=1
+    float lane[PF];
+#pragma HLS ARRAY_PARTITION variable=lane complete dim=1     // lanes in parallel registers
+    const int n = (N - i < PF) ? (N - i) : PF;               // tail: last (partial) word
+
+    au::read_array_elem<WORD_BW>(&x_words[iword], lane, n);  // one word → pf lanes
+    for (int k = 0; k < PF; ++k) {
+#pragma HLS UNROLL
+        if (k < n) lane[k] = lane[k] * lane[k];              // one element per lane
+    }
+    au::write_array_elem<WORD_BW>(lane, &y_words[iword], n); // pf lanes → one word
+    ++iword;
+}
+```
+
+The three pragmas are what vectorize the loop:
+
+- **`ARRAY_PARTITION variable=lane complete`** — splits the lane array into `pf` registers so every lane is
+  live in the same cycle (otherwise it is a BRAM and the `UNROLL` serializes on memory ports).
+- **`UNROLL`** — instantiates `pf` parallel copies of the compute.
+- **`PIPELINE II=1`** — issues one word (so `pf` elements) per cycle.
+
+The `iword` counter is a small but real win: advancing it by one word per iteration gives the address
+`&x_words[iword]` rather than `x_words + i / PF`, avoiding a per-iteration hardware divide (and the matching
+`y_words[iword]` for the output).
+
+Widen `WORD_BW` and `PF` rises with it; the same loop retires more elements per cycle. That is the
+bus-width → throughput relationship made concrete (and what the VMAC `mem_dwidth` sweep measures).
+
+### Streams instead of memory
+
+For an AXI-Stream port the shape is identical, but the lane read/write use the stream variants, which also
+carry `TLAST`:
+
+```cpp
+au::read_axi4_stream_elem<WORD_BW>(s_in,  lane, n);                 // pf lanes off the stream
+au::write_axi4_stream_elem<WORD_BW>(s_out, lane, /*tlast=*/last, n);
+```
+
+`examples/stream_inband/poly_evaluate_impl.tpp` is the worked stream example;
+`examples/vmac/vmac_compute_impl.tpp` is the worked `m_axi` example.
+
+## See also
+
+- [Serialization](../schema/serialization.md) — the schema-level packing model and `word_bw`.
+- [Data Arrays](../schema/dataarrays.md) — declaring `DataArray`, `struct` vs `raw`.
+- [`vitis_struct.md`](./vitis_struct.md) — the same packing behind a generated struct's methods.
+- [`vitis_complex.md`](./vitis_complex.md) — complex elements (wireless).

--- a/docs/guide/vectorization/vitis_struct.md
+++ b/docs/guide/vectorization/vitis_struct.md
@@ -1,0 +1,71 @@
+---
+title: "Vitis: struct arrays"
+parent: Vectorization
+nav_order: 11
+---
+
+# Vectorized arrays in Vitis — `struct` storage
+
+The default `cpp_storage` for a `DataArray` is `"struct"`. Where [`raw` mode](./vitis_raw.md) gives you a
+flat C array and the free-function packing helpers for explicit lane control, **`struct` mode wraps the
+array in a generated type whose methods do the packing for you** — the whole array in, the whole array out,
+the lanes hidden. Reach for it when the array is a *field* of a larger schema, a port payload, or an object
+you pass around, and you don't need cycle-level control of the loop.
+
+## Code generation in `struct` mode
+
+A `struct`-mode `DataArray` lowers to a generated struct — a `data[N]` member plus serialization methods —
+emitted by `DataSchemaStep` as part of the schema's C++ type (the same build flow as any schema header; see
+[Code Generation](../schema/codegen.md)). The element's packing still comes from `ArrayUtilsStep`: the
+struct's methods **delegate to the element's `<elem>_array_utils` free functions**, so both storage modes
+share one packing implementation. A generated array struct looks like:
+
+```cpp
+struct Float32Array {
+    float data[256];
+    template<int WORD_BW> void read_array(const ap_uint<WORD_BW> x[]);    // words → data
+    template<int WORD_BW> void write_array(ap_uint<WORD_BW> x[]) const;   // data → words
+    // ... stream variants (read_stream / read_axi4_stream / ...)
+};
+```
+
+## Declaring and using the struct in C++
+
+Declare an instance, call its serialize/deserialize methods to move the **whole array** over a channel, and
+read or write elements through the `data` member:
+
+```cpp
+#include "include/sample_array.h"
+
+Float32Array samples;
+samples.read_array<WORD_BW>(words);          // deserialize all 256 elements from packed words
+
+for (int i = 0; i < 256; ++i) {
+    samples.data[i] = samples.data[i] * samples.data[i];   // y = x*x
+}
+
+samples.write_array<WORD_BW>(out_words);     // serialize back
+```
+
+The packing factor and word layout are identical to `raw` mode (`pf = WORD_BW / element_bits`) — the struct
+just keeps them under the hood. Like every Waveflow serializer the methods are templated on `WORD_BW`, so
+retargeting the channel width is a one-constant change, and the bytes match the Python golden exactly.
+
+## `struct` vs `raw`: which to use
+
+| | `struct` | `raw` |
+|---|---|---|
+| C++ shape | a wrapper struct (`data[N]` + methods) | a flat `elem_t[N]` |
+| Packing | hidden inside the methods | explicit (`read_array_elem` free functions) |
+| Lane control | no | yes — the unrolled lane loop |
+| Best for | a field of a schema, a port payload, whole-array I/O | throughput kernels, per-cycle lane scheduling |
+
+If you find yourself wanting to unroll across lanes (the throughput pattern), reach for
+[`raw`](./vitis_raw.md). If you just want to move an array in and out as one typed object, `struct` is the
+simpler default.
+
+## See also
+
+- [`vitis_raw.md`](./vitis_raw.md) — the flat array, lane loop, and throughput pattern.
+- [Serialization](../schema/serialization.md) — the schema-level packing model.
+- [Data Arrays](../schema/dataarrays.md) — declaring `DataArray` and `cpp_storage`.


### PR DESCRIPTION
Adds the **C++/HLS side** of the vectorization docs — how a synthesizable kernel uses the generated array helpers — now that `ComplexField` serializes through the general `array_utils` (PR #69). Also splits the schema-level *serialization* concept out of `codegen.md` into its own page so all three Vitis pages can lean on it.

## Pages
- **`schema/codegen.md`** (revised) — focused on *what is created* (the generated struct + the `DataSchemaStep`/`ArrayUtilsStep` build flow); hands serialization detail off.
- **`schema/serialization.md`** (new) — the `word_bw` channel model, packing factor, and the generated serialize/deserialize methods (interface table + the words/cycles intuition).
- **`vectorization/vitis_raw.md`** (new) — the flat-array mode: packing factor, lanes, the unrolled lane loop (with the `iword` counter to avoid a per-iteration divide, and the `pf ≥ 1` precondition), plus the full-vector / slice / wide-element cases.
- **`vectorization/vitis_struct.md`** (new) — the wrapper-struct mode + a struct-vs-raw decision table.
- **`vectorization/vitis_complex.md`** (new) — complex elements end-to-end (the wireless vertical), `complex_utils.hpp` arithmetic, qualified-call caveat.
- **`vectorization/index.md`** — lists the new Vitis pages.

All code snippets are grounded in real generated headers (`float32_array_utils.h`, `Conv2DCmd`, the migrated complex example) and the generator (`arrayutils.py` — e.g. `pf = word_bw/elem_bits`, integer division, no clamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)