### PR TITLE
array_utils: read_array_slice / write_array_slice (serialization redesign, phase 1b)

### DIFF
--- a/tests/hw/resources/arrayutils_slice_run.tcl
+++ b/tests/hw/resources/arrayutils_slice_run.tcl
@@ -1,0 +1,28 @@
+open_project -reset waveflow_arrayutils_slice_vitis_proj
+set_top main
+add_files -tb arrayutils_slice_test.cpp
+
+set script_dir [file dirname [file normalize [info script]]]
+set streamutils_cpp [file join $script_dir "streamutils.cpp"]
+if {![file exists $streamutils_cpp]} {
+    set streamutils_cpp [file join $script_dir "include" "streamutils.cpp"]
+}
+if {[file exists $streamutils_cpp]} {
+    add_files -tb $streamutils_cpp
+}
+
+open_solution -reset "solution1"
+set_part {xc7z020clg484-1}
+create_clock -period 10
+set in_full   [file join $script_dir "in_full.txt"]
+set in_repl   [file join $script_dir "in_repl.txt"]
+set out_read  [file join $script_dir "out_read.txt"]
+set out_write [file join $script_dir "out_write.txt"]
+
+if {[catch {csim_design -argv "$in_full $in_repl $out_read $out_write"} res]} {
+    puts "WAVEFLOW_ERROR: HLS C-Simulation failed."
+    puts $res
+    exit 1
+}
+puts "WAVEFLOW_SUCCESS: Arrayutils slice Vitis conformance passed."
+exit 0

--- a/tests/hw/resources/arrayutils_slice_test.cpp
+++ b/tests/hw/resources/arrayutils_slice_test.cpp
@@ -1,0 +1,91 @@
+// Phase 1b range-method (read_array_slice / write_array_slice) conformance testbench (template).
+//
+// Three checks per case, against the Python golden (arrayutils.write_array):
+//   (A) static whole-array overloads: read [0, N) then re-pack must reproduce the input words.
+//   (B) ranged read  [I0, I1): read the sub-range, re-pack contiguously -> out_read file,
+//       compared to write_array(data[I0:I1]).
+//   (C) ranged write [I0, I1) RMW: copy the full golden words, write a replacement sub-array into
+//       the middle -> out_write file, compared to write_array(data with [I0:I1] replaced). This
+//       is the load-bearing check: neighbor elements sharing the boundary words must be preserved.
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "__HEADER__"
+
+namespace au = __NAMESPACE__;
+
+static std::vector<ap_uint<__WORD_BW__>> read_words(const char* path) {
+    std::ifstream f(path);
+    std::vector<ap_uint<__WORD_BW__>> w;
+    unsigned long long raw = 0;
+    while (f >> raw) {
+        w.push_back((ap_uint<__WORD_BW__>)raw);
+    }
+    return w;
+}
+
+static void dump_words(const char* path, const ap_uint<__WORD_BW__>* w, int n) {
+    std::ofstream o(path);
+    for (int i = 0; i < n; ++i) {
+        o << static_cast<unsigned long long>(w[i]) << "\n";
+    }
+}
+
+int main(int argc, char** argv) {
+    const char* in_full = (argc > 1) ? argv[1] : "in_full.txt";
+    const char* in_repl = (argc > 2) ? argv[2] : "in_repl.txt";
+    const char* out_read = (argc > 3) ? argv[3] : "out_read.txt";
+    const char* out_write = (argc > 4) ? argv[4] : "out_write.txt";
+
+    constexpr int N = __N__;
+    constexpr int M = __M__;
+    constexpr int I0 = __I0__;
+    constexpr int I1 = __I1__;
+    constexpr int NWF = __NWORDS_FULL__;
+    constexpr int NWS = __NWORDS_SUB__;
+
+    std::vector<ap_uint<__WORD_BW__>> full_v = read_words(in_full);
+    std::vector<ap_uint<__WORD_BW__>> repl_v = read_words(in_repl);
+    if ((int)full_v.size() != NWF || (int)repl_v.size() != NWS) {
+        std::cerr << "Unexpected word counts: full=" << full_v.size() << "/" << NWF
+                  << " repl=" << repl_v.size() << "/" << NWS << std::endl;
+        return 1;
+    }
+    ap_uint<__WORD_BW__> full[NWF];
+    for (int i = 0; i < NWF; ++i) full[i] = full_v[i];
+    ap_uint<__WORD_BW__> repl[NWS];
+    for (int i = 0; i < NWS; ++i) repl[i] = repl_v[i];
+
+    // (A) static whole-array overloads: read [0,N) and re-pack -> must equal the input words.
+    au::value_type whole[N];
+    au::read_array_slice<__WORD_BW__>(full, whole);          // 2-arg overload, N deduced
+    ap_uint<__WORD_BW__> whole_w[NWF];
+    for (int i = 0; i < NWF; ++i) whole_w[i] = 0;
+    au::write_array_slice<__WORD_BW__>(whole, whole_w);       // 2-arg overload, N deduced
+    for (int i = 0; i < NWF; ++i) {
+        if (whole_w[i] != full[i]) {
+            std::cerr << "Whole-array overload mismatch at word " << i << std::endl;
+            return 5;
+        }
+    }
+
+    // (B) ranged read [I0, I1) -> re-pack contiguously (range [0, M)) -> out_read.
+    au::value_type rbuf[M];
+    au::read_array_slice<__WORD_BW__>(full, I0, I1, rbuf);
+    ap_uint<__WORD_BW__> rout[NWS];
+    for (int i = 0; i < NWS; ++i) rout[i] = 0;                // fresh buffer: pad bits stay 0
+    au::write_array_slice<__WORD_BW__>(rbuf, rout, 0, M);
+    dump_words(out_read, rout, NWS);
+
+    // (C) ranged write [I0, I1) RMW: start from a copy of the full golden, splice in M
+    // replacement elements, dump the whole array. Neighbors in the boundary words must survive.
+    ap_uint<__WORD_BW__> work[NWF];
+    for (int i = 0; i < NWF; ++i) work[i] = full[i];
+    au::value_type wbuf[M];
+    au::read_array_slice<__WORD_BW__>(repl, 0, M, wbuf);
+    au::write_array_slice<__WORD_BW__>(wbuf, work, I0, I1);
+    dump_words(out_write, work, NWF);
+
+    return 0;
+}

