### PR TITLE
vmac item 13: Scalar immediate as one ComplexField (+ two framework generalizations)

### DIFF
--- a/examples/vmac/vmac.py
+++ b/examples/vmac/vmac.py
@@ -142,7 +142,7 @@ class VmacAccel(HwComponent):
     def _scalar(cls, sc, n_cols: int, in_fmt: Format, mem: np.ndarray) -> DataArray:
         """Build an alpha/beta operand: direct immediate (shape (1,)) or indirect per-column."""
         if bool(sc.direct):
-            M = cx.make_complex([int(sc.re)], [int(sc.im)], in_fmt)
+            M = cx.make_complex([int(cx.re_of(sc.value))], [int(cx.im_of(sc.value))], in_fmt)
         else:
             idx = int(sc.addr) + np.arange(n_cols) * int(sc.stride)
             M = mem[idx]

--- a/examples/vmac/vmac_build.py
+++ b/examples/vmac/vmac_build.py
@@ -139,8 +139,8 @@ def _flat(pair):
 
 def _scalar_field(s, addr):
     if np.ndim(s[0]) == 0:
-        return {"direct": 1, "re": int(s[0]), "im": int(s[1]), "addr": 0, "stride": 0}
-    return {"direct": 0, "re": 0, "im": 0, "addr": int(addr), "stride": 1}
+        return {"direct": 1, "value": (int(s[0]), int(s[1])), "addr": 0, "stride": 0}
+    return {"direct": 0, "value": (0, 0), "addr": int(addr), "stride": 1}
 
 
 def build(accel: VmacAccel, flags: dict, a, b, c, alpha, beta):
@@ -580,7 +580,8 @@ def _tput_vectors(cfg: StructCfg):
     scalars = [int(cmd.n_rows), int(cmd.n_cols),
                int(cmd.a.addr), int(cmd.a.row_stride), int(cmd.b.addr), int(cmd.b.row_stride),
                int(cmd.c.addr), int(cmd.c.row_stride), int(cmd.d.addr), int(cmd.d.row_stride),
-               int(cmd.alpha.re), int(cmd.alpha.im), int(cmd.beta.re), int(cmd.beta.im), flags]
+               int(cx.re_of(cmd.alpha.value)), int(cx.im_of(cmd.alpha.value)),
+               int(cx.re_of(cmd.beta.value)), int(cx.im_of(cmd.beta.value)), flags]
     return (scalars,
             _mem_words(mem, in_elem, cfg.mem_dwidth),
             _mem_words(post, in_elem, cfg.mem_dwidth))
