### PR TITLE
docs: keep figures/README out of the nav tree

### DIFF
--- a/docs/overview/figures/README.md
+++ b/docs/overview/figures/README.md
@@ -1,3 +1,9 @@
+---
+title: SALSA figure sources
+nav_exclude: true
+search_exclude: true
+---
+
 # Overview figures — TikZ source → committed SVG
 
 **Single source of truth, rendered artifact** — the Waveflow philosophy applied to diagrams. The TikZ


### PR DESCRIPTION
`docs/overview/figures/README.md` documents the TikZ→SVG render workflow (`render.sh`) — a developer note, not a user-facing docs page. It was showing up in the just-the-docs navigation tree.

Adds `nav_exclude: true` + `search_exclude: true` to its frontmatter so it's hidden from the nav and search while remaining in the repo. One-line, docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)