### PR TITLE
array_utils: regime-agnostic lane methods (serialization redesign, phase 1a)

### DIFF
--- a/tests/hw/resources/arrayutils_lane_roundtrip_test.cpp
+++ b/tests/hw/resources/arrayutils_lane_roundtrip_test.cpp
@@ -1,0 +1,171 @@
+// Phase 1a lane-method conformance testbench (template).
+//
+// Exercises the regime-agnostic *_lane methods over all three interfaces with the SAME
+// canonical loop (step by LW = lane_capacity<W>()), for both the vectorized regime (pf >= 1)
+// and the wide-element regime (pf == 0, one element spanning ceil(elem/W) words/beats):
+//
+//   memory : read_array_lane  -> identity -> write_array_lane   (the file round-trip below)
+//   fifo   : write_stream_lane -> read_stream_lane
+//   axi4   : write_axi4_stream_lane -> read_axi4_stream_lane
+//
+// The memory path's reconstructed words are written to the out file and compared, bit-exact,
+// against the Python golden (arrayutils.write_array) by the pytest driver. The fifo / axi4
+// paths are checked in-sim to reproduce the same words; any divergence returns non-zero so the
+// csim (and the test) fails.
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include <hls_stream.h>
+
+#include "__HEADER__"
+
+namespace au = __NAMESPACE__;
+
+// Canonical MEMORY lane loop: decode all N elements via read_array_lane (running word pointer
+// advanced by get_nwords<W>(LW) each step), into a flat element buffer.
+template <int W>
+static void mem_lane_read(const ap_uint<W>* words, au::value_type* dst, int N) {
+    constexpr int LW = au::lane_capacity<W>();
+    constexpr int WPU = au::get_nwords<W>(LW);
+    const ap_uint<W>* xp = words;
+    for (int i = 0; i < N; i += LW) {
+        const int n = (N - i < LW) ? (N - i) : LW;
+        au::value_type lane[LW];
+        au::read_array_lane<W>(xp, lane, n);
+        for (int k = 0; k < LW; ++k) {
+            if (k < n) dst[i + k] = lane[k];
+        }
+        xp += WPU;
+    }
+}
+
+// Canonical MEMORY lane loop: encode all N elements via write_array_lane.
+template <int W>
+static void mem_lane_write(const au::value_type* src, ap_uint<W>* words, int N) {
+    constexpr int LW = au::lane_capacity<W>();
+    constexpr int WPU = au::get_nwords<W>(LW);
+    ap_uint<W>* yp = words;
+    for (int i = 0; i < N; i += LW) {
+        const int n = (N - i < LW) ? (N - i) : LW;
+        au::value_type lane[LW];
+        for (int k = 0; k < LW; ++k) {
+            if (k < n) lane[k] = src[i + k];
+        }
+        au::write_array_lane<W>(lane, yp, n);
+        yp += WPU;
+    }
+}
+
+// FIFO lane loop: src elements -> write_stream_lane -> stream -> read_stream_lane -> dst.
+template <int W>
+static void fifo_lane_roundtrip(const au::value_type* src, au::value_type* dst, int N) {
+    constexpr int LW = au::lane_capacity<W>();
+    hls::stream<ap_uint<W>> s;
+    for (int i = 0; i < N; i += LW) {
+        const int n = (N - i < LW) ? (N - i) : LW;
+        au::value_type lane[LW];
+        for (int k = 0; k < LW; ++k) {
+            if (k < n) lane[k] = src[i + k];
+        }
+        au::write_stream_lane<W>(lane, s, n);
+    }
+    for (int i = 0; i < N; i += LW) {
+        const int n = (N - i < LW) ? (N - i) : LW;
+        au::value_type lane[LW];
+        au::read_stream_lane<W>(s, lane, n);
+        for (int k = 0; k < LW; ++k) {
+            if (k < n) dst[i + k] = lane[k];
+        }
+    }
+}
+
+// AXI4-Stream lane loop: src -> write_axi4_stream_lane -> stream -> read_axi4_stream_lane -> dst.
+template <int W>
+static void axi4_lane_roundtrip(const au::value_type* src, au::value_type* dst, int N) {
+    constexpr int LW = au::lane_capacity<W>();
+    hls::stream<streamutils::axi4s_word<W>> s;
+    for (int i = 0; i < N; i += LW) {
+        const int n = (N - i < LW) ? (N - i) : LW;
+        const bool tlast = (i + LW >= N);
+        au::value_type lane[LW];
+        for (int k = 0; k < LW; ++k) {
+            if (k < n) lane[k] = src[i + k];
+        }
+        au::write_axi4_stream_lane<W>(lane, s, tlast, n);
+    }
+    for (int i = 0; i < N; i += LW) {
+        const int n = (N - i < LW) ? (N - i) : LW;
+        au::value_type lane[LW];
+        streamutils::tlast_status tl = streamutils::tlast_status::no_tlast;
+        au::read_axi4_stream_lane<W>(s, lane, n, tl);
+        for (int k = 0; k < LW; ++k) {
+            if (k < n) dst[i + k] = lane[k];
+        }
+    }
+}
+
+int main(int argc, char** argv) {
+    const char* in_words_path = (argc > 1) ? argv[1] : "array_words.txt";
+    const char* out_words_path = (argc > 2) ? argv[2] : "array_words_out.txt";
+
+    std::ifstream in_words(in_words_path);
+    if (!in_words) {
+        std::cerr << "Failed to open input words file: " << in_words_path << std::endl;
+        return 1;
+    }
+
+    std::vector<ap_uint<__WORD_BW__>> words;
+    unsigned long long raw = 0;
+    while (in_words >> raw) {
+        words.push_back((ap_uint<__WORD_BW__>)raw);
+    }
+    if ((int)words.size() != __NWORDS__) {
+        std::cerr << "Unexpected word count: got " << words.size()
+                  << ", expected " << __NWORDS__ << std::endl;
+        return 1;
+    }
+
+    constexpr int N = __ARRAY_LEN__;
+
+    // Decode the golden words into elements via the memory lane loop.
+    au::value_type elems[N];
+    mem_lane_read<__WORD_BW__>(words.data(), elems, N);
+
+    // (1) Memory: re-encode via the lane loop; this is the golden-compared output.
+    ap_uint<__WORD_BW__> out_words[__NWORDS__];
+    mem_lane_write<__WORD_BW__>(elems, out_words, N);
+
+    // (2) FIFO round-trip -> re-encode -> must match the memory words.
+    au::value_type fifo_elems[N];
+    fifo_lane_roundtrip<__WORD_BW__>(elems, fifo_elems, N);
+    ap_uint<__WORD_BW__> fifo_words[__NWORDS__];
+    mem_lane_write<__WORD_BW__>(fifo_elems, fifo_words, N);
+
+    // (3) AXI4-Stream round-trip -> re-encode -> must match the memory words.
+    au::value_type axi_elems[N];
+    axi4_lane_roundtrip<__WORD_BW__>(elems, axi_elems, N);
+    ap_uint<__WORD_BW__> axi_words[__NWORDS__];
+    mem_lane_write<__WORD_BW__>(axi_elems, axi_words, N);
+
+    for (int i = 0; i < __NWORDS__; ++i) {
+        if (fifo_words[i] != out_words[i]) {
+            std::cerr << "FIFO lane mismatch at word " << i << std::endl;
+            return 2;
+        }
+        if (axi_words[i] != out_words[i]) {
+            std::cerr << "AXI4 lane mismatch at word " << i << std::endl;
+            return 3;
+        }
+    }
+
+    std::ofstream out(out_words_path);
+    if (!out) {
+        std::cerr << "Failed to open output words file: " << out_words_path << std::endl;
+        return 1;
+    }
+    for (int i = 0; i < __NWORDS__; ++i) {
+        out << static_cast<unsigned long long>(out_words[i]) << "\n";
+    }
+    return 0;
+}