@@ -627,13 +628,14 @@ def render_top(cfg: StructCfg, depth: int) -> str:
     lines += [
         "#pragma HLS INTERFACE s_axilite port=return bundle=control",
         "    // Call the scalar-arg core directly (no VmacCmd struct — it mis-decomposes at csynth).",
-        "    // The complex scalars are built locally from the s_axilite (re, im) codes (a flat",
+        "    // The complex scalars are built locally from the s_axilite (re, im) codes — packed",
+        "    // into one wf_cint complex-code element, then reinterpreted by cx_from_codes (a flat",
         "    // std::complex<ap_fixed> by-value param does not DCE; the nested struct did).",
         "    typedef vmac_impl::vmac_in_au::value_type cx_t;",
-        f"    cx_t alpha = complex_utils::cx_from_codes<cx_t>((ap_int<{cfg.data_bw}>)al_re, "
-        f"(ap_int<{cfg.data_bw}>)al_im);",
-        f"    cx_t beta = complex_utils::cx_from_codes<cx_t>((ap_int<{cfg.data_bw}>)be_re, "
-        f"(ap_int<{cfg.data_bw}>)be_im);",
+        f"    cx_t alpha = complex_utils::cx_from_codes<cx_t>("
+        f"wf_cint<{cfg.data_bw}>((ap_int<{cfg.data_bw}>)al_re, (ap_int<{cfg.data_bw}>)al_im));",
+        f"    cx_t beta = complex_utils::cx_from_codes<cx_t>("
+        f"wf_cint<{cfg.data_bw}>((ap_int<{cfg.data_bw}>)be_re, (ap_int<{cfg.data_bw}>)be_im));",
         f"    vmac_impl::vmac_compute_core<{mbw}, {MEM_AWIDTH}, {cfg.data_bw}, {cfg.int_bits}, "
         f"{cfg.acc_bw}, {cfg.out_bw}, {cfg.q_rnd}, {cfg.o_sat}, {TPUT_MAX_COLS}>(",
         "        gmem, n_rows, n_cols, flags & 1, (flags >> 1) & 1, (flags >> 2) & 1,",

--- a/examples/vmac/vmac_cmd.py
+++ b/examples/vmac/vmac_cmd.py
@@ -21,7 +21,8 @@ accumulator fractional depth is ``2·F_in`` or ``3·F_in`` per ``b_one`` / ``c_z
 variable shift on a fixed-width accumulator, not a dynamic type.
 
 The width-bearing fields are set by the accelerator that produces/consumes the command
-(``addr`` is ``mem_awidth`` bits; the immediate ``re`` / ``im`` are ``data_bw`` bits).
+(``addr`` is ``mem_awidth`` bits; the immediate complex ``value`` is a ``data_bw``-per-component
+``ComplexField``).
 These schemas are **Level-2 declarative** (:class:`~waveflow.hw.dataschema.ParamSchema`):
 each declares :class:`~waveflow.hw.param.Param` attributes and a dict-literal ``elements``
 that references them directly — the core ``IntField.specialize`` / ``Region.specialize``
@@ -32,6 +33,7 @@ so it serializes / deserializes and code-generates like any schema.
 from __future__ import annotations
 
 from waveflow.hw import BooleanField, IntField, Param, ParamSchema
+from waveflow.hw.complexfield import ComplexField
 
 # --- field aliases (names match the auto-generated IntField subclass __name__) ----
 UInt16 = IntField.specialize(16, signed=False)
@@ -56,16 +58,23 @@ class Region(ParamSchema):
 
 
 class Scalar(ParamSchema):
-    """An ``alpha`` / ``beta`` operand: direct immediate (``re`` / ``im`` stored ints) or
-    indirect (per-column pointer ``addr`` + ``stride``; ``stride 0`` broadcasts)."""
+    """An ``alpha`` / ``beta`` operand: direct immediate (one complex ``value``) or indirect
+    (per-column pointer ``addr`` + ``stride``; ``stride 0`` broadcasts).
+
+    The direct immediate is a single :class:`~waveflow.hw.complexfield.ComplexField` element
+    (one interleaved re/im pair of stored ints, ``data_bw`` bits each) rather than two split
+    ``IntField``s -- so it matches the indirect path's complex element and the kernel reads
+    ``cmd.alpha.value`` as one complex code, no re/im reconstruction.  The inner stays a raw
+    ``IntField`` (stored codes; the command is format-free -- ``int_bits`` is structural), and
+    the packed bit order is unchanged (re low, im high), so it is bit-neutral."""
 
     mem_awidth = Param(32)
     data_bw = Param(32)
     elements = {
         "direct": {"schema": BooleanField,
-                   "description": "True = immediate re/im; False = indirect addr/stride"},
-        "re": IntField.specialize(data_bw, signed=True),    # immediate stored int (real part)
-        "im": IntField.specialize(data_bw, signed=True),    # immediate stored int (imag part)
+                   "description": "True = immediate complex value; False = indirect addr/stride"},
+        # immediate complex stored-code (re low, im high; data_bw bits per component)
+        "value": ComplexField.specialize(IntField.specialize(data_bw, signed=True)),
         "addr": IntField.specialize(mem_awidth, signed=False),
         "stride": IntField.specialize(mem_awidth, signed=True),
     }