--- a/tests/hw/test_arrayutils_slice_vitis.py
+++ b/tests/hw/test_arrayutils_slice_vitis.py
@@ -1,0 +1,173 @@
+"""Phase 1b range-method conformance — Python golden vs Vitis csim, bit-exact.
+
+Exercises the new element-indexed range methods (``read_array_slice`` / ``write_array_slice``,
+built on the Phase 1a lane methods) through real Vitis csim. Per case the C++ testbench runs three
+checks against the Python golden (``arrayutils.write_array``):
+
+- **(A) static whole-array overloads** — read ``[0, N)`` then re-pack must reproduce the words.
+- **(B) ranged read** ``[i0, i1)`` — read the sub-range, re-pack contiguously, compare to
+  ``write_array(data[i0:i1])``.
+- **(C) ranged write RMW** ``[i0, i1)`` — splice a replacement sub-array into the middle of a copy
+  of the full golden and compare to ``write_array(data with [i0:i1] replaced)``. The load-bearing
+  check: neighbor elements sharing the boundary words must be preserved (not clobbered).
+
+Cases cover: whole array; aligned and unaligned ``[i0, i1)``; both regimes including ``pf == 0``
+(wide int + wide complex); a non-power-of-two ``pf`` with intra-word padding; and the unaligned-end
+RMW. Reuses the Phase 1a / existing arrayutils Vitis harness pattern (template cpp + tcl + csim).
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from waveflow.build.build import BuildConfig
+from waveflow.build.streamutils import StreamUtilsStep
+from waveflow.hw.arrayutils import gen_array_utils, write_array
+from waveflow.hw.complexfield import ComplexField
+from waveflow.hw.dataschema import IntField
+from waveflow.toolchain import toolchain
+from waveflow.utils import complexutils as cx
+
+TEST_DIR = Path(__file__).parent
+RESOURCE_DIR = TEST_DIR / "resources"
+SLICE_CPP_PATH = RESOURCE_DIR / "arrayutils_slice_test.cpp"
+SLICE_TCL_PATH = RESOURCE_DIR / "arrayutils_slice_run.tcl"
+WF_CINT_PATH = Path(__file__).resolve().parents[2] / "waveflow" / "build" / "wf_cint.h"
+
+
+def _sint(bw: int):
+    return IntField.specialize(bitwidth=bw, signed=True, include_dir="include")
+
+
+def _uint(bw: int):
+    return IntField.specialize(bitwidth=bw, signed=False, include_dir="include")
+
+
+def _cint(bw: int):
+    return ComplexField.specialize(_sint(bw), include_dir="include")
+
+
+def _spaced(lo: int, hi: int, n: int) -> np.ndarray:
+    # Evenly spaced integers in [lo, hi] via integer math (no float overflow at bw = 64).
+    if n == 1:
+        return np.array([hi], dtype=np.int64)
+    step = (hi - lo) // (n - 1)
+    vals = [lo + step * i for i in range(n)]
+    vals[0], vals[-1] = lo, hi
+    return np.array(vals, dtype=np.int64)
+
+
+def _data(kind: str, bw: int, n: int) -> np.ndarray:
+    if kind == "sint":
+        return _spaced(-(1 << (bw - 1)), (1 << (bw - 1)) - 1, n)
+    if kind == "uint":
+        return _spaced(0, (1 << bw) - 1, n)
+    re = _spaced(-(1 << (bw - 1)), (1 << (bw - 1)) - 1, n)
+    im = np.roll(re, 1)
+    return cx.make_complex(re, im, cx.int_format(bw, True))
+
+
+def _complement(seg: np.ndarray, kind: str, bw: int) -> np.ndarray:
+    # A distinct, in-range replacement: bitwise complement maps the range onto itself bijectively
+    # and never equals the original (so a missed write or a clobbered neighbor is detectable).
+    if kind == "sint":
+        return (-1 - np.asarray(seg)).astype(np.int64)
+    if kind == "uint":
+        return (((1 << bw) - 1) - np.asarray(seg)).astype(np.int64)
+    re = -1 - cx.re_of(seg)
+    im = -1 - cx.im_of(seg)
+    return cx.make_complex(re, im, cx.int_format(bw, True))
+
+
+# (id, kind, bw, word_bw, N, i0, i1)
+def _cases():
+    return [
+        ("s16_w32_whole", "sint", 16, 32, 8, 0, 8),        # pf=2, whole array
+        ("s16_w32_aligned", "sint", 16, 32, 10, 2, 8),     # pf=2, aligned [2,8)
+        ("s16_w32_unaligned", "sint", 16, 32, 10, 3, 7),   # pf=2, both ends unaligned (RMW x2)
+        ("s16_w64_unaligned", "sint", 16, 64, 13, 5, 11),  # pf=4, unaligned
+        ("s32_w32_mid", "sint", 32, 32, 6, 2, 5),          # pf=1
+        ("u10_w32_unaligned", "uint", 10, 32, 11, 2, 9),   # pf=3 (non-power-of-two), padding, RMW
+        ("s64_w32_mid", "sint", 64, 32, 5, 1, 4),          # pf=0 wide int
+        ("cint32_w32_mid", "complex", 32, 32, 5, 1, 4),    # pf=0 wide complex
+    ]
+
+
+def _run_vitis_tcl(tcl_path: Path, work_dir: Path, failure_prefix: str) -> None:
+    try:
+        toolchain.run_vitis_hls(tcl_path, work_dir=work_dir)
+    except RuntimeError as exc:
+        pytest.skip(f"Vitis execution unavailable in current setup: {exc}")
+    except subprocess.CalledProcessError as exc:
+        pytest.fail(
+            f"{failure_prefix}\n"
+            f"Command: {exc.cmd}\n"
+            f"Return code: {exc.returncode}\n"
+            f"Stdout:\n{exc.stdout}\n"
+            f"Stderr:\n{exc.stderr}"
+        )
+
+
+@pytest.mark.vitis
+@pytest.mark.parametrize("case", _cases(), ids=[c[0] for c in _cases()])
+def test_arrayutils_slice_vitis(tmp_path: Path, case):
+    name, kind, bw, word_bw, n, i0, i1 = case
+
+    vitis_path = toolchain.find_vitis_path()
+    if not vitis_path:
+        pytest.skip("Vitis installation not found; skipping arrayutils slice integration test.")
+
+    elem_type = {"sint": _sint, "uint": _uint, "complex": _cint}[kind](bw)
+    data = _data(kind, bw, n)
+    repl = _complement(data[i0:i1], kind, bw)
+    expected_full = data.copy()
+    expected_full[i0:i1] = repl
+
+    save_dtype = np.uint32 if word_bw <= 32 else np.uint64
+    in_full = np.asarray(write_array(data, elem_type=elem_type, word_bw=word_bw))
+    in_repl = np.asarray(write_array(repl, elem_type=elem_type, word_bw=word_bw))
+    expected_read = np.asarray(write_array(data[i0:i1], elem_type=elem_type, word_bw=word_bw))
+    expected_write = np.asarray(write_array(expected_full, elem_type=elem_type, word_bw=word_bw))
+
+    np.savetxt(tmp_path / "in_full.txt", in_full.astype(save_dtype), fmt="%u")
+    np.savetxt(tmp_path / "in_repl.txt", in_repl.astype(save_dtype), fmt="%u")
+
+    cfg = BuildConfig(root_dir=tmp_path)
+    generated_header = gen_array_utils(elem_type, [word_bw], cfg=cfg, streamutils_dir="include")
+    StreamUtilsStep(output_dir="include").run(cfg)
+    if "wf_cint.h" in generated_header.read_text(encoding="utf-8"):
+        shutil.copy(WF_CINT_PATH, generated_header.parent / "wf_cint.h")
+
+    cpp_src = (
+        SLICE_CPP_PATH.read_text(encoding="utf-8")
+        .replace("__HEADER__", generated_header.relative_to(tmp_path).as_posix())
+        .replace("__NAMESPACE__", generated_header.stem)
+        .replace("__WORD_BW__", str(word_bw))
+        .replace("__NWORDS_FULL__", str(in_full.shape[0]))
+        .replace("__NWORDS_SUB__", str(in_repl.shape[0]))
+        .replace("__N__", str(n))
+        .replace("__M__", str(i1 - i0))
+        .replace("__I0__", str(i0))
+        .replace("__I1__", str(i1))
+    )
+    (tmp_path / "arrayutils_slice_test.cpp").write_text(cpp_src, encoding="utf-8")
+    shutil.copy(SLICE_TCL_PATH, tmp_path / "arrayutils_slice_run.tcl")
+
+    _run_vitis_tcl(
+        tmp_path / "arrayutils_slice_run.tcl",
+        work_dir=tmp_path,
+        failure_prefix=f"Vitis execution failed for arrayutils slice case {name!r}.",
+    )
+
+    out_read = np.atleast_1d(np.loadtxt(tmp_path / "out_read.txt", dtype=save_dtype))
+    out_write = np.atleast_1d(np.loadtxt(tmp_path / "out_write.txt", dtype=save_dtype))
+
+    assert np.array_equal(out_read, expected_read.astype(save_dtype)), (
+        f"{name}: read_array_slice[{i0},{i1}) words differ from the Python golden."
+    )
+    assert np.array_equal(out_write, expected_write.astype(save_dtype)), (
+        f"{name}: write_array_slice[{i0},{i1}) RMW words differ from the Python golden "
+        "(a neighbor in a boundary word may have been clobbered)."
+    )

--- a/waveflow/hw/arrayutils.py
+++ b/waveflow/hw/arrayutils.py
@@ -1207,6 +1207,105 @@ def _gen_lane_helpers(
     ])
 
 
+def _gen_slice_helpers(
+    elem_type: type[DataSchema],
+    indent_level: int = 0,
+) -> str:
+    """Element-indexed range methods (Phase 1b) over memory, built on the 1a lane methods.
+
+    ``read_array_slice<W>(words, i0, i1, out)`` reads elements ``[i0, i1)`` into ``out[0 ..
+    i1-i0)``; ``write_array_slice<W>(in, words, i0, i1)`` is the inverse.  The caller works in
+    **element coordinates** -- no ``i0/PF`` in the kernel.
+
+    Layout is word-aligned (matching the Python golden): element ``i`` is lane ``i % LW`` of group
+    ``i / LW``, where ``LW = lane_capacity<W>()`` and a group spans ``WPU = get_nwords<W>(LW)``
+    words -- ``1`` word holding ``pf`` lanes when ``pf >= 1``, or ``ceil(elem/W)`` words for one
+    wide element when ``pf == 0``.  The walk keeps a running word pointer (advanced by ``WPU`` per
+    group) and a per-group lane index, so there is no per-element divide; ``i0`` is located once
+    with the compile-time-constant ``LW`` (a multiply/shift, not a hardware divider), correct for
+    any ``pf`` -- non-powers-of-two and ``pf == 0`` included.
+
+    ``write_array_slice`` read-modify-writes a **partial boundary group** (one whose word it shares
+    with neighbor elements outside ``[i0, i1)``) so those neighbors are preserved; a fully-covered
+    group skips the read.  A statically-sized whole-array overload (range ``[0, N)``) deduces ``N``.
+    """
+    indent = elem_type._get_indent(indent_level)
+    i1 = elem_type._get_indent(indent_level + 1)
+    i2 = elem_type._get_indent(indent_level + 2)
+
+    return "\n".join([
+        "// --- range methods (Phase 1b): element-indexed [i0, i1) over memory, on the lane methods ---",
+        "// Word-aligned layout: element i is lane (i % LW) of group (i / LW); a group is one word",
+        "// (pf >= 1) or ceil(elem/W) words (pf == 0, one wide element). Walk groups with a running",
+        "// word pointer (advance WPU = get_nwords<W>(LW) per group) + a per-group lane index -- no",
+        "// per-element divide. Element coordinates throughout: the caller never computes i0/PF.",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void read_array_slice(const ap_uint<word_bw>* words, int i0, int i1, value_type* out) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}if (words == nullptr || out == nullptr || i1 <= i0) {{",
+        f"{i2}return;",
+        f"{i1}}}",
+        f"{i1}constexpr int LW = lane_capacity<word_bw>();",
+        f"{i1}constexpr int WPU = get_nwords<word_bw>(LW);",
+        f"{i1}const int q0 = i0 / LW;                          // first group (LW is compile-time)",
+        f"{i1}const ap_uint<word_bw>* wp = words + q0 * WPU;",
+        f"{i1}int o = 0;",
+        f"{i1}for (int gb = q0 * LW; gb < i1; gb += LW) {{     // gb = group base element index",
+        f"{i2}const int lstart = (gb < i0) ? (i0 - gb) : 0;",
+        f"{i2}const int lend = (gb + LW > i1) ? (i1 - gb) : LW;",
+        f"{i2}value_type lane[LW];",
+        f"{i2}read_array_lane<word_bw>(wp, lane, LW);",
+        f"{i2}for (int l = lstart; l < lend; ++l) {{",
+        f"{i2}    out[o++] = lane[l];",
+        f"{i2}}}",
+        f"{i2}wp += WPU;",
+        f"{i1}}}",
+        f"{indent}}}",
+        "",
+        "template<int word_bw>",
+        f"{indent}inline void write_array_slice(const value_type* in, ap_uint<word_bw>* words, int i0, int i1) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}if (words == nullptr || in == nullptr || i1 <= i0) {{",
+        f"{i2}return;",
+        f"{i1}}}",
+        f"{i1}constexpr int LW = lane_capacity<word_bw>();",
+        f"{i1}constexpr int WPU = get_nwords<word_bw>(LW);",
+        f"{i1}const int q0 = i0 / LW;",
+        f"{i1}ap_uint<word_bw>* wp = words + q0 * WPU;",
+        f"{i1}int o = 0;",
+        f"{i1}for (int gb = q0 * LW; gb < i1; gb += LW) {{",
+        f"{i2}const int lstart = (gb < i0) ? (i0 - gb) : 0;",
+        f"{i2}const int lend = (gb + LW > i1) ? (i1 - gb) : LW;",
+        f"{i2}value_type lane[LW];",
+        f"{i2}// Partial boundary group shares its word with neighbors outside [i0, i1):",
+        f"{i2}// read-modify-write to preserve them. A fully-covered group skips the read.",
+        f"{i2}if (lstart != 0 || lend != LW) {{",
+        f"{i2}    read_array_lane<word_bw>(wp, lane, LW);",
+        f"{i2}}}",
+        f"{i2}for (int l = lstart; l < lend; ++l) {{",
+        f"{i2}    lane[l] = in[o++];",
+        f"{i2}}}",
+        f"{i2}write_array_lane<word_bw>(lane, wp, LW);",
+        f"{i2}wp += WPU;",
+        f"{i1}}}",
+        f"{indent}}}",
+        "",
+        "// Whole-array overloads (range [0, N)); N is deduced from the statically-sized buffer.",
+        "template<int word_bw, int N>",
+        f"{indent}inline void read_array_slice(const ap_uint<word_bw>* words, value_type (&out)[N]) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}read_array_slice<word_bw>(words, 0, N, out);",
+        f"{indent}}}",
+        "",
+        "template<int word_bw, int N>",
+        f"{indent}inline void write_array_slice(const value_type (&in)[N], ap_uint<word_bw>* words) {{",
+        f"{i1}#pragma HLS INLINE",
+        f"{i1}write_array_slice<word_bw>(in, words, 0, N);",
+        f"{indent}}}",
+    ])
+
+
 def _gen_stream_elem_helpers(
     elem_type: type[DataSchema],
     word_bw_supported: list[int],
@@ -1268,6 +1367,8 @@ def _gen_stream_elem_helpers(
         ),
         "",
         _gen_lane_helpers(elem_type=elem_type, indent_level=indent_level),
+        "",
+        _gen_slice_helpers(elem_type=elem_type, indent_level=indent_level),
         "",
         "template<int word_bw>",
         f"{indent}inline void read_stream(hls::stream<ap_uint<word_bw>>& s, value_type* dst, int len) {{",


### PR DESCRIPTION
Phase 1b of the array_utils serialization redesign (`plans/serialization_impl.md`; contract: `plans/serialization_reference.md`). Builds on phase 1a's lane methods (#77). **Purely additive** — no existing method or caller changes.

## What's added (`waveflow/hw/arrayutils.py`, generated C++)
- **`read_array_slice<W>(words, i0, i1, out)`** — read elements `[i0, i1)` into `out[0 .. i1-i0)` in **element coordinates** (no caller `÷PF`). Built on phase-1a `read_array_lane`: locate `i0`'s unit, peel the partial first/last word, stream the whole middle. **Division-free** (running offset + wrapping lane counter), correct for **any `pf`** — non-powers-of-two and `pf=0` (wide elements). Whole array = `[0, N)`; overload `read_array_slice<W>(words, out)` deduces `N` from a static `out`.
- **`write_array_slice<W>(in, words, i0, i1)`** — the inverse; **unaligned ends read-modify-write** the boundary words so neighbor elements survive; aligned ranges skip the RMW.
- `words` is `ap_uint<W>*` — `m_axi` port or local BRAM array (word-indexed).

## Verification (independently re-run)
- **Slice conformance: 8/8 bit-exact on real Vitis HLS** — aligned + unaligned `[i0, i1)`, both regimes incl. **`pf=0`** (wide int + complex), **non-power-of-two `pf=3`**, and the load-bearing **unaligned-write RMW** (neighbor preservation confirmed).
- Existing arrayutils + phase-1a lane Vitis tests: 12/12 (no regression).
- Non-vitis: 15-baseline (additive — no regressions).
- Diff: **393 insertions, 0 deletions**; `read_array_elem` / bulk `read_array` / callers untouched.

This completes the **new API surface** (lane + slice). Next: phase 2 — migrate VMAC + examples onto these methods, retire `read_array_elem` and bulk `read_array`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)