--- a/tests/hw/test_arrayutils_lane_vitis.py
+++ b/tests/hw/test_arrayutils_lane_vitis.py
@@ -1,0 +1,163 @@
+"""Phase 1a lane-method conformance — Python golden vs Vitis csim, bit-exact.
+
+Exercises the new regime-agnostic ``*_lane`` methods (``read_array_lane`` / ``write_array_lane``
++ the FIFO / AXI4-Stream variants) through the canonical lane loop, for **both** regimes:
+
+- ``pf >= 1`` (vectorized): several word widths, including a **partial tail** (``n < pf``).
+- ``pf == 0`` (wide element, the path nothing tested before): a 64-bit element on a 32-bit
+  channel, and a wide complex element — each spanning ``ceil(elem/W)`` words/beats.
+
+Each case lays the array with the Python golden (``arrayutils.write_array``), runs the lane loop
+read→write round-trip in Vitis csim, and asserts the re-emitted words equal the golden words
+bit-for-bit. The C++ testbench additionally re-checks the FIFO and AXI4-Stream lane paths
+reproduce the same words in-sim (a divergence returns non-zero and fails csim).
+
+Reuses the ``tests/hw/test_arrayutils_vitis.py`` harness pattern (template cpp + tcl + csim).
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from waveflow.build.build import BuildConfig
+from waveflow.build.streamutils import StreamUtilsStep
+from waveflow.hw.arrayutils import gen_array_utils, read_array, write_array
+from waveflow.hw.complexfield import ComplexField
+from waveflow.hw.dataschema import FloatField, IntField
+from waveflow.toolchain import toolchain
+from waveflow.utils import complexutils as cx
+
+TEST_DIR = Path(__file__).parent
+RESOURCE_DIR = TEST_DIR / "resources"
+LANE_CPP_PATH = RESOURCE_DIR / "arrayutils_lane_roundtrip_test.cpp"
+ROUNDTRIP_TCL_PATH = RESOURCE_DIR / "arrayutils_roundtrip_run.tcl"
+WF_CINT_PATH = Path(__file__).resolve().parents[2] / "waveflow" / "build" / "wf_cint.h"
+
+
+def _s(bw: int):
+    return IntField.specialize(bitwidth=bw, signed=True, include_dir="include")
+
+
+def _cint(bw: int):
+    return ComplexField.specialize(_s(bw), include_dir="include")
+
+
+def _f(bw: int):
+    return FloatField.specialize(bitwidth=bw, include_dir="include")
+
+
+def _int_data(bw: int, n: int) -> np.ndarray:
+    # Evenly spaced integers in [lo, hi] via integer math (no float overflow at bw = 64),
+    # with the signed extremes pinned at the ends.
+    lo, hi = -(1 << (bw - 1)), (1 << (bw - 1)) - 1
+    if n == 1:
+        return np.array([hi], dtype=np.int64)
+    step = (hi - lo) // (n - 1)
+    vals = [lo + step * i for i in range(n)]
+    vals[-1] = hi
+    return np.array(vals, dtype=np.int64)
+
+
+def _complex_data(bw: int, n: int) -> np.ndarray:
+    re = _int_data(bw, n)
+    im = np.roll(_int_data(bw, n), 1)
+    return cx.make_complex(re, im, cx.int_format(bw, True))
+
+
+# (id, elem_type, word_bw, length, data, regime-note). pf = word_bw // elem_bw (0 if wider).
+def _cases():
+    return [
+        # --- pf >= 1 (vectorized), various word widths + partial tails ---
+        ("s16_w32_full", _s(16), 32, 8, _int_data(16, 8)),       # pf=2, no tail
+        ("s16_w32_tail", _s(16), 32, 7, _int_data(16, 7)),       # pf=2, tail n=1
+        ("s16_w64_tail", _s(16), 64, 11, _int_data(16, 11)),     # pf=4, tail n=3
+        ("s32_w32", _s(32), 32, 5, _int_data(32, 5)),            # pf=1
+        ("f32_w32", _f(32), 32, 6, np.linspace(-2.5, 3.5, 6, dtype=np.float32)),   # pf=1
+        ("f32_w64", _f(32), 64, 6, np.linspace(-9.0, 9.0, 6, dtype=np.float32)),   # pf=2
+        # --- pf == 0 (wide element: one element spans ceil(elem/W) words) ---
+        ("s64_w32", _s(64), 32, 4, _int_data(64, 4)),            # 64-bit elem on 32-bit channel
+        ("s64_w32_odd", _s(64), 32, 3, _int_data(64, 3)),        # wide, odd count
+        ("cint32_w32", _cint(32), 32, 4, _complex_data(32, 4)),  # wide complex (re|im = 64 bits)
+    ]
+
+
+def _run_vitis_tcl(tcl_path: Path, work_dir: Path, failure_prefix: str) -> None:
+    try:
+        toolchain.run_vitis_hls(tcl_path, work_dir=work_dir)
+    except RuntimeError as exc:
+        pytest.skip(f"Vitis execution unavailable in current setup: {exc}")
+    except subprocess.CalledProcessError as exc:
+        pytest.fail(
+            f"{failure_prefix}\n"
+            f"Command: {exc.cmd}\n"
+            f"Return code: {exc.returncode}\n"
+            f"Stdout:\n{exc.stdout}\n"
+            f"Stderr:\n{exc.stderr}"
+        )
+
+
+@pytest.mark.vitis
+@pytest.mark.parametrize("case", _cases(), ids=[c[0] for c in _cases()])
+def test_arrayutils_lane_roundtrip_vitis(tmp_path: Path, case):
+    name, elem_type, word_bw, length, data = case
+
+    vitis_path = toolchain.find_vitis_path()
+    if not vitis_path:
+        pytest.skip("Vitis installation not found; skipping arrayutils lane integration test.")
+
+    in_words = np.asarray(write_array(data, elem_type=elem_type, word_bw=word_bw))
+    save_dtype = np.uint32 if word_bw <= 32 else np.uint64
+
+    in_words_path = tmp_path / "array_words.txt"
+    out_words_path = tmp_path / "array_words_out.txt"
+    np.savetxt(in_words_path, in_words.astype(save_dtype), fmt="%u")
+
+    cfg = BuildConfig(root_dir=tmp_path)
+    generated_header = gen_array_utils(elem_type, [word_bw], cfg=cfg, streamutils_dir="include")
+    StreamUtilsStep(output_dir="include").run(cfg)
+
+    # An integer-inner ComplexField element maps to wf_cint<W>; its array-utils header
+    # #includes "wf_cint.h", so make it resolvable next to the generated header.
+    if "wf_cint.h" in generated_header.read_text(encoding="utf-8"):
+        shutil.copy(WF_CINT_PATH, generated_header.parent / "wf_cint.h")
+
+    header_include = generated_header.relative_to(tmp_path).as_posix()
+    namespace_name = generated_header.stem
+    cpp_src = (
+        LANE_CPP_PATH.read_text(encoding="utf-8")
+        .replace("__HEADER__", header_include)
+        .replace("__NAMESPACE__", namespace_name)
+        .replace("__WORD_BW__", str(word_bw))
+        .replace("__ARRAY_LEN__", str(length))
+        .replace("__NWORDS__", str(in_words.shape[0]))
+    )
+    (tmp_path / "arrayutils_lane_roundtrip_test.cpp").write_text(cpp_src, encoding="utf-8")
+
+    tcl_src = ROUNDTRIP_TCL_PATH.read_text(encoding="utf-8").replace(
+        "arrayutils_roundtrip_test.cpp", "arrayutils_lane_roundtrip_test.cpp"
+    )
+    (tmp_path / "arrayutils_lane_roundtrip_run.tcl").write_text(tcl_src, encoding="utf-8")
+
+    _run_vitis_tcl(
+        tmp_path / "arrayutils_lane_roundtrip_run.tcl",
+        work_dir=tmp_path,
+        failure_prefix=f"Vitis execution failed for arrayutils lane roundtrip case {name!r}.",
+    )
+
+    out_words = np.atleast_1d(np.loadtxt(out_words_path, dtype=save_dtype))
+
+    # The lane-loop round-trip must reproduce the Python golden words bit-for-bit.
+    assert np.array_equal(out_words, in_words.astype(save_dtype)), (
+        f"{name}: lane round-trip words differ from the Python golden."
+    )
+
+    # Numeric round-trip check for the simple element types (complex is covered by words-equal).
+    if isinstance(elem_type, type) and issubclass(elem_type, (IntField, FloatField)):
+        got = np.asarray(read_array(out_words, elem_type=elem_type, word_bw=word_bw, shape=length))
+        ref = np.asarray(data)
+        if issubclass(elem_type, FloatField):
+            assert np.allclose(got, ref, rtol=1e-6, atol=1e-6)
+        else:
+            assert np.array_equal(got, ref.astype(got.dtype))

--- a/waveflow/hw/arrayutils.py
+++ b/waveflow/hw/arrayutils.py
@@ -1128,6 +1128,85 @@ def _gen_write_axi4_stream_elem_specializations(
     return "\n".join(lines)
 
 
+def _gen_lane_helpers(
+    elem_type: type[DataSchema],
+    indent_level: int = 0,
+) -> str:
+    """Regime-agnostic lane methods (Phase 1a) over all three interfaces.
+
+    Each call moves the next ``LW = lane_capacity<W>() = max(1, pf)`` elements:
+
+    - ``pf >= 1`` (``LW = pf``): one word/beat -> ``pf`` lanes; ``n`` (``1 <= n <= LW``) is the
+      valid count (``pf`` for a full word, fewer only for the final partial one).
+    - ``pf == 0`` (``LW = 1``, wide element): one element spanning ``ceil(elem/W)`` words/beats
+      -> ``dst[0]``; ``n`` is ignored (always 1).
+
+    Both regimes are already implemented by the corresponding ``*_elem_impl<W>::run`` structs (the
+    ``pf >= 1`` lane logic and the ``pf == 0`` multi-word assembly the bulk ``read_array`` also
+    does), so the lane methods delegate to them, passing ``pf >= 1 ? n : 1`` so the wide-element
+    call always moves its single element regardless of the supplied ``n``.  (They call the
+    ``*_impl::run`` structs, not the ``*_elem`` wrappers: the wrappers declare a
+    ``value_type out[pf<W>()]`` buffer, which is an illegal zero-length array for ``pf == 0``,
+    whereas ``run`` takes a plain ``value_type*``.)  Memory methods act at the given word pointer
+    and do not advance -- the caller advances by ``get_nwords<W>(LW)`` words.
+    """
+    indent = elem_type._get_indent(indent_level)
+    i1 = elem_type._get_indent(indent_level + 1)
+    lc = "lane_capacity<word_bw>()"
+    sel = "pf<word_bw>() >= 1 ? n : 1"
+    axis = "hls::stream<streamutils::axi4s_word<word_bw>>&"
+
+    return "\n".join([
+        "// --- lane methods (Phase 1a): move LW = lane_capacity<W>() = max(1, pf) elements ---",
+        "// dst is a buffer of length LW; pf >= 1 -> n valid lanes of one word/beat, pf == 0 ->",
+        "// one wide element across ceil(elem/W) words/beats (n ignored).  Memory: the caller",
+        "// advances the word pointer by get_nwords<W>(LW); streams self-sequence.",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void read_array_lane(const ap_uint<word_bw>* src, value_type dst[{lc}], int n = {lc}) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}read_array_elem_impl<word_bw>::run(src, dst, {sel});",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void write_array_lane(const value_type src[{lc}], ap_uint<word_bw>* dst, int n = {lc}) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}write_array_elem_impl<word_bw>::run(src, dst, {sel});",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void read_stream_lane(hls::stream<ap_uint<word_bw>>& s, value_type dst[{lc}], int n = {lc}) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}read_stream_elem_impl<word_bw>::run(s, dst, {sel});",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void write_stream_lane(const value_type src[{lc}], hls::stream<ap_uint<word_bw>>& s, int n = {lc}) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}write_stream_elem_impl<word_bw>::run(s, src, {sel});",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void read_axi4_stream_lane({axis} s, value_type dst[{lc}], int n, streamutils::tlast_status& tl) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}read_axi4_stream_elem_impl<word_bw>::run(s, dst, tl, {sel});",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void read_axi4_stream_lane({axis} s, value_type dst[{lc}], int n = {lc}) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}streamutils::tlast_status tl = streamutils::tlast_status::no_tlast;",
+        f"{i1}read_axi4_stream_lane<word_bw>(s, dst, n, tl);",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void write_axi4_stream_lane(const value_type src[{lc}], {axis} s, bool tlast = false, int n = {lc}) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}write_axi4_stream_elem_impl<word_bw>::run(s, src, tlast, {sel});",
+        f"{indent}}}",
+    ])
+
+
 def _gen_stream_elem_helpers(
     elem_type: type[DataSchema],
     word_bw_supported: list[int],
@@ -1143,6 +1222,13 @@ def _gen_stream_elem_helpers(
         "template<int word_bw>",
         f"{indent}static constexpr int pf() {{",
         f"{i1}return word_bw / {elem_bw};",
+        f"{indent}}}",
+        "",
+        "// lane_capacity = max(1, pf): the lane-buffer size and loop step (call it LW). It is pf",
+        "// in the vectorized regime (pf >= 1) and 1 in the wide-element regime (pf == 0).",
+        "template<int word_bw>",
+        f"{indent}static constexpr int lane_capacity() {{",
+        f"{i1}return pf<word_bw>() >= 1 ? pf<word_bw>() : 1;",
         f"{indent}}}",
         "",
         _gen_read_array_elem_specializations(
@@ -1180,6 +1266,8 @@ def _gen_stream_elem_helpers(
             word_bw_supported=word_bw_supported,
             indent_level=indent_level,
         ),
+        "",
+        _gen_lane_helpers(elem_type=elem_type, indent_level=indent_level),
         "",
         "template<int word_bw>",
         f"{indent}inline void read_stream(hls::stream<ap_uint<word_bw>>& s, value_type* dst, int len) {{",


### PR DESCRIPTION
Phase 1a of the array_utils serialization redesign (`plans/serialization_impl.md`; contract: `plans/serialization_reference.md`). **Purely additive** — no existing method or caller changes.

## What's added (`waveflow/hw/arrayutils.py`, generated C++)
- **`lane_capacity<W>() = max(1, pf<W>())`** — the lane-buffer size / loop step `LW`.
- **Six regime-agnostic lane methods**, each moving the next `LW` elements:
  - memory: `read_array_lane` / `write_array_lane`
  - FIFO: `read_stream_lane` / `write_stream_lane`
  - AXI4-Stream: `read_axi4_stream_lane` / `write_axi4_stream_lane`
  - `pf ≥ 1`: one word/beat ↔ `pf` lanes (`n` valid). `pf = 0`: one wide element across `⌈elem/W⌉` words/beats ↔ `dst[0]` (`n` ignored). Memory acts at the given pointer; caller advances by `get_nwords<W>(LW)`.

## The `pf = 0` enablement
The existing `*_elem` wrappers declare `value_type out[pf<W>()]` — an illegal **zero-length array** when `pf=0`, so they were uncallable for wide elements (which is exactly why nothing exercised that path before). The lane methods delegate to `*_elem_impl<W>::run(...)` (plain `value_type*`) with `n = pf>=1 ? n : 1`, and size buffers `lane_capacity` (≥1) — so wide elements work.

## Verification (independently re-run)
- **Lane conformance: 9/9 bit-exact on real Vitis HLS** — both regimes across word widths, `pf=0` (64-bit elem on 32-bit channel; wide complex) **first-class**, partial-tail (`n<pf`) included.
- Existing arrayutils Vitis tests: 3/3 (no regression to `read_array`/`write_array`).
- Non-vitis: 15-baseline (no regressions — additive).
- Diff: **422 insertions, 0 deletions**; `read_array_elem` / bulk `read_array` / callers untouched.

Next: phase 1b (`read_array_slice` / `write_array_slice`, built on these lane methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)