--- a/examples/vmac/vmac_compute_impl.tpp
+++ b/examples/vmac/vmac_compute_impl.tpp
@@ -224,10 +224,10 @@ void vmac_compute(VmacCmd cmd, ap_uint<MEM_BW>* mem) {
         cmd.c.addr, cmd.c.row_stride,
         cmd.d.addr, cmd.d.row_stride,
         (bool)cmd.alpha.direct,
-        complex_utils::cx_from_codes<CXIN>(cmd.alpha.re, cmd.alpha.im),
+        complex_utils::cx_from_codes<CXIN>(cmd.alpha.value),
         cmd.alpha.addr, cmd.alpha.stride,
         (bool)cmd.beta.direct,
-        complex_utils::cx_from_codes<CXIN>(cmd.beta.re, cmd.beta.im),
+        complex_utils::cx_from_codes<CXIN>(cmd.beta.value),
         cmd.beta.addr, cmd.beta.stride);
 }
 

--- a/tests/examples/test_vmac_cmd.py
+++ b/tests/examples/test_vmac_cmd.py
@@ -6,8 +6,8 @@ VMAC is **complex-only** and the numeric format is **structural** (on ``VmacAcce
 serialize / deserialize back to an identical value across word widths — the wire-format
 contract for the (Phase-3) HLS kernel.  The structural widths live on ``VmacAccel`` (an
 ``HwComponent`` with ``HwParam`` fields); its computed ``Cmd`` specializes the command schema
-so a command's field widths track the silicon (``addr`` = ``mem_awidth`` bits; immediate
-``re`` / ``im`` = ``data_bw`` bits); same params → same schema class object.
+so a command's field widths track the silicon (``addr`` = ``mem_awidth`` bits; the immediate
+complex ``value`` = ``data_bw`` bits per component); same params → same schema class object.
 """
 import pytest
 
@@ -27,8 +27,8 @@ def _full_cmd():
     cmd.b = {"addr": 24, "row_stride": 4}
     cmd.c = {"addr": 48, "row_stride": 8}          # row pitch wider than n_cols (sub-matrix)
     cmd.d = {"addr": 72, "row_stride": 4}
-    cmd.alpha = {"direct": 1, "re": -16, "im": 8, "addr": 0, "stride": 0}
-    cmd.beta = {"direct": 0, "re": 0, "im": 0, "addr": 96, "stride": 1}
+    cmd.alpha = {"direct": 1, "value": (-16, 8), "addr": 0, "stride": 0}
+    cmd.beta = {"direct": 0, "value": (0, 0), "addr": 96, "stride": 1}
     cmd.b_one, cmd.c_zero, cmd.b_conj, cmd.reduce_rows = 0, 1, 1, 1
     return cmd
 
@@ -46,10 +46,11 @@ def test_nested_region_scalar_roundtrip():
     r2 = Region().deserialize(reg.serialize(32), 32)
     assert r2.val == reg.val == {"addr": 12, "row_stride": -3}
 
-    sc = Scalar(direct=1, re=-100, im=77, addr=5, stride=-1)
+    sc = Scalar(direct=1, value=(-100, 77), addr=5, stride=-1)
     s2 = Scalar().deserialize(sc.serialize(32), 32)
     assert s2.val == sc.val
     assert s2.direct is True                                     # BooleanField -> Python bool
+    assert int(s2.value["re"]) == -100 and int(s2.value["im"]) == 77
 
 
 def test_default_cmd_roundtrips():
@@ -61,10 +62,10 @@ def test_default_cmd_roundtrips():
 def test_signed_fields_preserve_negatives():
     cmd = _full_cmd()
     cmd.a = {"addr": 10, "row_stride": -4}
-    cmd.alpha = {"direct": 1, "re": -32768, "im": -1, "addr": 0, "stride": 0}  # data_bw=16 range
+    cmd.alpha = {"direct": 1, "value": (-32768, -1), "addr": 0, "stride": 0}  # data_bw=16 range
     restored = Cmd().deserialize(cmd.serialize(32), 32)
     assert restored.a.row_stride == -4
-    assert restored.alpha.re == -32768 and restored.alpha.im == -1
+    assert int(restored.alpha.value["re"]) == -32768 and int(restored.alpha.value["im"]) == -1
     assert restored.val == cmd.val
 
 
@@ -116,17 +117,18 @@ def test_cmd_specialize_cached_and_matches_accel():
 
 
 def test_cmd_field_widths_track_mem_awidth_and_data_bw():
-    # addr (and strides) follow mem_awidth; immediate re/im follow data_bw
+    # addr (and strides) follow mem_awidth; the immediate complex value's components follow data_bw
     region = ACCEL.Cmd.get_element_schema("a")
     scalar = ACCEL.Cmd.get_element_schema("alpha")
     assert region.get_element_schema("addr").get_bitwidth() == 32
     assert region.get_element_schema("row_stride").get_bitwidth() == 32
-    assert scalar.get_element_schema("re").get_bitwidth() == 16
-    assert scalar.get_element_schema("im").get_bitwidth() == 16
+    value = scalar.get_element_schema("value")
+    assert value.inner_type.get_bitwidth() == 16                 # per-component data_bw
+    assert value.get_bitwidth() == 32                            # packed re/im = 2*data_bw
 
     wide = VmacAccel(mem_dwidth=256, mem_awidth=40, data_bw=24, acc_bw=64, out_bw=24)
     assert wide.Cmd.get_element_schema("a").get_element_schema("addr").get_bitwidth() == 40
-    assert wide.Cmd.get_element_schema("alpha").get_element_schema("re").get_bitwidth() == 24
+    assert wide.Cmd.get_element_schema("alpha").get_element_schema("value").inner_type.get_bitwidth() == 24
 
 
 def test_region_scalar_specialize_cached_and_sized():
@@ -134,8 +136,10 @@ def test_region_scalar_specialize_cached_and_sized():
     assert Region.specialize(mem_awidth=40) is not Region.specialize(mem_awidth=32)
     assert Region.specialize(mem_awidth=40).get_element_schema("addr").get_bitwidth() == 40
     assert Scalar.specialize(mem_awidth=32, data_bw=16) is Scalar.specialize(mem_awidth=32, data_bw=16)
-    assert Scalar.specialize(mem_awidth=32, data_bw=16).get_element_schema("re").get_bitwidth() == 16
-    assert Scalar.specialize(mem_awidth=32, data_bw=24).get_element_schema("re").get_bitwidth() == 24
+    assert Scalar.specialize(
+        mem_awidth=32, data_bw=16).get_element_schema("value").inner_type.get_bitwidth() == 16
+    assert Scalar.specialize(
+        mem_awidth=32, data_bw=24).get_element_schema("value").inner_type.get_bitwidth() == 24
 
 
 def test_format_fields_removed_from_cmd():

--- a/tests/examples/test_vmac_golden.py
+++ b/tests/examples/test_vmac_golden.py
@@ -169,8 +169,8 @@ def build(accel, cfg, a, b, c, alpha, beta):
 
 def _scalar_field(s, addr):
     if np.ndim(s[0]) == 0:
-        return {"direct": 1, "re": int(s[0]), "im": int(s[1]), "addr": 0, "stride": 0}
-    return {"direct": 0, "re": 0, "im": 0, "addr": int(addr), "stride": 1}
+        return {"direct": 1, "value": (int(s[0]), int(s[1])), "addr": 0, "stride": 0}
+    return {"direct": 0, "value": (0, 0), "addr": int(addr), "stride": 1}
 
 
 def run(cfg, a, b, c, alpha, beta):

--- a/waveflow/build/complex_utils.hpp
+++ b/waveflow/build/complex_utils.hpp
@@ -117,14 +117,16 @@ static inline auto conj(const C& a) {
 // stored codes, losslessly widen into a wider accumulator element, and requantize down to an
 // output element -- with no hand-split re/im.  (std::complex<ap_fixed> elements.)
 
-// cx_from_codes: build a std::complex<ap_fixed> element from its stored (re, im) integer codes,
-// i.e. the generated ComplexField (re, im) constructor (stored bits -> ap_fixed value).
+// cx_from_codes: build a std::complex<ap_fixed> element from one complex stored-code element
+// (the generated integer-inner ComplexField, wf_cint<W> = interleaved re/im stored codes),
+// reinterpreting each component's bits as the ap_fixed value -- the bits->ap_fixed counterpart
+// of cx_requantize, with no hand-split re/im at the call site.
 template <typename CXT, int W>
-static inline CXT cx_from_codes(ap_int<W> re, ap_int<W> im) {
+static inline CXT cx_from_codes(const wf_cint<W>& codes) {
 #pragma HLS INLINE
     typedef typename CXT::value_type FX;
-    return CXT(streamutils::bits_to_fixed<FX>((ap_uint<W>)re),
-               streamutils::bits_to_fixed<FX>((ap_uint<W>)im));
+    return CXT(streamutils::bits_to_fixed<FX>((ap_uint<W>)codes.re),
+               streamutils::bits_to_fixed<FX>((ap_uint<W>)codes.im));
 }
 
 // cwiden: value-preserving widen of a complex value into element type ACC -- the lossless

--- a/waveflow/hw/complexfield.py
+++ b/waveflow/hw/complexfield.py
@@ -29,6 +29,7 @@ from typing import Any, ClassVar
 import numpy as np
 
 from waveflow.hw.dataschema import DataArray, DataField, FloatField, IntField, _elem_kind
+from waveflow.hw.param import defer_if_symbolic
 from waveflow.utils import complexutils as cx
 from waveflow.utils import fixputils
 from waveflow.utils.complexutils import complex_dtype, int_format
@@ -58,8 +59,15 @@ class ComplexField(DataField):
 
     # --- specialization -------------------------------------------------------
     @classmethod
+    @defer_if_symbolic
     def specialize(cls, inner: type[DataField], **kwargs: Any) -> type["ComplexField"]:
-        """Return a cached ``ComplexField`` over a scalar ``inner`` field (one per inner)."""
+        """Return a cached ``ComplexField`` over a scalar ``inner`` field (one per inner).
+
+        Like the other ``specialize`` methods, this defers (returns a ``LazyField``) when the
+        ``inner`` is symbolic -- e.g. a ``ParamSchema`` element ``ComplexField.specialize(
+        IntField.specialize(data_bw, ...))`` over a symbolic ``data_bw`` ``Param``, where the
+        inner ``IntField.specialize`` is itself a deferred ``LazyField`` -- so the cascade
+        resolves both layers when the schema is specialized."""
         if not isinstance(inner, type) or not issubclass(inner, DataField):
             raise TypeError("ComplexField inner must be a scalar DataField subclass.")
         kind = _inner_kind(inner)

--- a/waveflow/hw/dataschema.py
+++ b/waveflow/hw/dataschema.py
@@ -4231,6 +4231,25 @@ class DataSchemaStep(Buildable):
             "tb_include": Path(self.tb_include_path()),
         }
 
+    def _member_codegen_include_lines(self) -> list[str]:
+        """Return ``#include`` lines a member element's ``cpp_type`` needs (its
+        ``get_codegen_includes`` bodies, e.g. ``"wf_cint.h"`` for an integer-inner
+        ``ComplexField`` element), deduped + order-preserved.  Only the direct element
+        types are gathered: a nested ``DataSchema`` member emits its own header (pulled in
+        by :meth:`_dep_include_lines`), so its includes need not be re-emitted here."""
+        iter_elems = getattr(self._schema, "_iter_element_schemas", None)
+        if iter_elems is None:
+            return []
+        lines: list[str] = []
+        seen: set[str] = set()
+        for _, schema_cls in iter_elems():
+            for body in schema_cls.get_codegen_includes():
+                line = f"#include {body}"
+                if line not in seen:
+                    seen.add(line)
+                    lines.append(line)
+        return lines
+
     def _dep_include_lines(self) -> list[str]:
         """Return ``#include`` lines for schema dependencies."""
         dep_step_map = {d._schema: d for d in self.deps if isinstance(d, DataSchemaStep)}
