### PR TITLE
docs: add Project status page (honest snapshot + CG milestone)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ notebooks, HDL fragments, and build glue.
 ## Start here
 
 - **[Overview](./overview/)** — the motivation, what makes Waveflow different, and the flow
+- **[Project status](./overview/status.md)** — what works today, what's next, and the first integrated milestone
 - **[Installation](./guide/installation/)** — install Waveflow from source
 - **[Guide](./guide/)** — schemas, interfaces, components, simulation, synthesis, and builds
 - **[Examples](./examples/)** — worked designs, starting with [basic vectorization](./examples/basic_vec/)

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -13,12 +13,17 @@ simulation harnesses, HDL, software bindings, and build scripts, Waveflow descri
 **structured, executable Python** — so simulation, generated implementation, software, and
 tooling all stay aligned around a single model.
 
-This section covers the *why*, the *what*, and the *how*:
+This section covers the *why*, the *what*, and the *how* — plus the concrete system that motivates
+Waveflow and an honest status:
 
-- **[Motivation](./motivation.md)** — the fragmentation problem, why Python, and who it's for.
-- **[The harness for AI](./aiharness.md)** — why Waveflow is the substrate that makes AI
-  effective for hardware design.
+- **[Motivation](./motivation.md)** — the problem, Waveflow's single-source approach, and who it's for.
+- **[The Python model](./pymodel.md)** — what a Waveflow component *is*: schemas, interfaces,
+  parameters, and a compute hook.
 - **[The Waveflow flow](./flow.md)** — the two-loop design methodology, end to end.
+- **[The harness for AI](./aiharness.md)** — why Waveflow is the substrate that makes AI effective
+  for hardware design.
+- **[SALSA](./salsa.md)** — the reconfigurable wireless system Waveflow was built for.
+- **[Project status](./status.md)** — what works today, what's next, and the first integrated milestone.
 
 New to the project? The fastest way in is the
 [basic vectorization example](../examples/basic_vec/) — one multiply-accumulate, bit-exact from

--- a/docs/overview/status.md
+++ b/docs/overview/status.md
@@ -1,0 +1,62 @@
+---
+title: Project status
+parent: Overview
+nav_order: 6
+---
+
+# Project status
+
+Waveflow is **early-stage research software**. The foundation — the type system, the simulator, the build graph, and the codegen path to Vitis HLS — is built and works end to end, and is validated **bit-for-bit
+against the real toolchain** on a growing set of individual modules. What does *not* exist yet is an
+integrated, multi-module subsystem or a head-to-head comparison against existing frameworks. This page is an
+honest snapshot of where that line currently sits.
+
+## What works today
+
+While the project is early, the **core of the Waveflow framework is developed and validated end to end**:
+
+- A rich set of [data schemas](../guide/schema/)
+are already supported.  These schemas 
+include fixed and floating point [fields](../guide/schema/fields.md), and [data lists](../guide/schema/datalists.md), [data unions](../guide/schema/dataunion.md), [data arrays](../guide/schema/dataarrays.md) with full numpy [vectorization](../guide/vectorization/).
+Users can auto-generate the corresponding Vitis code, verified to match the Python model bit-exact.
+- Core [interfaces](../guide/interface/) such as HLS stream, AXI memory-mapped, and other memory interfaces are also in place.  Users can create [hardware components](../guide/components/) with the interfaces, auto-generate Vitis HLS code implementing core transactions including block and pipelined reads of raw data and schemas.  These have also been verified as functionally correct and cycle approximate.  Hardware components support [parameterization](../guide/components/hwparam.md).
+- A SimPy-based discrete-event simulator (DES) has also been developed, enabling cycle-approximate timing of processing and interface transactions of the hardware components.
+- A [build DAG](../guide/build/)
+has been developed that provides pre-built steps for DES simulation, code generation, Vitis HLS simulation, RTL co-simulation and others.  Tools are available for timing and resource extraction and visualization enabling closed-loop functional and timing verification.  
+- The framework has been validated **end to end**
+on a set of simple [examples](../examples/) with individual kernels over a variety of interfaces.  The validation demonstrated bit-exact match and near exact timing match with proper calibration. 
+
+
+
+
+## What is coming next?
+
+Several new core components are on the horizon.
+
+- **More complex modules**.  We will soon include modules wrapping GEMM and FFT blocks for Vitis L1 DSP.
+- **Multi-module integrated systems.** Composing the individually-verified modules into working subsystems — the conjugate-gradient demonstrator below is the first.
+- **AI integration.** The structured framework is the substrate AI needs; the code generation, agentic DSE, and MCP developer tooling are still being built out.
+- **Model calibration tools.** Fitting the resource and cycle-timing models from measured data.
+- **Comparative benchmarks.** Measuring Waveflow against PyMTL / Chisel / HLS on design productivity and result quality.
+- **The full [SALSA](./salsa.md) machine** — the long-term target the whole foundation is building toward.
+
+## The next milestone: a conjugate-gradient demonstrator
+
+The deliberate next step is the first *system-level* result: **conjugate gradient (CG)** — a real
+linear-solve kernel — built from **three interacting modules**:
+
+- a **systolic array** (matrix–matrix product),
+- the **VMAC** vector engine (the complex vector-MAC tile, already verified), and
+- a **general-purpose processor** (control and scalar work).
+
+Composed and simulated as one system, the goal is to show that Waveflow's **fast, bit-exact, timing-aware simulation** — paired with **agentic design-space exploration** — finds good parameterizations *much faster*
+than an RTL-first flow. That is a concrete, publishable validation of the central claim, and the first
+design that exercises the platform as an integrated whole rather than a set of verified parts.
+
+## Trajectory
+
+> verified foundation **(here)** → the CG demonstrator (next) → additional SALSA tiles → the full
+> reconfigurable system
+
+The bet is that getting the *foundation* right is the hard part; with a correct, verified substrate, the
+convincing examples follow.


### PR DESCRIPTION
Adds `docs/overview/status.md` — an honest project-status page aimed at external readers (the gap a cold review flagged: the docs read as "vision only" because they didn't surface the working, verified state).

- **What works today** — the verified foundation: data schemas (fixed/float fields, lists, unions, arrays + numpy vectorization), core interfaces (HLS stream, AXI-MM, memory), hardware components, a SimPy DES, and the build DAG — all bit-exact against real Vitis HLS on a set of example kernels. Linked to the guide throughout.
- **What's coming next** — GEMM/FFT wrappers, multi-module integration, AI tooling, calibration, benchmarks, and the full SALSA machine.
- **Next milestone** — the **conjugate-gradient demonstrator** (systolic array + VMAC + general-purpose processor) showing fast sim + agentic DSE finds parameterizations far faster than RTL-first. The first publishable, system-level result.

Also: `overview/index.md` now lists all six overview pages, and the cover (`index.md`) links Project status high in "Start here" for discoverability. Pure docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)