@@ -4276,6 +4295,14 @@ class DataSchemaStep(Buildable):
             f'#include "{sutils_hls_rel}"',
             "",
         ]
+
+        # Includes that a member element's cpp_type needs beyond streamutils_hls.h (e.g. the
+        # wf_cint.h / <complex> for a ComplexField element), so the struct header is
+        # self-contained — nested DataSchema members get their own headers via dep includes.
+        member_include_lines = self._member_codegen_include_lines()
+        if member_include_lines:
+            lines.extend(member_include_lines)
+            lines.append("")
 
         dep_include_lines = self._dep_include_lines()
         if dep_include_lines:


### PR DESCRIPTION
Completes the VMAC cleanup tail. The `Scalar`'s direct immediate goes from two split `IntField`s (`re`/`im`) to a single `ComplexField` element, so `cmd.alpha`/`cmd.beta` carry it as one complex value — dropping the wrapper's re/im split and matching the indirect (per-column) path, which already reads complex elements. Completes "complex as first-class *in commands*".

## The change
- **`vmac_cmd.py`** — `Scalar.elements`: `"re"`/`"im"` → `"value": ComplexField.specialize(IntField.specialize(data_bw, signed=True))`.
- **`vmac.py`** — `_scalar` direct branch reads the codes via the complex `value`.
- **`vmac_build.py`** — `_scalar_field` sets `value`; the throughput vector + RTL top pack the s_axilite `(re, im)` into a `wf_cint` before `cx_from_codes`.
- **`vmac_compute_impl.tpp`** — wrapper passes `cmd.{alpha,beta}.value` (one arg, no re/im split).
- **`complex_utils.hpp`** — `cx_from_codes` takes one complex code element (`wf_cint<W>`) instead of split `ap_int` re/im.

## Two framework generalizations (beyond the plan, both general wins)
- **`complexfield.py`** — `ComplexField.specialize` gains `@defer_if_symbolic`, matching the existing deferred-resolution pattern: a `ParamSchema` element `ComplexField.specialize(IntField.specialize(data_bw, …))` over a symbolic `data_bw` now resolves through the cascade (the inner `IntField.specialize` is itself a deferred `LazyField`).
- **`dataschema.py`** — `DataSchemaStep` header codegen now emits member elements' `get_codegen_includes()` (e.g. `wf_cint.h`), so a generated struct header is self-contained. Deduped + order-preserved, scoped to direct elements (nested schemas emit their own headers). Benefits any schema with a member needing an include — not VMAC-specific.

## Bit-neutral
The `value` element packs `re` → low `data_bw` bits, `im` → high — identical to the old `re`-then-`im` layout; the `Scalar` struct bitwidth is unchanged (81). The command serialization doesn't change, only the access pattern — which is why csim reproduces exactly.

## Gates (real Vitis HLS 2025.1, independently re-verified)
- vmac csim: **80/80 bit-exact** (reproduced exactly)
- vmac cosim: throughput unchanged — **15878 / 7431 / 3719** (1.0 / 2.14 / 4.27×)
- complex conformance: **47/47** (fresh re-run — the shared-code changes don't regress the complex example)
- non-vitis: exactly the 15-baseline (no regressions from `complexfield.py` / `dataschema.py`)
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)