### PR TITLE
VMAC: redesign to a three-op element-wise engine

### DIFF
--- a/examples/vmac/vmac.py
+++ b/examples/vmac/vmac.py
@@ -14,19 +14,21 @@ component's ``HwParam`` with the schema's symbolic ``Param``::
     cmd   = accel.Cmd(...)                     # VmacCmd.specialize(mem_awidth=…, data_bw=…)
     dst   = accel.execute(cmd, mem)            # the bit-exact golden (instance method)
 
-The fused op is ``D = α·A·op(B) + β·C [, reduce_rows]`` over a shared-memory array.  The
-**single** synthesizable hook is :meth:`vmac_compute` — read operands, fused op, requantize,
-write — whose **Python body is the golden** (it delegates to :meth:`execute`) and whose **C++
-is hand-written** in ``vmac_compute_impl.tpp`` (linked via ``@synthesizable(impl_file=…)``).
+The op is one of three **element-wise** complex ops over a row-major shared-memory region —
+``scalar_mult`` (``α[i]·A``), ``inner_prod`` (``A·conj(B)``), ``sum`` (``A+B``) — with an
+optional row reduction ``Y[j] = Σ_i R[i, j]``.  The **single** synthesizable hook is
+:meth:`vmac_compute` — read operands, op, requantize, write — whose **Python body is the
+golden** (it delegates to :meth:`execute`) and whose **C++ is hand-written** in
+``vmac_compute_impl.tpp`` (linked via ``@synthesizable(impl_file=…)``).
 This mirrors :class:`~examples.shared_mem.hist.HistAccel`: declare the structure, hand-write
 the compute, with a golden that auto-checks it.
 
 The golden :meth:`execute` composes the merged integer-backed numpy ``ComplexField``
 operators (``cmult`` / ``cadd`` / ``conj``), the wide-accumulator column reduction
-:func:`~waveflow.hw.complexfield.csum` for ``reduce_rows``, and the output requantize
+:func:`~waveflow.hw.complexfield.csum` when ``reduce`` is set, and the output requantize
 (right-shift + round + saturate) via the ``ap_fixed``-exact integer requantizer.  The
-datapath: **multiply → wide accumulate (full precision, ≤ acc_bw) → right-shift → round +
-saturate → write (out_bw)**.  The right-shift is the single lossy step (an ``ap_fixed``
+datapath: **element-wise op → wide accumulate (full precision, ≤ acc_bw) → right-shift →
+round + saturate → write (out_bw)**.  The right-shift is the single lossy step (an ``ap_fixed``
 assignment); its amount ``SHIFT = F_acc − F_in`` is *derived* from the flags + the structural
 format (not in the command — see :meth:`output_format` / :meth:`derived_shift`), so the golden
 is bit-exact with the Vitis kernel.  ``mem`` is the shared memory: a 1-D structured
@@ -95,7 +97,7 @@ class VmacAccel(HwComponent):
             object.__setattr__(self, "_hw_construction_complete", True)
         else:
             super().__post_init__()
-            # The m_axi data port (the shared memory the fused op reads/writes) and the
+            # The m_axi data port (the shared memory the op reads/writes) and the
             # command stream; mirror HistAccel's endpoint set.
             self.s_in = StreamIFSlave(
                 name=f"{self.name}_s_in", sim=self.sim, bitwidth=int(self.mem_dwidth)
@@ -307,8 +309,8 @@ class VmacAccel(HwComponent):
     # --- the synthesizable hook + kernel body --------------------------------
     @synthesizable(impl_file="vmac_compute_impl.tpp")
     def vmac_compute(self, cmd: VmacCmd, mem: np.ndarray) -> ProcessGen[DataArray]:
-        """The fused op ``D = α·A·op(B) + β·C [, reduce_rows]`` — the **single** hook (the
-        whole datapath: read operands, fused op, requantize, write).
+        """The element-wise op (``scalar_mult`` / ``inner_prod`` / ``sum``, optional row
+        reduce) — the **single** hook (the whole datapath: read operands, op, requantize, write).
 
         Its Python body is the golden (delegates to :meth:`execute`); its C++ is the
         hand-written ``vmac_compute_impl.tpp`` (the ``ap_fixed`` accumulator =
@@ -322,7 +324,7 @@ class VmacAccel(HwComponent):
     def run_proc(self) -> ProcessGen[None]:
         """Kernel body (single ap_ctrl_hs invocation) — the codegen root.
 
-        Read one :class:`VmacCmd` off ``s_in``, then run the fused op in the
+        Read one :class:`VmacCmd` off ``s_in``, then run the op in the
         :meth:`vmac_compute` hook against the ``m_mem`` shared memory.  The m_axi
         read/write plumbing around the hook (the strided gather/scatter the
         ``.tpp`` performs lane-by-lane) and the codegen wiring are completed in the

--- a/examples/vmac/vmac.py
+++ b/examples/vmac/vmac.py
@@ -41,6 +41,7 @@ full ``HwComponent``: an ``m_axi`` (``MMIFMaster``) data port + an ``s_in`` comm
 with :meth:`run_proc` the kernel body the generated kernel is lowered from (the m_axi data
 plumbing + codegen are wired in the build phase).
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -48,7 +49,7 @@ from typing import ClassVar
 
 import numpy as np
 
-from examples.vmac.vmac_cmd import VmacCmd
+from examples.vmac.vmac_cmd import OpCode, VmacCmd
 from waveflow.hw.clock import Clock
 from waveflow.hw.complexfield import ComplexField, cadd, cmult, conj, csum
 from waveflow.hw.dataschema import DataArray
@@ -70,19 +71,19 @@ class VmacAccel(HwComponent):
     ``vmac_compute`` synthesizable hook (the codegen source for ``gen/vmac.cpp``)."""
 
     cpp_kernel_name: ClassVar[str | None] = "vmac"
-    cpp_namespace:   ClassVar[str | None] = "vmac_impl"
+    cpp_namespace: ClassVar[str | None] = "vmac_impl"
 
     # structural params (synthesis-time HLS template params).  Everything that sizes or
     # types the datapath lives here — so A_T / ACC_T / OUT_T are compile-time (no dynamic
     # types).  q_rnd / o_sat MUST be structural (ap_fixed's Q/O modes are compile-time).
-    mem_dwidth: HwParam[int] = 512          # MEM_BW (memory-interface width / lane factor)
-    mem_awidth: HwParam[int] = 32           # m_axi address width
-    data_bw: HwParam[int] = 16              # IN_BW — operand (re/im) component width
-    int_bits: HwParam[int] = 8              # I of the operand format (F_in = data_bw - int_bits)
-    acc_bw: HwParam[int] = 48               # accumulator width budget
-    out_bw: HwParam[int] = 16               # writeback (re/im) component width
-    q_rnd: HwParam[int] = 0                 # output rounding: 0 = AP_TRN, 1 = AP_RND
-    o_sat: HwParam[int] = 0                 # output overflow: 0 = AP_WRAP, 1 = AP_SAT
+    mem_dwidth: HwParam[int] = 512  # MEM_BW (memory-interface width / lane factor)
+    mem_awidth: HwParam[int] = 32  # m_axi address width
+    data_bw: HwParam[int] = 16  # IN_BW — operand (re/im) component width
+    int_bits: HwParam[int] = 8  # I of the operand format (F_in = data_bw - int_bits)
+    acc_bw: HwParam[int] = 48  # accumulator width budget
+    out_bw: HwParam[int] = 16  # writeback (re/im) component width
+    q_rnd: HwParam[int] = 0  # output rounding: 0 = AP_TRN, 1 = AP_RND
+    o_sat: HwParam[int] = 0  # output overflow: 0 = AP_WRAP, 1 = AP_SAT
     clk: Clock = field(default_factory=lambda: Clock(freq=1e9))
 
     def __post_init__(self) -> None:
@@ -96,10 +97,12 @@ class VmacAccel(HwComponent):
             super().__post_init__()
             # The m_axi data port (the shared memory the fused op reads/writes) and the
             # command stream; mirror HistAccel's endpoint set.
-            self.s_in  = StreamIFSlave(name=f'{self.name}_s_in', sim=self.sim,
-                                       bitwidth=int(self.mem_dwidth))
-            self.m_mem = MMIFMaster(name=f'{self.name}_m_mem', sim=self.sim,
-                                    bitwidth=int(self.mem_dwidth))
+            self.s_in = StreamIFSlave(
+                name=f"{self.name}_s_in", sim=self.sim, bitwidth=int(self.mem_dwidth)
+            )
+            self.m_mem = MMIFMaster(
+                name=f"{self.name}_m_mem", sim=self.sim, bitwidth=int(self.mem_dwidth)
+            )
             for ep in (self.s_in, self.m_mem):
                 self.add_endpoint(ep)
 
@@ -107,7 +110,9 @@ class VmacAccel(HwComponent):
     def Cmd(self) -> type[VmacCmd]:
         """The command schema specialized to this accelerator's widths — the instance → type
         bridge from ``HwParam`` values to the schema's ``Param`` specialization."""
-        return VmacCmd.specialize(mem_awidth=int(self.mem_awidth), data_bw=int(self.data_bw))
+        return VmacCmd.specialize(
+            mem_awidth=int(self.mem_awidth), data_bw=int(self.data_bw)
+        )
 
     @property
     def q_mode(self) -> QMode:
@@ -122,7 +127,9 @@ class VmacAccel(HwComponent):
     # --- private datapath helpers (complex-only → static / class) ----------------
     @staticmethod
     def _fixed_cls(fmt: Format) -> type[FixedField]:
-        return FixedField.specialize(fmt.W, fmt.int_bits, fmt.signed, fmt.q_mode, fmt.o_mode)
+        return FixedField.specialize(
+            fmt.W, fmt.int_bits, fmt.signed, fmt.q_mode, fmt.o_mode
+        )
 
     @staticmethod
     def _region_idx(reg, n_rows: int, n_cols: int) -> np.ndarray:
@@ -139,13 +146,20 @@ class VmacAccel(HwComponent):
         return DataArray.specialize(elem, max_shape=tuple(shape))(M)
 
     @classmethod
-    def _scalar(cls, sc, n_cols: int, in_fmt: Format, mem: np.ndarray) -> DataArray:
-        """Build an alpha/beta operand: direct immediate (shape (1,)) or indirect per-column."""
+    def _alpha(
+        cls, sc, n_rows: int, n_cols: int, in_fmt: Format, mem: np.ndarray
+    ) -> DataArray:
+        """Build the ``scalar_mult`` alpha operand as an ``(n_rows, n_cols)`` broadcast: direct
+        immediate (one value, broadcast over every row/col) or per-row indirect (``alpha[i]`` at
+        ``addr + i·stride``, broadcast over columns)."""
         if bool(sc.direct):
-            M = cx.make_complex([int(cx.re_of(sc.value))], [int(cx.im_of(sc.value))], in_fmt)
+            re = np.full((n_rows, n_cols), int(cx.re_of(sc.imm)), dtype=np.int64)
+            im = np.full((n_rows, n_cols), int(cx.im_of(sc.imm)), dtype=np.int64)
+            M = cx.make_complex(re, im, in_fmt)
         else:
-            idx = int(sc.addr) + np.arange(n_cols) * int(sc.stride)
-            M = mem[idx]
+            idx = int(sc.addr) + np.arange(n_rows) * int(sc.stride)
+            col = mem[idx]  # (n_rows,) structured complex
+            M = np.broadcast_to(col[:, None], (n_rows, n_cols)).copy()
         return cls._operand(M, in_fmt)
 
     @staticmethod
@@ -165,8 +179,8 @@ class VmacAccel(HwComponent):
     @staticmethod
     def _writeback(mem: np.ndarray, reg, dst: DataArray) -> None:
         val = np.asarray(dst.val)
-        if val.ndim == 1:                                   # reduced -> single row of columns
-            idx = int(reg.addr) + np.arange(val.shape[0])   # columns unit-stride
+        if val.ndim == 1:  # reduced -> single row of columns
+            idx = int(reg.addr) + np.arange(val.shape[0])  # columns unit-stride
         else:
             idx = VmacAccel._region_idx(reg, val.shape[0], val.shape[1])
         mem[idx] = val
@@ -180,29 +194,29 @@ class VmacAccel(HwComponent):
     def accumulator_format(self, cmd: VmacCmd) -> Format:
         """The wide-accumulator component ``FixedField`` for ``cmd`` — full precision, no loss.
 
-        Complex-only, so every multiply is ``cmult_format`` (``sub_format``-based, +1 integer
-        bit).  Composes the datapath as pure format algebra (no data):
+        Complex-only, so a multiply is ``cmult_format`` (``sub_format``-based, +1 integer bit)
+        and an add is ``add_format`` (+1 integer bit).  Composes the datapath as pure format
+        algebra (no data), per op:
 
-        - **product** ``A·op(B)`` (``conj`` grows the inner ``(W+1, I+1)``);
-        - **scale** by ``alpha``: one more multiply;
-        - **+ β·C**: aligned add (``add_format``) — fractions align, integer bits +1 (carry);
-        - **row reduction**: ``+⌈log₂ n_rows⌉`` integer bits (``sum_format``).
+        - **scalar_mult** ``alpha·A``: one multiply → ``cmult_format(in, in)`` (``F_acc = 2·F_in``);
+        - **inner_prod** ``A·conj(B)``: ``conj`` grows the inner ``(W+1, I+1)``, then a multiply
+          → ``cmult_format(in, conj(in))`` (``F_acc = 2·F_in``);
+        - **sum** ``A+B``: aligned add → ``add_format(in, in)`` (``F_acc = F_in``);
+        - **reduce**: ``+⌈log₂ n_rows⌉`` integer bits (``sum_format``).
 
-        ``F_acc`` (fractional depth) depends only on the multiply depth: ``2·F_in`` when
-        ``b_one`` (``alpha·A``), else ``3·F_in`` (``alpha·A·op(B)``).  This is what makes the
-        requantize shift derivable from the flags (see :meth:`output_format`)."""
-        mul = cx.cmult_format
+        ``F_acc`` (fractional depth) depends only on the op (``2·F_in`` for the products, ``F_in``
+        for the add); this is what makes the requantize shift derivable (see
+        :meth:`output_format` / :meth:`derived_shift`)."""
         in_fmt = self._in_fmt()
-        if bool(cmd.b_one):
-            ab = in_fmt                                         # op(B) = 1, A·op(B) = A
-        else:
-            op_b = cx.conj_format(in_fmt) if bool(cmd.b_conj) else in_fmt  # conj: (W+1, I+1)
-            ab = mul(in_fmt, op_b)
-        acc = mul(in_fmt, ab)                                   # alpha · A·op(B)
-        if not bool(cmd.c_zero):
-            acc = add_format(acc, mul(in_fmt, in_fmt))          # + beta · C (aligned, +1 int bit)
-        if bool(cmd.reduce_rows):
-            acc = sum_format(acc, int(cmd.n_rows))              # + ceil(log2 n_rows) int bits
+        op = OpCode(int(cmd.op))
+        if op is OpCode.scalar_mult:
+            acc = cx.cmult_format(in_fmt, in_fmt)  # alpha · A
+        elif op is OpCode.inner_prod:
+            acc = cx.cmult_format(in_fmt, cx.conj_format(in_fmt))  # A · conj(B)
+        else:  # sum
+            acc = add_format(in_fmt, in_fmt)  # A + B (aligned, +1 int bit)
+        if bool(cmd.reduce):
+            acc = sum_format(acc, int(cmd.n_rows))  # + ceil(log2 n_rows) int bits
         return acc
 
     def output_format(self, cmd: VmacCmd) -> type[FixedField]:
@@ -210,30 +224,38 @@ class VmacAccel(HwComponent):
         codegen target.
 
         The output is fixed at the **input fractional scale** ``F_out = F_in`` (a normalized
-        MAC: the result is comparable to the inputs), with structural width ``out_bw`` and
-        round/saturate modes ``q_mode`` / ``o_mode``.  The single lossy step requantizes the
-        accumulator (``F_acc`` fractional bits) down to ``F_out``, i.e. a right-shift of
-        ``SHIFT = F_acc − F_in`` (= ``F_in`` when ``b_one`` else ``2·F_in``) — *derived* from
-        the flags, not carried in the command.  Fail-loud on a mis-sized accelerator: an
-        accumulator wider than ``acc_bw``, or an ``out_bw`` too small to hold the integer part."""
+        result comparable to the inputs), with structural width ``out_bw`` and round/saturate
+        modes ``q_mode`` / ``o_mode``.  The single lossy step requantizes the accumulator
+        (``F_acc`` fractional bits) down to ``F_out``, i.e. a right-shift of
+        ``SHIFT = F_acc − F_in`` (= ``F_in`` for the product ops, ``0`` for ``sum``) — *derived*
+        from the op, not carried in the command.  Fail-loud on a mis-sized accelerator: an
+        accumulator wider than ``acc_bw``, or an ``out_bw`` too small to hold the integer part.
+        """
         acc = self.accumulator_format(cmd)
         if acc.W > int(self.acc_bw):
             raise ValueError(
-                f"accumulator width {acc.W} exceeds acc_bw={int(self.acc_bw)}; widen acc_bw.")
-        out_frac = int(self.data_bw) - int(self.int_bits)       # F_out = F_in (structural)
+                f"accumulator width {acc.W} exceeds acc_bw={int(self.acc_bw)}; widen acc_bw."
+            )
+        out_frac = int(self.data_bw) - int(self.int_bits)  # F_out = F_in (structural)
         out_bw = int(self.out_bw)
         int_bits = out_bw - out_frac
         if int_bits < 0:
             raise ValueError(
                 f"out_bw={out_bw} is too small: F_out={out_frac} fractional bits exceed it "
-                f"(need out_bw >= {out_frac}).")
-        return FixedField.specialize(out_bw, int_bits, acc.signed, self.q_mode, self.o_mode)
+                f"(need out_bw >= {out_frac})."
+            )
+        return FixedField.specialize(
+            out_bw, int_bits, acc.signed, self.q_mode, self.o_mode
+        )
 
     def derived_shift(self, cmd: VmacCmd) -> int:
-        """The requantize right-shift derived from the flags + structural format —
-        ``SHIFT = F_acc − F_out`` (the residual runtime numeric, a variable barrel shift on
-        the fixed-width accumulator).  The ``.tpp`` computes the same value at runtime."""
-        return self.accumulator_format(cmd).frac_bits - (int(self.data_bw) - int(self.int_bits))
+        """The requantize right-shift derived from the op + structural format —
+        ``SHIFT = F_acc − F_out`` (``F_in`` for the product ops, ``0`` for ``sum``; the residual
+        runtime numeric).  The ``.tpp`` reproduces it via the ``ap_fixed`` requantize scale.
+        """
+        return self.accumulator_format(cmd).frac_bits - (
+            int(self.data_bw) - int(self.int_bits)
+        )
 
     # --- the golden ----------------------------------------------------------
     def execute(self, cmd: VmacCmd, mem: np.ndarray) -> DataArray:
@@ -246,44 +268,40 @@ class VmacAccel(HwComponent):
         in_fmt = self._in_fmt()
         n, m = int(cmd.n_rows), int(cmd.n_cols)
         mem = np.asarray(mem)
-        out_cls = self.output_format(cmd)       # fail-loud config guards (acc_bw / out_bw)
+        out_cls = self.output_format(cmd)  # fail-loud config guards (acc_bw / out_bw)
 
         def region(reg) -> DataArray:
             return self._operand(mem[self._region_idx(reg, n, m)], in_fmt)
 
-        # op(B) and A·op(B)
+        # element-wise op -> R[i, j]
+        op = OpCode(int(cmd.op))
         a = region(cmd.a)
-        if bool(cmd.b_one):
-            ab = a
-        else:
-            b = region(cmd.b)
-            if bool(cmd.b_conj):                            # op(B) = conj(B): negate imag
-                b = conj(b)
-            ab = cmult(a, b)
-
-        # alpha · A·op(B)
-        alpha = self._scalar(cmd.alpha, m, in_fmt, mem)
-        t = cmult(alpha, ab)
-
-        # + beta · C
-        if not bool(cmd.c_zero):
-            beta = self._scalar(cmd.beta, m, in_fmt, mem)
-            t = cadd(t, cmult(beta, region(cmd.c)))
+        if op is OpCode.scalar_mult:
+            t = cmult(self._alpha(cmd.alpha, n, m, in_fmt, mem), a)  # alpha[i] · A
+        elif op is OpCode.inner_prod:
+            t = cmult(a, conj(region(cmd.b)))  # A · conj(B)
+        else:  # sum
+            t = cadd(a, region(cmd.b))  # A + B
 
         # optional row reduction (wide accumulator)
-        if bool(cmd.reduce_rows):
+        if bool(cmd.reduce):
             t = csum(t, axis=0)
 
         # invariant: the actual accumulator format must equal the derived spec (the format
         # algebra in accumulator_format mirrors the operators it composes).
         actual = t.element_type.inner_format()
         spec = self.accumulator_format(cmd)
-        if (actual.W, actual.int_bits, actual.signed) != (spec.W, spec.int_bits, spec.signed):
+        if (actual.W, actual.int_bits, actual.signed) != (
+            spec.W,
+            spec.int_bits,
+            spec.signed,
+        ):
             raise AssertionError(
-                f"accumulator format mismatch: actual {actual} != derived {spec}")
+                f"accumulator format mismatch: actual {actual} != derived {spec}"
+            )
 
         dst = self._requantize(t, out_cls)
-        self._writeback(mem, cmd.d, dst)
+        self._writeback(mem, cmd.y, dst)
         return dst
 
     # --- the synthesizable hook + kernel body --------------------------------
@@ -296,7 +314,8 @@ class VmacAccel(HwComponent):
         hand-written ``vmac_compute_impl.tpp`` (the ``ap_fixed`` accumulator =
         :meth:`accumulator_format`, output = :meth:`output_format`).  As a
         ``@synthesizable`` hook the body is not extracted — codegen emits a call to the
-        ``.tpp`` function — so the SimPy model may freely use the full-precision numpy golden."""
+        ``.tpp`` function — so the SimPy model may freely use the full-precision numpy golden.
+        """
         return self.execute(cmd, mem)
         yield  # unreachable — makes this a generator (ProcessGen)
 

--- a/examples/vmac/vmac_build.py
+++ b/examples/vmac/vmac_build.py
@@ -1,24 +1,25 @@
 """VMAC conformance + throughput BuildDag — Python golden vs Vitis, bit-exact.
 
 The single ``vmac_compute`` datapath (the hand-written ``vmac_compute_impl.tpp`` hook, lowered
-onto the **generated ComplexField serialization** ``read_array_elem`` / ``write_array_elem``)
-is checked against :meth:`examples.vmac.vmac.VmacAccel.execute` — the Python golden — for every
-op-flag / rounding / saturation config, bit-for-bit.  The Python model is the spec: if Vitis
-ever disagrees, fix the kernel, never loosen the compare.
+onto the **generated ComplexField serialization** — the fused ``read_array_lane`` operand-row
+loop + ``read_array_slice`` per-row alpha) is checked against
+:meth:`examples.vmac.vmac.VmacAccel.execute` — the Python golden — for every op / reduce /
+alpha-mode / rounding config, bit-for-bit.  The Python model is the spec: if Vitis ever
+disagrees, fix the kernel, never loosen the compare.
 
-Structure (mirrors :mod:`examples.shared_mem.hist_build` / :mod:`examples.schemas.complex.complex_build`):
+Three element-wise ops (``scalar_mult`` = ``alpha[i]·A``, ``inner_prod`` = ``A·conj(B)``,
+``sum`` = ``A+B``), each with an optional row reduction ``Y[j] = Σ_i R[i, j]``.
+
+Structure (mirrors :mod:`examples.schemas.complex.complex_build`):
 
 - **Structural config** = the synthesis-time widths the kernel is templated on
   (``data_bw`` / ``int_bits`` / ``acc_bw`` / ``out_bw`` / ``q_rnd`` / ``o_sat`` / ``mem_dwidth``).
-  ``q_rnd`` / ``o_sat`` / ``out_bw`` are compile-time (``ap_fixed`` Q/O, output width), so each
-  distinct combination is its **own** synthesized kernel → its own generated sources + csim run.
-- **Runtime case** = one ``VmacCmd`` (op flags + geometry + operands) run within a structural
-  config.  All of a config's cases share one compiled testbench and one Vitis csim invocation
-  (a manifest of ``cmd``/``mem`` vector files), so the whole sweep is a handful of csim runs.
+- **Runtime case** = one ``VmacCmd`` (op + reduce + geometry + operands) run within a config.
+  All of a config's cases share one compiled testbench and one Vitis csim invocation.
 
-The conformance runs at ``mem_dwidth = 2·data_bw`` (PF = 1: one complex column per word) so the
-layout is trivially word-aligned; the PF > 1 lane packing is validated by the throughput cosim
-(``CosimStep`` checks its output against the golden too) as ``mem_dwidth`` is swept up.
+The csim conformance sweeps ``mem_dwidth`` ∈ {16, 32, 64} → **PF = 1, 2, 4** (cases use
+``n_cols`` a multiple of 4, so every row is word-aligned at each PF), plus the four
+rounding/saturation modes at PF=1; the throughput cosim re-checks the golden as it sweeps PF.
 
 CLI::
 
@@ -28,6 +29,7 @@ CLI::
     python vmac_build.py --through extract_cosim_timing   # + throughput sweep (Vitis)
     python vmac_build.py --list-steps
 """
+
 from __future__ import annotations
 
 import json
@@ -44,10 +46,13 @@ from waveflow.build.build import BuildConfig, BuildDag, BuildStep, SourceStep
 from waveflow.build.cli import run_dag_cli
 from waveflow.build.streamutils import StreamUtilsStep
 from waveflow.hw.arrayutils import (
-    ArrayUtilsStep, _array_utils_filename, _array_utils_namespace, write_array,
+    ArrayUtilsStep,
+    _array_utils_filename,
+    _array_utils_namespace,
+    write_array,
 )
 from waveflow.hw.complexfield import ComplexField
-from waveflow.hw.dataschema import DataArray, DataSchemaStep
+from waveflow.hw.dataschema import DataArray, DataSchemaStep, EnumField
 from waveflow.hw.fixpoint import FixedField
 from waveflow.toolchain import toolchain
 from waveflow.utils import complexutils as cx
@@ -55,19 +60,21 @@ from waveflow.utils.fixputils import Format
 
 try:
     from examples.vmac.vmac import VmacAccel
-    from examples.vmac.vmac_cmd import Region, Scalar, VmacCmd
+    from examples.vmac.vmac_cmd import Alpha, OpCode, Region, VmacCmd
 except ModuleNotFoundError:  # direct execution from the example dir
     from vmac import VmacAccel  # type: ignore[no-redef]
-    from vmac_cmd import Region, Scalar, VmacCmd  # type: ignore[no-redef]
+    from vmac_cmd import Alpha, OpCode, Region, VmacCmd  # type: ignore[no-redef]
 
 _SOURCE_DIR = Path(__file__).resolve().parent
-_BUILD_DIR = Path(__file__).resolve().parents[2] / "waveflow" / "build"  # complex_utils.hpp / wf_cint.h
+_BUILD_DIR = (
+    Path(__file__).resolve().parents[2] / "waveflow" / "build"
+)  # complex_utils.hpp / wf_cint.h
 INCLUDE_DIR = "include"
-WORD_BW_SUPPORTED = [32, 64]                 # cmd schema word widths
-MEM_WORD_BWS = [16, 32, 64, 128]             # m_axi widths the array-utils support (PF sweep)
-CMD_NWORDS = 16                              # VmacCmd.serialize(word_bw=32) word count
-MAX_COLS_CAP = 16                            # acc[] capacity in the kernel (>= any case n_cols)
-MEM_AWIDTH = 32                              # cmd address width (the kernel's MEM_AWIDTH param)
+WORD_BW_SUPPORTED = [32, 64]  # cmd schema word widths
+MEM_WORD_BWS = [16, 32, 64, 128]  # m_axi widths the array-utils support (PF sweep)
+CMD_NWORDS = 12  # >= VmacCmd.serialize(word_bw=32) word count
+MAX_COLS_CAP = 16  # acc[] capacity in the kernel (>= any case n_cols)
+MEM_AWIDTH = 32  # cmd address width (the kernel's MEM_AWIDTH param)
 # the hand-written hook + the complex-arithmetic header it pulls in (no integer-code bridging)
 HOOK_FILES = ("vmac_compute_impl.tpp",)
 BUILD_HDRS = ("complex_utils.hpp", "wf_cint.h")
@@ -79,7 +86,7 @@ class StructCfg:
     out_bw: int
     q_rnd: int
     o_sat: int
-    mem_dwidth: int = 16                      # PF = mem_dwidth / (2*data_bw); 16 -> PF=1
+    mem_dwidth: int = 16  # PF = mem_dwidth / (2*data_bw); 16 -> PF=1
     data_bw: int = 8
     int_bits: int = 4
     acc_bw: int = 48
@@ -94,33 +101,45 @@ class StructCfg:
 
     @property
     def out_int(self) -> int:
-        return self.out_bw - self.f_in       # F_out = F_in (structural normalized MAC)
+        return self.out_bw - self.f_in  # F_out = F_in (structural normalized result)
+
+    @property
+    def pf(self) -> int:
+        return self.mem_dwidth // (2 * self.data_bw)
 
     def accel(self) -> VmacAccel:
         return VmacAccel(
-            mem_dwidth=self.mem_dwidth, mem_awidth=32, data_bw=self.data_bw,
-            int_bits=self.int_bits, acc_bw=self.acc_bw, out_bw=self.out_bw,
-            q_rnd=self.q_rnd, o_sat=self.o_sat,
+            mem_dwidth=self.mem_dwidth,
+            mem_awidth=32,
+            data_bw=self.data_bw,
+            int_bits=self.int_bits,
+            acc_bw=self.acc_bw,
+            out_bw=self.out_bw,
+            q_rnd=self.q_rnd,
+            o_sat=self.o_sat,
         )
 
     def in_elem(self) -> type:
-        return ComplexField.specialize(FixedField.specialize(self.data_bw, self.int_bits, True))
+        return ComplexField.specialize(
+            FixedField.specialize(self.data_bw, self.int_bits, True)
+        )
 
     def out_elem(self) -> type:
-        return ComplexField.specialize(FixedField.specialize(self.out_bw, self.out_int, True))
+        return ComplexField.specialize(
+            FixedField.specialize(self.out_bw, self.out_int, True)
+        )
 
 
-# The conformance sweeps the 4 rounding/saturation modes (trn/wrap x rnd/sat) at
-# out_bw == data_bw, so the output element equals the input element and the in/out lane
-# packing is uniform over the flat ap_uint<MEM_BW> image.  (A wider output element, e.g.
-# out_bw=12 -> 24-bit element, would not co-pack with the 16-bit input words in one flat
-# image; that wide-output numeric edge is covered by tests/examples/test_vmac_golden's
-# test_cg_rnorm at the Python-golden level.)
+# PF = 1/2/4 at the default rounding (validates the lane packing for every op bit-exactly),
+# plus the rounding/saturation modes at PF=1 (out_bw == data_bw, so in/out lane packing is
+# uniform over the flat ap_uint<MEM_BW> image).
 STRUCT_CFGS = [
-    StructCfg(out_bw=8, q_rnd=0, o_sat=0),
-    StructCfg(out_bw=8, q_rnd=1, o_sat=0),
-    StructCfg(out_bw=8, q_rnd=0, o_sat=1),
-    StructCfg(out_bw=8, q_rnd=1, o_sat=1),
+    StructCfg(out_bw=8, q_rnd=0, o_sat=0, mem_dwidth=16),  # PF = 1
+    StructCfg(out_bw=8, q_rnd=0, o_sat=0, mem_dwidth=32),  # PF = 2
+    StructCfg(out_bw=8, q_rnd=0, o_sat=0, mem_dwidth=64),  # PF = 4
+    StructCfg(out_bw=8, q_rnd=1, o_sat=0),  # rounding
+    StructCfg(out_bw=8, q_rnd=0, o_sat=1),  # saturation
+    StructCfg(out_bw=8, q_rnd=1, o_sat=1),  # round + saturate
 ]
 
 
@@ -134,50 +153,54 @@ def _pair(re, im=None):
 def _flat(pair):
     re = np.asarray(pair[0]).ravel()
     im = np.asarray(pair[1]).ravel()
-    return cx.make_complex(re, im, Format(8, 4, True))   # dtype only; format irrelevant
+    return cx.make_complex(re, im, Format(8, 4, True))  # dtype only; format irrelevant
 
 
-def _scalar_field(s, addr):
-    if np.ndim(s[0]) == 0:
-        return {"direct": 1, "value": (int(s[0]), int(s[1])), "addr": 0, "stride": 0}
-    return {"direct": 0, "value": (0, 0), "addr": int(addr), "stride": 1}
+def _alpha_field(op: OpCode, alpha, addr) -> dict:
+    """The ``alpha`` command field: per-row indirect (scalar_mult with an ``(n_rows,)`` alpha)
+    or a direct complex immediate (scalar_mult scalar, or unused for inner_prod / sum).
+    """
+    if op is OpCode.scalar_mult and np.ndim(alpha[0]) > 0:
+        return {"direct": 0, "imm": (0, 0), "addr": int(addr), "stride": 1}
+    re = int(alpha[0]) if np.ndim(alpha[0]) == 0 else 0
+    im = int(alpha[1]) if np.ndim(alpha[0]) == 0 else 0
+    return {"direct": 1, "imm": (re, im), "addr": 0, "stride": 0}
 
 
-def build(accel: VmacAccel, flags: dict, a, b, c, alpha, beta):
-    """Lay a/b/c (+ per-column alpha/beta) into mem (row-major) and build the matching Cmd.
-
-    Returns ``(cmd, mem)`` with ``mem`` the structured complex image (pre-execute)."""
+def build(accel: VmacAccel, op: OpCode, reduce: int, a, b, alpha):
+    """Lay A (+ B for inner_prod/sum, + per-row alpha for indirect scalar_mult) into ``mem``
+    (row-major) and build the matching ``VmacCmd``.  Returns ``(cmd, mem)`` (pre-execute).
+    """
     n, m = a[0].shape
     nm = n * m
+    need_b = op in (OpCode.inner_prod, OpCode.sum)
+    alpha_pr = op is OpCode.scalar_mult and np.ndim(alpha[0]) > 0  # per-row indirect
+
     blocks, addr, cur = [], {}, 0
-    for name, op in (("a", a), ("b", b), ("c", c)):
-        addr[name] = cur
-        blocks.append(_flat(op))
+    addr["a"] = cur
+    blocks.append(_flat(a))
+    cur += nm
+    if need_b:
+        addr["b"] = cur
+        blocks.append(_flat(b))
         cur += nm
-    alpha_pc, beta_pc = np.ndim(alpha[0]) > 0, np.ndim(beta[0]) > 0
-    if alpha_pc:
+    if alpha_pr:
         addr["alpha"] = cur
         blocks.append(_flat(alpha))
-        cur += m
-    if beta_pc:
-        addr["beta"] = cur
-        blocks.append(_flat(beta))
-        cur += m
-    addr["d"] = cur
-    cur += nm                                            # dst region (>= reduced m)
+        cur += n  # one alpha per row
+    addr["y"] = cur
+    cur += nm  # dst region (>= reduced m)
+
     mem = cx.make_complex(np.zeros(cur), np.zeros(cur), Format(8, 4, True))
-    order = ["a", "b", "c"] + (["alpha"] if alpha_pc else []) + (["beta"] if beta_pc else [])
+    order = ["a"] + (["b"] if need_b else []) + (["alpha"] if alpha_pr else [])
     for name, blk in zip(order, blocks):
-        mem[addr[name]:addr[name] + len(blk)] = blk
+        mem[addr[name] : addr[name] + len(blk)] = blk
 
     cmd = accel.Cmd()
-    cmd.n_rows, cmd.n_cols = n, m
-    for name in ("a", "b", "c", "d"):
-        setattr(cmd, name, {"addr": addr[name], "row_stride": m})
-    cmd.alpha = _scalar_field(alpha, addr.get("alpha"))
-    cmd.beta = _scalar_field(beta, addr.get("beta"))
-    for f in ("b_one", "c_zero", "b_conj", "reduce_rows"):
-        setattr(cmd, f, int(flags.get(f, 0)))
+    cmd.op, cmd.reduce, cmd.n_rows, cmd.n_cols = op, int(reduce), n, m
+    for name in ("a", "b", "y"):
+        setattr(cmd, name, {"addr": addr.get(name, 0), "row_stride": m})
+    cmd.alpha = _alpha_field(op, alpha, addr.get("alpha"))
     return cmd, mem
 
 
@@ -191,7 +214,7 @@ def _q_real(value: Fraction, out_frac: int, W: int, q_rnd: bool, o_sat: bool) ->
     return y - (1 << W) if (y >> (W - 1)) & 1 else y
 
 
-def oracle(cfg: StructCfg, flags: dict, a, b, c, alpha, beta):
+def oracle(cfg: StructCfg, op: OpCode, reduce: int, a, b, alpha):
     """Exact (re, im) Fraction arithmetic — independent of the production golden."""
     F = cfg.f_in
     scale = Fraction(2) ** F
@@ -200,13 +223,13 @@ def oracle(cfg: StructCfg, flags: dict, a, b, c, alpha, beta):
     def fr(x):
         return Fraction(int(x), 1) / scale
 
-    def at(op, i, j):
-        return (fr(op[0][i, j]), fr(op[1][i, j]))
+    def at(opnd, i, j):
+        return (fr(opnd[0][i, j]), fr(opnd[1][i, j]))
 
-    def scal(s, j):
-        if np.ndim(s[0]) == 0:
-            return (fr(s[0]), fr(s[1]))
-        return (fr(s[0][j]), fr(s[1][j]))
+    def alpha_at(i):
+        if np.ndim(alpha[0]) == 0:
+            return (fr(alpha[0]), fr(alpha[1]))
+        return (fr(alpha[0][i]), fr(alpha[1][i]))
 
     def cmul(x, y):
         return (x[0] * y[0] - x[1] * y[1], x[0] * y[1] + x[1] * y[0])
@@ -216,87 +239,67 @@ def oracle(cfg: StructCfg, flags: dict, a, b, c, alpha, beta):
         terms = []
         for i in range(n):
             av = at(a, i, j)
-            if flags.get("b_one"):
-                ab = av
-            else:
+            if op is OpCode.scalar_mult:
+                t = cmul(alpha_at(i), av)
+            elif op is OpCode.inner_prod:
                 bv = at(b, i, j)
-                if flags.get("b_conj"):
-                    bv = (bv[0], -bv[1])
-                ab = cmul(av, bv)
-            t = cmul(scal(alpha, j), ab)
-            if not flags.get("c_zero"):
-                bc = cmul(scal(beta, j), at(c, i, j))
-                t = (t[0] + bc[0], t[1] + bc[1])
+                t = cmul(av, (bv[0], -bv[1]))  # A · conj(B)
+            else:  # sum
+                bv = at(b, i, j)
+                t = (av[0] + bv[0], av[1] + bv[1])
             terms.append(t)
-        if flags.get("reduce_rows"):
+        if reduce:
             acc = terms[0]
             for t in terms[1:]:
                 acc = (acc[0] + t[0], acc[1] + t[1])
             rows = [acc]
         else:
             rows = terms
-        cols_re.append([_q_real(r[0], F, cfg.out_bw, cfg.q_rnd, cfg.o_sat) for r in rows])
-        cols_im.append([_q_real(r[1], F, cfg.out_bw, cfg.q_rnd, cfg.o_sat) for r in rows])
+        cols_re.append(
+            [_q_real(r[0], F, cfg.out_bw, cfg.q_rnd, cfg.o_sat) for r in rows]
+        )
+        cols_im.append(
+            [_q_real(r[1], F, cfg.out_bw, cfg.q_rnd, cfg.o_sat) for r in rows]
+        )
     re = np.array(cols_re, dtype=np.int64).T
     im = np.array(cols_im, dtype=np.int64).T
-    if flags.get("reduce_rows"):
+    if reduce:
         re, im = re[0], im[0]
     return re, im
 
 
 # --- runtime cases ------------------------------------------------------------
 def _runtime_cases():
-    """The op-flag / operand cases for one structural config (the CG + general matrix ops).
+    """Every op × {reduce, no-reduce}, with direct + indirect alpha for scalar_mult.
 
-    Operands are sized to exercise rounding and saturation so the structural q_rnd / o_sat
-    modes genuinely matter.  The wide-output config (out_bw=12) adds the CG |R|^2 case (whose
-    non-negative magnitude needs the extra integer headroom to clamp rather than wrap)."""
+    All cases use n_rows = n_cols = 4 (a multiple of 4) so each row is word-aligned at PF =
+    1/2/4; operands span a range that exercises rounding and saturation."""
     rng = np.random.default_rng(2)
-    n, m = 4, 3
+    n, m = 4, 4
 
     def cop():
         return _pair(rng.integers(-60, 61, (n, m)), rng.integers(-60, 61, (n, m)))
 
-    a, b, c = cop(), cop(), cop()
-    alpha_s, beta_s = _pair(20, -8), _pair(-12, 5)
-    alpha_pc = _pair(rng.integers(-30, 31, m), rng.integers(-30, 31, m))
-    beta_pc = _pair(rng.integers(-30, 31, m), rng.integers(-30, 31, m))
+    a, b = cop(), cop()
+    alpha_s = _pair(20, -8)  # scalar (direct)
+    alpha_pr = _pair(rng.integers(-30, 31, n), rng.integers(-30, 31, n))  # per-row (n,)
 
-    flagsets = [
-        ("scaled_copy", dict(b_one=1, c_zero=1)),
-        ("hadamard", dict(c_zero=1)),
-        ("conj_hadamard", dict(b_conj=1, c_zero=1)),
-        ("full_mac", dict()),
-        ("axpbc", dict(b_one=1)),
-        ("col_sum", dict(b_one=1, c_zero=1, reduce_rows=1)),
-        ("conj_inner", dict(b_conj=1, c_zero=1, reduce_rows=1)),
-        ("reduced_mac", dict(reduce_rows=1)),
-    ]
     cases = []
-    for label, flags in flagsets:
-        for scl, (al, be) in [("s", (alpha_s, beta_s)), ("pc", (alpha_pc, beta_pc))]:
-            cases.append((f"{label}_{scl}", flags, a, b, c, al, be))
+    for reduce in (0, 1):
+        tag = "red" if reduce else "nr"
+        cases.append(
+            (f"scalar_mult_direct_{tag}", OpCode.scalar_mult, reduce, a, b, alpha_s)
+        )
+        cases.append(
+            (f"scalar_mult_indirect_{tag}", OpCode.scalar_mult, reduce, a, b, alpha_pr)
+        )
+        cases.append((f"inner_prod_{tag}", OpCode.inner_prod, reduce, a, b, alpha_s))
+        cases.append((f"sum_{tag}", OpCode.sum, reduce, a, b, alpha_s))
 
-    # rounding/saturation-triggering singletons
-    sat_op = _pair([[112]]), _pair([[112]])              # 7.0 * 7.0 = 49 -> over +-8 range
-    cases.append(("saturate", dict(c_zero=1), sat_op[0], sat_op[1],
-                  _pair([[0]]), _pair(16), _pair(0)))
-    rr = np.random.default_rng(9)
-    ra, rb = _pair(rr.integers(-120, 121, (3, 2))), _pair(rr.integers(-120, 121, (3, 2)))
-    cases.append(("round", dict(c_zero=1), ra, rb, _pair(np.zeros((3, 2))), _pair(16), _pair(0)))
-
-    # CG ops
-    cg = np.random.default_rng(11)
-    P = _pair(cg.integers(-100, 101, (5, 3)), cg.integers(-100, 101, (5, 3)))
-    X = _pair(cg.integers(-100, 101, (5, 3)), cg.integers(-100, 101, (5, 3)))
-    neg_alpha = _pair(-cg.integers(-30, 31, 3), -cg.integers(-30, 31, 3))
-    cases.append(("cg_axpy", dict(b_one=1), P, _pair(np.zeros((5, 3)), np.zeros((5, 3))),
-                  X, neg_alpha, _pair(16, 0)))
-    cg2 = np.random.default_rng(13)
-    S = _pair(cg2.integers(-50, 51, (6, 2)), cg2.integers(-50, 51, (6, 2)))
-    Pp = _pair(cg2.integers(-50, 51, (6, 2)), cg2.integers(-50, 51, (6, 2)))
-    cases.append(("cg_conj_inner", dict(b_conj=1, c_zero=1, reduce_rows=1),
-                  S, Pp, _pair(np.zeros((6, 2)), np.zeros((6, 2))), _pair(16, 0), _pair(0, 0)))
+    # rounding/saturation-triggering singletons (products well over the +-8 output range).
+    big = _pair(rng.integers(40, 61, (4, 4)), rng.integers(40, 61, (4, 4)))
+    cases.append(("inner_sat", OpCode.inner_prod, 0, big, big, alpha_s))
+    cases.append(("scalar_sat", OpCode.scalar_mult, 0, big, b, _pair(112, 0)))
     return cases
 
 
@@ -307,31 +310,38 @@ def _mem_words(mem, elem_cls, word_bw: int) -> list[int]:
 
 def golden_case(cfg: StructCfg, case) -> dict:
     """Run the Python golden + oracle for one case; return the cmd / mem / expected vectors."""
-    label, flags, a, b, c, alpha, beta = case
+    label, op, reduce, a, b, alpha = case
     accel = cfg.accel()
-    cmd, mem = build(accel, flags, a, b, c, alpha, beta)
+    cmd, mem = build(accel, op, reduce, a, b, alpha)
     in_elem = cfg.in_elem()
     cmd_words = [int(w) for w in np.asarray(cmd.serialize(word_bw=32)).ravel()]
     mem_in_words = _mem_words(mem, in_elem, cfg.mem_dwidth)
 
     post = mem.copy()
-    dst = accel.execute(cmd, post)                       # mutates `post` (writes dst region)
-    # independent-oracle cross-check on the dst bits (golden == spec)
-    exp_re, exp_im = oracle(cfg, flags, a, b, c, alpha, beta)
+    dst = accel.execute(cmd, post)  # mutates `post` (writes dst region)
+    exp_re, exp_im = oracle(cfg, op, reduce, a, b, alpha)
     got_re, got_im = np.asarray(dst.val["re"]), np.asarray(dst.val["im"])
     oracle_ok = np.array_equal(got_re, exp_re) and np.array_equal(got_im, exp_im)
 
     mem_exp_words = _mem_words(post, in_elem, cfg.mem_dwidth)
     return {
-        "label": label, "n_cols": int(cmd.n_cols), "oracle_ok": bool(oracle_ok),
-        "cmd_words": cmd_words, "mem_in_words": mem_in_words, "mem_exp_words": mem_exp_words,
+        "label": label,
+        "n_cols": int(cmd.n_cols),
+        "oracle_ok": bool(oracle_ok),
+        "cmd_words": cmd_words,
+        "mem_in_words": mem_in_words,
+        "mem_exp_words": mem_exp_words,
     }
 
 
 # --- C++ testbench renderer (one batched TB per structural config) -------------
 def render_tb(cfg: StructCfg) -> str:
-    in_ns, out_ns = _array_utils_namespace(cfg.in_elem()), _array_utils_namespace(cfg.out_elem())
-    in_hdr, out_hdr = _array_utils_filename(cfg.in_elem()), _array_utils_filename(cfg.out_elem())
+    in_ns, out_ns = _array_utils_namespace(cfg.in_elem()), _array_utils_namespace(
+        cfg.out_elem()
+    )
+    in_hdr, out_hdr = _array_utils_filename(cfg.in_elem()), _array_utils_filename(
+        cfg.out_elem()
+    )
     incs = [f'#include "{in_hdr}"']
     if out_hdr != in_hdr:
         incs.append(f'#include "{out_hdr}"')
@@ -411,19 +421,43 @@ exit 0
 """
 
 
+def _cmd_schema_steps(cfg: StructCfg) -> list:
+    """The DataSchemaSteps the VmacCmd header needs: the OpCode enum, Region, Alpha, VmacCmd."""
+    return [
+        DataSchemaStep(
+            EnumField.specialize(OpCode),
+            word_bw_supported=WORD_BW_SUPPORTED,
+            include_dir=INCLUDE_DIR,
+        ),
+        DataSchemaStep(
+            Region.specialize(mem_awidth=32),
+            word_bw_supported=WORD_BW_SUPPORTED,
+            include_dir=INCLUDE_DIR,
+        ),
+        DataSchemaStep(
+            Alpha.specialize(mem_awidth=32, data_bw=cfg.data_bw),
+            word_bw_supported=WORD_BW_SUPPORTED,
+            include_dir=INCLUDE_DIR,
+        ),
+        DataSchemaStep(
+            VmacCmd.specialize(mem_awidth=32, data_bw=cfg.data_bw),
+            word_bw_supported=WORD_BW_SUPPORTED,
+            include_dir=INCLUDE_DIR,
+        ),
+    ]
+
+
 def gen_config_sources(cfg: StructCfg, cfg_dir: Path) -> list[dict]:
     """Generate one structural config's dir: shared headers, the batched TB, run.tcl, and the
-    per-case cmd/mem/expected vectors + manifest.  Returns the per-case golden metadata."""
-    cfg_dir = Path(cfg_dir).resolve()         # absolute, so the manifest paths resolve from
+    per-case cmd/mem/expected vectors + manifest.  Returns the per-case golden metadata.
+    """
+    cfg_dir = Path(cfg_dir).resolve()  # absolute, so the manifest paths resolve from
     cfg_dir.mkdir(parents=True, exist_ok=True)  # the deep Vitis csim build dir.
     bc = BuildConfig(root_dir=cfg_dir)
     dag = BuildDag()
     dag.add(StreamUtilsStep(output_dir=INCLUDE_DIR))
-    # the command + its nested Region / Scalar schemas (the cmd header #includes them)
-    for sch in (Region.specialize(mem_awidth=32),
-                Scalar.specialize(mem_awidth=32, data_bw=cfg.data_bw),
-                VmacCmd.specialize(mem_awidth=32, data_bw=cfg.data_bw)):
-        dag.add(DataSchemaStep(sch, word_bw_supported=WORD_BW_SUPPORTED, include_dir=INCLUDE_DIR))
+    for step in _cmd_schema_steps(cfg):
+        dag.add(step)
     dag.add(ArrayUtilsStep(cfg.in_elem(), MEM_WORD_BWS))
     if cfg.out_elem() is not cfg.in_elem():
         dag.add(ArrayUtilsStep(cfg.out_elem(), MEM_WORD_BWS))
@@ -446,13 +480,25 @@ def gen_config_sources(cfg: StructCfg, cfg_dir: Path) -> list[dict]:
         cf = cases_dir / f"{label}_cmd.txt"
         mf = cases_dir / f"{label}_mem.txt"
         of = cases_dir / f"{label}_out.txt"
-        cf.write_text("\n".join(str(w) for w in g["cmd_words"]) + "\n", encoding="utf-8")
-        mf.write_text("\n".join(str(w) for w in g["mem_in_words"]) + "\n", encoding="utf-8")
-        manifest.append(f"{len(g['cmd_words'])} {len(g['mem_in_words'])} "
-                        f"{cf.as_posix()} {mf.as_posix()} {of.as_posix()}")
-        meta.append({"label": label, "oracle_ok": g["oracle_ok"],
-                     "expected": g["mem_exp_words"], "out_file": of.as_posix(),
-                     "nmem": len(g["mem_in_words"])})
+        cf.write_text(
+            "\n".join(str(w) for w in g["cmd_words"]) + "\n", encoding="utf-8"
+        )
+        mf.write_text(
+            "\n".join(str(w) for w in g["mem_in_words"]) + "\n", encoding="utf-8"
+        )
+        manifest.append(
+            f"{len(g['cmd_words'])} {len(g['mem_in_words'])} "
+            f"{cf.as_posix()} {mf.as_posix()} {of.as_posix()}"
+        )
+        meta.append(
+            {
+                "label": label,
+                "oracle_ok": g["oracle_ok"],
+                "expected": g["mem_exp_words"],
+                "out_file": of.as_posix(),
+                "nmem": len(g["mem_in_words"]),
+            }
+        )
     (cfg_dir / "manifest.txt").write_text("\n".join(manifest) + "\n", encoding="utf-8")
     (cfg_dir / "expected.json").write_text(json.dumps(meta), encoding="utf-8")
     return meta
@@ -474,7 +520,9 @@ class GenStep(BuildStep):
 
 @dataclass(kw_only=True)
 class PySimStep(BuildStep):
-    description = "Golden-vs-independent-oracle parity over every case (the non-Vitis anchor)."
+    description = (
+        "Golden-vs-independent-oracle parity over every case (the non-Vitis anchor)."
+    )
     consumes = ["gen_dir"]
     produces = {"py_summary": Path("results/py_summary.json")}
 
@@ -482,38 +530,57 @@ class PySimStep(BuildStep):
         gen = config.root_dir / "gen"
         n_cases, n_ok = 0, 0
         for cfg in STRUCT_CFGS:
-            meta = json.loads((gen / cfg.name / "expected.json").read_text(encoding="utf-8"))
+            meta = json.loads(
+                (gen / cfg.name / "expected.json").read_text(encoding="utf-8")
+            )
             for m in meta:
                 n_cases += 1
                 n_ok += bool(m["oracle_ok"])
         out = config.root_dir / "results" / "py_summary.json"
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps({"n_cases": n_cases, "n_oracle_ok": n_ok}, indent=2),
-                       encoding="utf-8")
+        out.write_text(
+            json.dumps({"n_cases": n_cases, "n_oracle_ok": n_ok}, indent=2),
+            encoding="utf-8",
+        )
         if n_ok != n_cases:
-            raise RuntimeError(f"golden disagreed with the oracle on {n_cases - n_ok}/{n_cases} cases.")
+            raise RuntimeError(
+                f"golden disagreed with the oracle on {n_cases - n_ok}/{n_cases} cases."
+            )
         return {"py_summary": out}
 
 
 def _csim_config(cfg_dir: Path, *, live_output: bool) -> list[dict]:
     """Run csim for one structural config and compare each case's mem_out bits to the golden."""
     meta = json.loads((cfg_dir / "expected.json").read_text(encoding="utf-8"))
-    toolchain.run_vitis_hls(cfg_dir / "run.tcl", work_dir=cfg_dir, capture_output=not live_output)
+    toolchain.run_vitis_hls(
+        cfg_dir / "run.tcl", work_dir=cfg_dir, capture_output=not live_output
+    )
     results = []
     for m in meta:
         got = [int(t) for t in Path(m["out_file"]).read_text(encoding="utf-8").split()]
         exp = m["expected"]
-        mism = [{"i": i, "expected": e, "got": g}
-                for i, (e, g) in enumerate(zip(exp, got)) if e != g]
-        results.append({"label": m["label"], "n": len(exp),
-                        "count_ok": len(got) == len(exp), "mismatches": mism[:5],
-                        "exact": len(got) == len(exp) and not mism})
+        mism = [
+            {"i": i, "expected": e, "got": g}
+            for i, (e, g) in enumerate(zip(exp, got))
+            if e != g
+        ]
+        results.append(
+            {
+                "label": m["label"],
+                "n": len(exp),
+                "count_ok": len(got) == len(exp),
+                "mismatches": mism[:5],
+                "exact": len(got) == len(exp) and not mism,
+            }
+        )
     return results
 
 
 @dataclass(kw_only=True)
 class CsimStep(BuildStep):
-    description = "Vitis C-sim per structural config; assert mem_out bits == the golden, exactly."
+    description = (
+        "Vitis C-sim per structural config; assert mem_out bits == the golden, exactly."
+    )
     consumes = ["gen_dir"]
     produces = {"csim_report": Path("results/csim_report.json")}
     params: dict = field(default_factory=lambda: {"live_output": False})
@@ -529,30 +596,40 @@ class CsimStep(BuildStep):
             n_exact += sum(r["exact"] for r in res)
         out = config.root_dir / "results" / "csim_report.json"
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps(
-            {"n_cases": n_cases, "n_exact": n_exact, "all_exact": n_exact == n_cases,
-             "by_config": report}, indent=2), encoding="utf-8")
+        out.write_text(
+            json.dumps(
+                {
+                    "n_cases": n_cases,
+                    "n_exact": n_exact,
+                    "all_exact": n_exact == n_cases,
+                    "by_config": report,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
         failed = [(cn, r) for cn, rs in report.items() for r in rs if not r["exact"]]
         if failed:
             cn, r = failed[0]
             raise RuntimeError(
                 f"STOP — Vitis disagreed with the Python golden on {len(failed)}/{n_cases} cases. "
                 f"The golden is the spec; fix the kernel, do not loosen the compare. "
-                f"First failure: config={cn} case={r['label']} mismatches={r['mismatches']}")
+                f"First failure: config={cn} case={r['label']} mismatches={r['mismatches']}"
+            )
         return {"csim_report": out}
 
 
 # --- throughput sweep (mem_dwidth scaling) ------------------------------------
 # One synthesized accelerator per mem_dwidth; PF = mem_dwidth / (2*data_bw) complex columns
-# packed per memory word.  With the inner column loop unrolled to PF lanes, the per-row column
-# iterations fall ~1/PF, so cosim transaction cycles should roughly halve as mem_dwidth doubles
-# — the bus-width parallelism the wide packing is meant to deliver.  The cosim also re-checks
-# the result against the golden, so it validates the PF > 1 lane packing (which the PF = 1
-# csim conformance does not exercise).
-TPUT_MEM_BWS = [16, 32, 64]                  # PF = 1, 2, 4  (element = 2*data_bw = 16 bits)
+# packed per memory word.  With the fused inner column loop unrolled to PF lanes, the per-row
+# column iterations fall ~1/PF, so cosim transaction cycles should roughly halve as mem_dwidth
+# doubles — the bus-width parallelism the wide packing delivers.  The cosim re-checks the result
+# against the golden, validating the PF > 1 lane packing (which the PF = 1 csim does not exercise).
+TPUT_MEM_BWS = [16, 32, 64]  # PF = 1, 2, 4  (element = 2*data_bw = 16 bits)
 TPUT_N_ROWS = 8
-TPUT_N_COLS = 64                             # multiple of every PF; row_stride = N_COLS
-TPUT_MAX_COLS = 64                           # kernel acc[] capacity for the sweep
+TPUT_N_COLS = 64  # multiple of every PF; row_stride = N_COLS
+TPUT_MAX_COLS = 64  # kernel acc[] capacity for the sweep
+TPUT_OP = OpCode.inner_prod  # the element-wise op the throughput sweep exercises
 
 
 def _tput_cfg(mem_bw: int) -> StructCfg:
@@ -560,8 +637,8 @@ def _tput_cfg(mem_bw: int) -> StructCfg:
 
 
 def _tput_vectors(cfg: StructCfg):
-    """The fixed throughput problem: a Hadamard product D = A·B (c_zero, alpha = 1.0) over an
-    N_ROWS x N_COLS image — a per-element op whose inner column loop is the unroll target.
+    """The fixed throughput problem: an element-wise inner_prod ``R = A·conj(B)`` (no reduce)
+    over an N_ROWS x N_COLS image — the inner column loop is the unroll target.
 
     Returns ``(scalar_args, mem_in_words, mem_exp_words)`` — the cmd is reduced to the scalar
     fields the top rebuilds it from (so it crosses into RTL as plain s_axilite registers, not a
@@ -570,50 +647,71 @@ def _tput_vectors(cfg: StructCfg):
     n, m = TPUT_N_ROWS, TPUT_N_COLS
     a = _pair(rng.integers(-30, 31, (n, m)), rng.integers(-30, 31, (n, m)))
     b = _pair(rng.integers(-30, 31, (n, m)), rng.integers(-30, 31, (n, m)))
-    c = _pair(np.zeros((n, m)), np.zeros((n, m)))
-    cmd, mem = build(cfg.accel(), dict(c_zero=1), a, b, c, _pair(16, 0), _pair(0, 0))
+    cmd, mem = build(cfg.accel(), TPUT_OP, 0, a, b, _pair(16, 0))
     post = mem.copy()
     cfg.accel().execute(cmd, post)
     in_elem = cfg.in_elem()
-    flags = (int(cmd.b_one) | (int(cmd.c_zero) << 1)
-             | (int(cmd.b_conj) << 2) | (int(cmd.reduce_rows) << 3))
-    scalars = [int(cmd.n_rows), int(cmd.n_cols),
-               int(cmd.a.addr), int(cmd.a.row_stride), int(cmd.b.addr), int(cmd.b.row_stride),
-               int(cmd.c.addr), int(cmd.c.row_stride), int(cmd.d.addr), int(cmd.d.row_stride),
-               int(cx.re_of(cmd.alpha.value)), int(cx.im_of(cmd.alpha.value)),
-               int(cx.re_of(cmd.beta.value)), int(cx.im_of(cmd.beta.value)), flags]
-    return (scalars,
-            _mem_words(mem, in_elem, cfg.mem_dwidth),
-            _mem_words(post, in_elem, cfg.mem_dwidth))
+    scalars = [
+        int(cmd.op),
+        int(cmd.reduce),
+        int(cmd.n_rows),
+        int(cmd.n_cols),
+        int(cmd.a.addr),
+        int(cmd.a.row_stride),
+        int(cmd.b.addr),
+        int(cmd.b.row_stride),
+        int(cmd.y.addr),
+        int(cmd.y.row_stride),
+        int(cmd.alpha.direct),
+        int(cx.re_of(cmd.alpha.imm)),
+        int(cx.im_of(cmd.alpha.imm)),
+        int(cmd.alpha.addr),
+        int(cmd.alpha.stride),
+    ]
+    return (
+        scalars,
+        _mem_words(mem, in_elem, cfg.mem_dwidth),
+        _mem_words(post, in_elem, cfg.mem_dwidth),
+    )
 
 
-_TOP_ARGS = ("int n_rows, int n_cols, int a_addr, int a_rs, int b_addr, int b_rs, "
-             "int c_addr, int c_rs, int d_addr, int d_rs, int al_re, int al_im, "
-             "int be_re, int be_im, unsigned flags")
+_TOP_ARGS = (
+    "int op, int reduce, int n_rows, int n_cols, int a_addr, int a_rs, int b_addr, "
+    "int b_rs, int y_addr, int y_rs, int al_direct, int al_re, int al_im, "
+    "int al_addr, int al_stride"
+)
+_SCALAR_PORTS = (
+    "op reduce n_rows n_cols a_addr a_rs b_addr b_rs y_addr y_rs "
+    "al_direct al_re al_im al_addr al_stride"
+).split()
 
 
 def _vmac_hpp(cfg: StructCfg) -> str:
     in_ns = _array_utils_namespace(cfg.in_elem())
     in_hdr = _array_utils_filename(cfg.in_elem())
-    return "\n".join([
-        "#ifndef VMAC_HPP", "#define VMAC_HPP",
-        "#include <ap_int.h>", "#include <ap_fixed.h>", "#include <complex>",
-        f'#include "{INCLUDE_DIR}/vmac_cmd_data_bw{cfg.data_bw}_mem_awidth32.h"',
-        f'#include "{in_hdr}"',
-        "namespace vmac_impl {",
-        f"typedef VmacCmd_data_bw{cfg.data_bw}_mem_awidth32 VmacCmd;",
-        f"namespace vmac_in_au  = ::{in_ns};",
-        f"namespace vmac_out_au = ::{in_ns};",
-        "}",
-        '#include "vmac_compute_impl.tpp"',
-        "#endif", "",
-    ])
+    return "\n".join(
+        [
+            "#ifndef VMAC_HPP",
+            "#define VMAC_HPP",
+            "#include <ap_int.h>",
+            "#include <ap_fixed.h>",
+            "#include <complex>",
+            f'#include "{INCLUDE_DIR}/vmac_cmd_data_bw{cfg.data_bw}_mem_awidth32.h"',
+            f'#include "{in_hdr}"',
+            "namespace vmac_impl {",
+            f"typedef VmacCmd_data_bw{cfg.data_bw}_mem_awidth32 VmacCmd;",
+            f"namespace vmac_in_au  = ::{in_ns};",
+            f"namespace vmac_out_au = ::{in_ns};",
+            "}",
+            '#include "vmac_compute_impl.tpp"',
+            "#endif",
+            "",
+        ]
+    )
 
 
 def render_top(cfg: StructCfg, depth: int) -> str:
     mbw = cfg.mem_dwidth
-    scalar_ports = ("n_rows n_cols a_addr a_rs b_addr b_rs c_addr c_rs d_addr d_rs "
-                    "al_re al_im be_re be_im flags").split()
     lines = [
         "// Synthesizable VMAC top — m_axi shared memory + scalar s_axilite command fields —",
         "// wrapping the vmac_compute hook at one structural mem_dwidth (PF = mem_dwidth/(2*data_bw)).",
@@ -624,23 +722,22 @@ def render_top(cfg: StructCfg, depth: int) -> str:
         f"void vmac(ap_uint<{mbw}>* gmem, {_TOP_ARGS}) {{",
         f"#pragma HLS INTERFACE m_axi port=gmem offset=slave bundle=gmem depth={depth}",
     ]
-    lines += [f"#pragma HLS INTERFACE s_axilite port={p} bundle=control" for p in scalar_ports]
+    lines += [
+        f"#pragma HLS INTERFACE s_axilite port={p} bundle=control"
+        for p in _SCALAR_PORTS
+    ]
     lines += [
         "#pragma HLS INTERFACE s_axilite port=return bundle=control",
         "    // Call the scalar-arg core directly (no VmacCmd struct — it mis-decomposes at csynth).",
-        "    // The complex scalars are built locally from the s_axilite (re, im) codes — packed",
-        "    // into one wf_cint complex-code element, then reinterpreted by cx_from_codes (a flat",
-        "    // std::complex<ap_fixed> by-value param does not DCE; the nested struct did).",
+        "    // The complex alpha is built locally from the s_axilite (re, im) codes — packed into",
+        "    // one wf_cint complex-code element, then reinterpreted by cx_from_codes.",
         "    typedef vmac_impl::vmac_in_au::value_type cx_t;",
         f"    cx_t alpha = complex_utils::cx_from_codes<cx_t>("
         f"wf_cint<{cfg.data_bw}>((ap_int<{cfg.data_bw}>)al_re, (ap_int<{cfg.data_bw}>)al_im));",
-        f"    cx_t beta = complex_utils::cx_from_codes<cx_t>("
-        f"wf_cint<{cfg.data_bw}>((ap_int<{cfg.data_bw}>)be_re, (ap_int<{cfg.data_bw}>)be_im));",
         f"    vmac_impl::vmac_compute_core<{mbw}, {MEM_AWIDTH}, {cfg.data_bw}, {cfg.int_bits}, "
         f"{cfg.acc_bw}, {cfg.out_bw}, {cfg.q_rnd}, {cfg.o_sat}, {TPUT_MAX_COLS}>(",
-        "        gmem, n_rows, n_cols, flags & 1, (flags >> 1) & 1, (flags >> 2) & 1,",
-        "        (flags >> 3) & 1, a_addr, a_rs, b_addr, b_rs, c_addr, c_rs, d_addr, d_rs,",
-        "        true, alpha, 0, 0, true, beta, 0, 0);",
+        "        gmem, op, reduce != 0, n_rows, n_cols, a_addr, a_rs, b_addr, b_rs, y_addr, y_rs,",
+        "        al_direct != 0, alpha, al_addr, al_stride);",
         "}",
         "",
     ]
@@ -650,38 +747,43 @@ def render_top(cfg: StructCfg, depth: int) -> str:
 def render_cosim_tb(cfg: StructCfg, scalars: list[int], nmem: int, depth: int) -> str:
     mbw = cfg.mem_dwidth
     call_args = ", ".join(str(v) for v in scalars)
-    return "\n".join([
-        "// Cosim testbench: load the mem image, drive the vmac top with the (baked) command",
-        "// fields, and re-check the result against the golden — so cosim validates the PF>1 lane",
-        "// packing as well as the timing.",
-        '#include "vmac.hpp"',
-        "#include <fstream>", "#include <iostream>", "#include <string>", "#include <vector>",
-        "",
-        f"void vmac(ap_uint<{mbw}>* gmem, {_TOP_ARGS});",
-        "",
-        "static std::vector<unsigned long long> rw(const std::string& p) {",
-        "    std::ifstream f(p.c_str()); std::vector<unsigned long long> v; unsigned long long x;",
-        "    while (f >> x) v.push_back(x); return v;",
-        "}",
-        "",
-        f"static ap_uint<{mbw}> mem[{depth}];",
-        "",
-        "int main(int argc, char** argv) {",
-        "    std::string d = argv[1];",
-        '    std::vector<unsigned long long> mw = rw(d + "/mem_in.txt");',
-        '    std::vector<unsigned long long> ew = rw(d + "/mem_exp.txt");',
-        f"    if ((int)mw.size() < {nmem} || (int)ew.size() < {nmem}) {{",
-        '        std::cerr << "VMAC_TB_ERROR: short vector files" << char(10); return 2; }',
-        f"    for (int i = 0; i < {nmem}; ++i) mem[i] = (ap_uint<{mbw}>)mw[i];",
-        f"    vmac(mem, {call_args});",
-        "    int bad = 0;",
-        f"    for (int i = 0; i < {nmem}; ++i) if ((unsigned long long)mem[i] != ew[i]) ++bad;",
-        '    if (bad) { std::cerr << "VMAC_COSIM_MISMATCH " << bad << char(10); return 1; }',
-        '    std::cout << "VMAC_COSIM_OK" << char(10);',
-        "    return 0;",
-        "}",
-        "",
-    ])
+    return "\n".join(
+        [
+            "// Cosim testbench: load the mem image, drive the vmac top with the (baked) command",
+            "// fields, and re-check the result against the golden — so cosim validates the PF>1 lane",
+            "// packing as well as the timing.",
+            '#include "vmac.hpp"',
+            "#include <fstream>",
+            "#include <iostream>",
+            "#include <string>",
+            "#include <vector>",
+            "",
+            f"void vmac(ap_uint<{mbw}>* gmem, {_TOP_ARGS});",
+            "",
+            "static std::vector<unsigned long long> rw(const std::string& p) {",
+            "    std::ifstream f(p.c_str()); std::vector<unsigned long long> v; unsigned long long x;",
+            "    while (f >> x) v.push_back(x); return v;",
+            "}",
+            "",
+            f"static ap_uint<{mbw}> mem[{depth}];",
+            "",
+            "int main(int argc, char** argv) {",
+            "    std::string d = argv[1];",
+            '    std::vector<unsigned long long> mw = rw(d + "/mem_in.txt");',
+            '    std::vector<unsigned long long> ew = rw(d + "/mem_exp.txt");',
+            f"    if ((int)mw.size() < {nmem} || (int)ew.size() < {nmem}) {{",
+            '        std::cerr << "VMAC_TB_ERROR: short vector files" << char(10); return 2; }',
+            f"    for (int i = 0; i < {nmem}; ++i) mem[i] = (ap_uint<{mbw}>)mw[i];",
+            f"    vmac(mem, {call_args});",
+            "    int bad = 0;",
+            f"    for (int i = 0; i < {nmem}; ++i) if ((unsigned long long)mem[i] != ew[i]) ++bad;",
+            '    if (bad) { std::cerr << "VMAC_COSIM_MISMATCH " << bad << char(10); return 1; }',
+            '    std::cout << "VMAC_COSIM_OK" << char(10);',
+            "    return 0;",
+            "}",
+            "",
+        ]
+    )
 
 
 _TPUT_TCL = """# Vitis HLS csim -> csynth -> cosim for one VMAC mem_dwidth (throughput point).
@@ -713,10 +815,8 @@ def gen_tput_config(cfg: StructCfg, tdir: Path) -> dict:
     bc = BuildConfig(root_dir=tdir)
     dag = BuildDag()
     dag.add(StreamUtilsStep(output_dir=INCLUDE_DIR))
-    for sch in (Region.specialize(mem_awidth=32),
-                Scalar.specialize(mem_awidth=32, data_bw=cfg.data_bw),
-                VmacCmd.specialize(mem_awidth=32, data_bw=cfg.data_bw)):
-        dag.add(DataSchemaStep(sch, word_bw_supported=WORD_BW_SUPPORTED, include_dir=INCLUDE_DIR))
+    for step in _cmd_schema_steps(cfg):
+        dag.add(step)
     dag.add(ArrayUtilsStep(cfg.in_elem(), MEM_WORD_BWS))
     dag.run(bc)
     for fname in HOOK_FILES:
@@ -729,18 +829,26 @@ def gen_tput_config(cfg: StructCfg, tdir: Path) -> dict:
     depth = nmem
     (tdir / "vmac.hpp").write_text(_vmac_hpp(cfg), encoding="utf-8")
     (tdir / "vmac_top.cpp").write_text(render_top(cfg, depth), encoding="utf-8")
-    (tdir / "vmac_tb.cpp").write_text(render_cosim_tb(cfg, scalars, nmem, depth), encoding="utf-8")
+    (tdir / "vmac_tb.cpp").write_text(
+        render_cosim_tb(cfg, scalars, nmem, depth), encoding="utf-8"
+    )
     (tdir / "run.tcl").write_text(_TPUT_TCL, encoding="utf-8")
     data = tdir / "data"
     data.mkdir(parents=True, exist_ok=True)
-    (data / "mem_in.txt").write_text("\n".join(str(w) for w in mem_in_w) + "\n", encoding="utf-8")
-    (data / "mem_exp.txt").write_text("\n".join(str(w) for w in mem_exp_w) + "\n", encoding="utf-8")
-    return {"mem_dwidth": cfg.mem_dwidth, "pf": cfg.mem_dwidth // (2 * cfg.data_bw), "nmem": nmem}
+    (data / "mem_in.txt").write_text(
+        "\n".join(str(w) for w in mem_in_w) + "\n", encoding="utf-8"
+    )
+    (data / "mem_exp.txt").write_text(
+        "\n".join(str(w) for w in mem_exp_w) + "\n", encoding="utf-8"
+    )
+    return {"mem_dwidth": cfg.mem_dwidth, "pf": cfg.pf, "nmem": nmem}
 
 
 @dataclass(kw_only=True)
 class GenTputStep(BuildStep):
-    description = "Generate the per-mem_dwidth synthesizable top + cosim TB + vectors (PF sweep)."
+    description = (
+        "Generate the per-mem_dwidth synthesizable top + cosim TB + vectors (PF sweep)."
+    )
     consumes = ["vmac_source", "tpp_source"]
     produces = {"tput_dir": Path("tput")}
 
@@ -753,7 +861,9 @@ class GenTputStep(BuildStep):
 
 @dataclass(kw_only=True)
 class CosimStep(BuildStep):
-    description = "Per mem_dwidth: Vitis csim/csynth/cosim (cosim re-checks the golden)."
+    description = (
+        "Per mem_dwidth: Vitis csim/csynth/cosim (cosim re-checks the golden)."
+    )
     consumes = ["tput_dir"]
     produces = {"cosim_done": Path("results/cosim_done.json")}
     params: dict = field(default_factory=lambda: {"live_output": False})
@@ -763,7 +873,9 @@ class CosimStep(BuildStep):
         done = []
         for mbw in TPUT_MEM_BWS:
             d = (tput / f"m{mbw}").resolve()
-            toolchain.run_vitis_hls(d / "run.tcl", work_dir=d, capture_output=not live_output)
+            toolchain.run_vitis_hls(
+                d / "run.tcl", work_dir=d, capture_output=not live_output
+            )
             done.append({"mem_dwidth": mbw})
         out = config.root_dir / "results" / "cosim_done.json"
         out.parent.mkdir(parents=True, exist_ok=True)
@@ -773,34 +885,53 @@ class CosimStep(BuildStep):
 
 @dataclass(kw_only=True)
 class ExtractCosimTimingStep(BuildStep):
-    description = "Parse cosim transaction cycles per mem_dwidth; report throughput vs PF."
+    description = (
+        "Parse cosim transaction cycles per mem_dwidth; report throughput vs PF."
+    )
     consumes = ["cosim_done"]
     produces = {"cosim_timing": Path("results/cosim_timing.json")}
 
     def run(self, config: BuildConfig, **_) -> dict[str, Any]:
         from waveflow.utils.cosimparse import CosimReportParser
+
         tput = config.root_dir / "tput"
         rows = []
         for mbw in TPUT_MEM_BWS:
             sol = tput / f"m{mbw}" / "vmac_tput_proj" / "solution1"
-            cycles = CosimReportParser(sol_path=sol, top="vmac").get_transaction_cycles()
-            rows.append({"mem_dwidth": mbw, "pf": mbw // (2 * StructCfg(out_bw=8, q_rnd=0,
-                         o_sat=0).data_bw), "transaction_cycles": cycles})
+            cycles = CosimReportParser(
+                sol_path=sol, top="vmac"
+            ).get_transaction_cycles()
+            rows.append(
+                {
+                    "mem_dwidth": mbw,
+                    "pf": _tput_cfg(mbw).pf,
+                    "transaction_cycles": cycles,
+                }
+            )
         base = next((r["transaction_cycles"] for r in rows if r["pf"] == 1), None)
         for r in rows:
-            r["speedup_vs_pf1"] = (base / r["transaction_cycles"]
-                                   if base and r["transaction_cycles"] else None)
+            r["speedup_vs_pf1"] = (
+                base / r["transaction_cycles"]
+                if base and r["transaction_cycles"]
+                else None
+            )
         out = config.root_dir / "results" / "cosim_timing.json"
         out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(json.dumps({"n_rows": TPUT_N_ROWS, "n_cols": TPUT_N_COLS, "points": rows},
-                                  indent=2), encoding="utf-8")
+        out.write_text(
+            json.dumps(
+                {"n_rows": TPUT_N_ROWS, "n_cols": TPUT_N_COLS, "points": rows}, indent=2
+            ),
+            encoding="utf-8",
+        )
         return {"cosim_timing": out}
 
 
 def build_vmac_dag() -> BuildDag:
     dag = BuildDag()
     dag.add(SourceStep(artifact="vmac_source", path=_SOURCE_DIR / "vmac.py"))
-    dag.add(SourceStep(artifact="tpp_source", path=_SOURCE_DIR / "vmac_compute_impl.tpp"))
+    dag.add(
+        SourceStep(artifact="tpp_source", path=_SOURCE_DIR / "vmac_compute_impl.tpp")
+    )
     dag.add(GenStep(name="gen"))
     dag.add(PySimStep(name="py_sim"))
     dag.add(CsimStep(name="csim"))

--- a/examples/vmac/vmac_cmd.py
+++ b/examples/vmac/vmac_cmd.py
@@ -1,42 +1,55 @@
-"""``VmacCmd`` — the VMAC fused-instruction DataSchema (runtime tier).
+"""``VmacCmd`` — the VMAC instruction DataSchema (runtime tier).
 
-A configurable vector MAC engine (VMAC) executes the **complex** fused op
+A configurable complex vector engine (VMAC) executes one of three **element-wise** complex
+ops over a row-major region of shared memory, with an optional row reduction::
 
-    D = alpha · A · op(B) + beta · C   [, reduced over rows]
+    scalar_mult :  R[i, j] = alpha[i] · A[i, j]
+    inner_prod  :  R[i, j] = A[i, j] · conj(B[i, j])
+    sum         :  R[i, j] = A[i, j] + B[i, j]
+    reduce      :  Y[j] = Σ_i R[i, j]   (else Y[i, j] = R[i, j])
 
-over a row-major region of shared memory.  VMAC is **complex-only** (every element is an
-interleaved ``re`` / ``im`` pair of ``data_bw``-bit stored ints); there is no real mode.
+VMAC is **complex-only** (every element is an interleaved ``re`` / ``im`` pair of
+``data_bw``-bit stored ints); there is no real mode.
 
-Parameters split into two tiers (see :class:`~examples.vmac.vmac.VmacAccel`): everything
-that **sizes or types the datapath** is **structural** and lives on the accelerator as
-``HwParam`` (``mem_dwidth`` / ``mem_awidth`` / ``data_bw`` / ``int_bits`` / ``acc_bw`` /
-``out_bw`` / ``q_rnd`` / ``o_sat``), so ``A_T`` / ``ACC_T`` / ``OUT_T`` are compile-time —
-no dynamic types.  The **runtime** instruction lives here in ``VmacCmd`` and carries only
-the **op + geometry**: the matrix shape (``n_rows`` / ``n_cols``), the row-major operand
-regions (``a`` / ``b`` / ``c`` / ``d`` — addr + row_stride pitch), the op flags
-(``b_one`` / ``c_zero`` / ``b_conj`` / ``reduce_rows``), and the ``alpha`` / ``beta``
-scalars (direct immediate or indirect pointer + stride, scalar or per-column).  **No format
-fields** — the requantize shift is *derived* from the flags + the structural format (the
-accumulator fractional depth is ``2·F_in`` or ``3·F_in`` per ``b_one`` / ``c_zero``), a
-variable shift on a fixed-width accumulator, not a dynamic type.
+Parameters split into two tiers (see :class:`~examples.vmac.vmac.VmacAccel`): everything that
+**sizes or types the datapath** is **structural** and lives on the accelerator as ``HwParam``
+(``mem_dwidth`` / ``mem_awidth`` / ``data_bw`` / ``int_bits`` / ``acc_bw`` / ``out_bw`` /
+``q_rnd`` / ``o_sat``), so ``A_T`` / ``ACC_T`` / ``OUT_T`` are compile-time — no dynamic types.
+The **runtime** instruction lives here in ``VmacCmd`` and carries only the **op + geometry**:
+the ``op`` selector, the ``reduce`` flag, the matrix shape (``n_rows`` / ``n_cols``), the
+row-major operand / destination regions (``a`` always; ``b`` for ``inner_prod`` / ``sum``;
+``y`` always — addr + row_stride pitch), and the ``alpha`` scalar (``scalar_mult`` only:
+direct immediate or per-row indirect pointer + stride, indexed by row ``i``).  **No format
+fields** — the requantize shift is *derived* from the op + the structural format.
 
 The width-bearing fields are set by the accelerator that produces/consumes the command
-(``addr`` is ``mem_awidth`` bits; the immediate complex ``value`` is a ``data_bw``-per-component
-``ComplexField``).
-These schemas are **Level-2 declarative** (:class:`~waveflow.hw.dataschema.ParamSchema`):
-each declares :class:`~waveflow.hw.param.Param` attributes and a dict-literal ``elements``
-that references them directly — the core ``IntField.specialize`` / ``Region.specialize``
-calls defer on the symbolic params, and ``specialize(**vals)`` resolves + caches (with the
-``Region`` / ``Scalar`` cascade sharing params).  ``VmacCmd`` is still a plain ``DataList``,
-so it serializes / deserializes and code-generates like any schema.
+(``addr`` is ``mem_awidth`` bits; the immediate complex ``imm`` is a ``data_bw``-per-component
+``ComplexField``).  These schemas are **Level-2 declarative**
+(:class:`~waveflow.hw.dataschema.ParamSchema`): each declares :class:`~waveflow.hw.param.Param`
+attributes and a dict-literal ``elements`` that references them directly — the core
+``IntField.specialize`` / ``Region.specialize`` calls defer on the symbolic params, and
+``specialize(**vals)`` resolves + caches (with the ``Region`` / ``Alpha`` cascade sharing
+params).  ``VmacCmd`` is still a plain ``DataList``, so it serializes / deserializes and
+code-generates like any schema.
 """
+
 from __future__ import annotations
 
-from waveflow.hw import BooleanField, IntField, Param, ParamSchema
+from enum import IntEnum
+
+from waveflow.hw import BooleanField, EnumField, IntField, Param, ParamSchema
 from waveflow.hw.complexfield import ComplexField
 
 # --- field aliases (names match the auto-generated IntField subclass __name__) ----
 UInt16 = IntField.specialize(16, signed=False)
+
+
+class OpCode(IntEnum):
+    """The VMAC element-wise op selector (the only runtime *control*; loop-invariant)."""
+
+    scalar_mult = 0  # R = alpha[i] · A
+    inner_prod = 1  # R = A · conj(B)
+    sum = 2  # R = A + B
 
 
 class Region(ParamSchema):
@@ -50,67 +63,78 @@ class Region(ParamSchema):
 
     mem_awidth = Param(32)
     elements = {
-        "addr": {"schema": IntField.specialize(mem_awidth, signed=False),
-                 "description": "base offset into shared memory"},
-        "row_stride": {"schema": IntField.specialize(mem_awidth, signed=True),
-                       "description": "outer pitch (in elements) between successive rows"},
+        "addr": {
+            "schema": IntField.specialize(mem_awidth, signed=False),
+            "description": "base offset into shared memory",
+        },
+        "row_stride": {
+            "schema": IntField.specialize(mem_awidth, signed=True),
+            "description": "outer pitch (in elements) between successive rows",
+        },
     }
 
 
-class Scalar(ParamSchema):
-    """An ``alpha`` / ``beta`` operand: direct immediate (one complex ``value``) or indirect
-    (per-column pointer ``addr`` + ``stride``; ``stride 0`` broadcasts).
+class Alpha(ParamSchema):
+    """The ``scalar_mult`` scaling operand ``alpha``: a direct complex immediate, or per-row
+    indirect (pointer ``addr`` + ``stride``; element ``i`` is read at ``addr + i·stride``,
+    ``stride 0`` broadcasts).
 
     The direct immediate is a single :class:`~waveflow.hw.complexfield.ComplexField` element
-    (one interleaved re/im pair of stored ints, ``data_bw`` bits each) rather than two split
-    ``IntField``s -- so it matches the indirect path's complex element and the kernel reads
-    ``cmd.alpha.value`` as one complex code, no re/im reconstruction.  The inner stays a raw
-    ``IntField`` (stored codes; the command is format-free -- ``int_bits`` is structural), and
-    the packed bit order is unchanged (re low, im high), so it is bit-neutral."""
+    (one interleaved re/im pair of stored ints, ``data_bw`` bits each), matching the indirect
+    path's complex element so the kernel reads one complex code with no re/im reconstruction.
+    The inner stays a raw ``IntField`` (stored codes; the command is format-free — ``int_bits``
+    is structural), packed re low / im high."""
 
     mem_awidth = Param(32)
     data_bw = Param(32)
     elements = {
-        "direct": {"schema": BooleanField,
-                   "description": "True = immediate complex value; False = indirect addr/stride"},
+        "direct": {
+            "schema": BooleanField,
+            "description": "True = immediate complex imm; False = indirect addr/stride",
+        },
         # immediate complex stored-code (re low, im high; data_bw bits per component)
-        "value": ComplexField.specialize(IntField.specialize(data_bw, signed=True)),
+        "imm": ComplexField.specialize(IntField.specialize(data_bw, signed=True)),
         "addr": IntField.specialize(mem_awidth, signed=False),
         "stride": IntField.specialize(mem_awidth, signed=True),
     }
 
 
 class VmacCmd(ParamSchema):
-    """The VMAC fused instruction — the runtime tier (see module docstring).
+    """The VMAC instruction — the runtime tier (see module docstring).
 
     Region/scalar field widths track the accelerator's ``mem_awidth`` (addresses) and
-    ``data_bw`` (immediates); the cascade runs through ``Region`` / ``Scalar`` specialize
+    ``data_bw`` (immediates); the cascade runs through ``Region`` / ``Alpha`` specialize
     (both share ``mem_awidth`` with ``VmacCmd`` and resolve to the same cached classes).
     """
 
     mem_awidth = Param(32)
     data_bw = Param(32)
     elements = {
-        # global matrix shape (operands share it; dst is (1, n_cols) when reduced)
+        # the element-wise op + the optional row reduction (the only runtime control).
+        "op": {
+            "schema": EnumField.specialize(OpCode),
+            "description": "element-wise op: scalar_mult / inner_prod / sum",
+        },
+        "reduce": {
+            "schema": BooleanField,
+            "description": "sum the rows (per-column reduction)",
+        },
+        # matrix shape (operands share it; dst is (1, n_cols) when reduced).
         "n_rows": UInt16,
         "n_cols": UInt16,
-        # row-major operand / destination regions (cascade: share mem_awidth)
-        "a": {"schema": Region.specialize(mem_awidth=mem_awidth),
-              "description": "operand A region (left multiplicand of A·op(B))"},
-        "b": {"schema": Region.specialize(mem_awidth=mem_awidth),
-              "description": "operand B region (op(B): identity, or conj(B) in complex mode)"},
-        "c": {"schema": Region.specialize(mem_awidth=mem_awidth),
-              "description": "addend C region (the β·C term; unused when c_zero)"},
-        "d": {"schema": Region.specialize(mem_awidth=mem_awidth),
-              "description": "destination D region (reduced to a single row when reduce_rows)"},
-        # scaling scalars (cascade: share mem_awidth and data_bw)
-        "alpha": Scalar.specialize(mem_awidth=mem_awidth, data_bw=data_bw),
-        "beta": Scalar.specialize(mem_awidth=mem_awidth, data_bw=data_bw),
-        # op flags — the only runtime *control* (loop-invariant if/mux, no II hit).
-        # No format fields: int_bits / out_bw / q_rnd / o_sat are structural (on VmacAccel),
-        # and the requantize shift is derived from these flags + that structural format.
-        "b_one": {"schema": BooleanField, "description": "op(B) = 1 (skip the A·op(B) multiply)"},
-        "c_zero": {"schema": BooleanField, "description": "drop the beta·C term"},
-        "b_conj": {"schema": BooleanField, "description": "op(B) = conj(B) (negate B's imag part)"},
-        "reduce_rows": {"schema": BooleanField, "description": "sum the rows (per-column reduction)"},
+        # row-major operand / destination regions (cascade: share mem_awidth).
+        "a": {
+            "schema": Region.specialize(mem_awidth=mem_awidth),
+            "description": "operand A region (always read)",
+        },
+        "b": {
+            "schema": Region.specialize(mem_awidth=mem_awidth),
+            "description": "operand B region (read for inner_prod / sum)",
+        },
+        "y": {
+            "schema": Region.specialize(mem_awidth=mem_awidth),
+            "description": "destination Y region (reduced to a single row when reduce)",
+        },
+        # the scalar_mult scaling operand (cascade: share mem_awidth and data_bw).
+        "alpha": Alpha.specialize(mem_awidth=mem_awidth, data_bw=data_bw),
     }

--- a/examples/vmac/vmac_compute_impl.tpp
+++ b/examples/vmac/vmac_compute_impl.tpp
@@ -1,21 +1,22 @@
 // vmac_compute_impl.tpp
 // Included from gen/vmac.hpp.  The generated header brings into scope, *before* this file:
 //
-//   * VmacCmd                  — the command struct (DataSchemaStep).
+//   * VmacCmd                  — the command struct (DataSchemaStep), incl. the OpCode enum.
 //   * vmac_in_au / vmac_out_au — namespace aliases for the **generated ComplexField
 //                                serialization** of the operand / output element types
 //                                (ArrayUtilsStep over ComplexField.specialize(FixedField…)).
 //     `vmac_in_au::value_type`  == std::complex<ap_fixed<DATA_BW, INT_BITS, …>>  (operand)
 //     `vmac_out_au::value_type` == std::complex<ap_fixed<OUT_BW,  OUT_INT,  …>>  (writeback)
-//   * complex_utils::{cmult,cadd,conj} — full-precision complex arithmetic (the explicit
-//                                re/im formula, widths following the native ap_fixed growth =
-//                                the Python *_format rules; cmult/cadd accept mixed operand
-//                                formats, so the F -> 2F -> 3F chain composes with no widen).
+//   * complex_utils::{cmult,cadd,conj,cwiden,cx_requantize,cx_from_codes} — the complex toolkit
+//                                (full-precision arithmetic + construct/widen/requantize).
 //
-// Hand-written body for the templated `vmac_impl::vmac_compute` hook — the single VMAC
-// datapath: the **complex** fused op
+// Hand-written body for the templated `vmac_impl::vmac_compute` hook — the VMAC datapath: one of
+// three **complex element-wise** ops, with an optional row reduction
 //
-//     D = alpha * A * op(B) + beta * C   [, reduced over rows]
+//     scalar_mult :  R[i, j] = alpha[i] · A[i, j]
+//     inner_prod  :  R[i, j] = A[i, j] · conj(B[i, j])
+//     sum         :  R[i, j] = A[i, j] + B[i, j]
+//     reduce      :  Y[j] = Σ_i R[i, j]          (else Y[i, j] = R[i, j])
 //
 // over a row-major shared-memory image reached through the `m_axi` pointer.  This is the C++
 // contract of `VmacAccel.vmac_compute` (whose Python body is the golden `VmacAccel.execute`);
@@ -23,22 +24,21 @@
 //
 // The datapath stays **complex-typed end to end** — `std::complex<ap_fixed>` lanes, a complex
 // scalar, `complex_utils` ops, a complex accumulator, and an `ap_fixed`-assignment requantize —
-// with no hand-split re/im and no integer-code bridging.  Full precision is carried in the
-// `ap_fixed` value (no rounding until the single requantize); the wide accumulator holds the
-// product at fractional depth 3*F_in (>= the per-flag 2F/3F the golden tracks), so requantizing
-// its *value* to F_out = F_in reproduces the golden's quantize bit-for-bit (the intermediate
-// fractional depth is irrelevant once the value is exact).
+// no hand-split re/im.  Full precision is carried in the `ap_fixed` value (no rounding until the
+// single requantize); the wide accumulator holds the value at fractional depth 2*F_in (>= the
+// per-op F_in/2F_in the golden tracks), so requantizing its *value* to F_out = F_in reproduces
+// the golden's quantize bit-for-bit (the intermediate fractional depth is irrelevant once the
+// value is exact).
 //
-// ONE fixed-format kernel, configured at *run time* by the command's op flags:
+// ONE fixed-format kernel, configured at *run time* by `op` / `reduce`:
 //   * Template params are **widths only** -> all ap_fixed types are compile-time (no dynamic types).
-//   * The op flags (b_one / c_zero / b_conj / reduce_rows) are **runtime** if/mux — loop-invariant.
+//   * `op` / `reduce` are **runtime** if/mux — loop-invariant (no II hit).
 //
-// VMAC is complex-only: every element is one packed ComplexField (interleaved re/im), so the
-// element bitwidth is 2*DATA_BW and the kernel processes PF = MEM_BW / (2*DATA_BW) complex
-// columns per memory word.  Lane I/O reuses the generated serialization
-// (`read_array_elem<ComplexField>` / `write_array_elem<ComplexField>`); per-row operand regions
-// are word-aligned (addr / row_stride multiples of PF), so the PF contiguous columns of a row
-// live in one word and are reached by a running word pointer advanced a constant per step.
+// Memory addressing: operand rows are read/written with the fused **element-lane** primitives
+// (`read_array_lane` / `write_array_lane`) over a running word pointer — the canonical
+// lane loop, one word/beat -> PF complex columns, advanced a constant per step (PF-packed rows
+// are word-aligned; `elem_to_word` checks it).  `read_array_slice` is used **only** for the
+// per-row alpha[i], a single element at an arbitrary element index (read once per row).
 
 #include <cassert>
 
@@ -46,11 +46,16 @@
 
 namespace vmac_impl {
 
+// OpCode values (mirror examples/vmac/vmac_cmd.py OpCode; the generated `enum class OpCode`
+// shares these, but the core takes a plain int so the s_axilite top can pass a register).
+static const int VMAC_OP_SCALAR_MULT = 0;
+static const int VMAC_OP_INNER_PROD = 1;
+static const int VMAC_OP_SUM = 2;
+
 // Map an *element* index/stride to its *word* index for PF-packed memory (PF elements/word):
 // the divide is a shift (PF is a compile-time power of two), with a PF-alignment check — the
-// per-row operand regions (bases + strides) must be word-aligned.  (The per-column indirect
-// scalar is genuinely element-addressed — word = e/PF, lane = e&(PF-1) — so it is read inline,
-// not through this aligned helper.)
+// per-row operand regions (bases + strides) must be word-aligned.  (The per-row indirect alpha
+// is genuinely element-addressed and is read via read_array_slice, not this aligned helper.)
 template <int PF, typename T>
 static inline T elem_to_word(T elem) {
 #pragma HLS INLINE
@@ -62,78 +67,81 @@ static inline T elem_to_word(T elem) {
 // synthesizable top calls this directly: a nested struct passed by value mis-decomposes
 // through HLS's Array/Struct optimization at csynth (loop bounds fold to 0 -> the kernel is
 // DCE'd), whereas scalar s_axilite args lower cleanly.  The fields keep their precise types
-// (addresses ap_uint<MEM_AWIDTH>, strides signed, shape ap_uint<16>, scalar codes ap_int) so
-// the address arithmetic is sized by MEM_AWIDTH, not a stray 32-bit int.  vmac_compute(cmd, mem)
+// (addresses ap_uint<MEM_AWIDTH>, strides signed, shape ap_uint<16>, the op an int, alpha a
+// complex value) so the address arithmetic is sized by MEM_AWIDTH.  vmac_compute(cmd, mem)
 // below is the thin struct-taking wrapper the csim conformance harness drives.
 template <int MEM_BW, int MEM_AWIDTH, int DATA_BW, int INT_BITS, int ACC_BW, int OUT_BW,
           bool Q_RND, bool O_SAT, int MAX_COLS>
 void vmac_compute_core(
     ap_uint<MEM_BW>* mem,
-    ap_uint<16> n_rows, ap_uint<16> n_cols, bool b_one, bool c_zero, bool b_conj, bool reduce_rows,
+    int op, bool reduce, ap_uint<16> n_rows, ap_uint<16> n_cols,
     ap_uint<MEM_AWIDTH> a_addr, ap_int<MEM_AWIDTH> a_rs,
     ap_uint<MEM_AWIDTH> b_addr, ap_int<MEM_AWIDTH> b_rs,
-    ap_uint<MEM_AWIDTH> c_addr, ap_int<MEM_AWIDTH> c_rs,
-    ap_uint<MEM_AWIDTH> d_addr, ap_int<MEM_AWIDTH> d_rs,
+    ap_uint<MEM_AWIDTH> y_addr, ap_int<MEM_AWIDTH> y_rs,
     bool al_direct, typename vmac_in_au::value_type alpha_imm,
-    ap_uint<MEM_AWIDTH> al_addr, ap_int<MEM_AWIDTH> al_stride,
-    bool be_direct, typename vmac_in_au::value_type beta_imm,
-    ap_uint<MEM_AWIDTH> be_addr, ap_int<MEM_AWIDTH> be_stride) {
+    ap_uint<MEM_AWIDTH> al_addr, ap_int<MEM_AWIDTH> al_stride) {
 #pragma HLS INLINE
     // Inline into the synthesizable top so the m_axi reads/writes belong to the top's gmem
     // port (kept as a separate module, the top would have "no outputs" and gmem would dangle).
     typedef typename vmac_in_au::value_type CX;     // std::complex<ap_fixed<DATA_BW, INT_BITS, …>>
-    typedef typename CX::value_type IN_FX;          // ap_fixed<DATA_BW, INT_BITS, …>
     typedef typename vmac_out_au::value_type CXO;   // std::complex<ap_fixed<OUT_BW, OUT_INT, …>>
-    typedef typename CXO::value_type OUT_FX;
-    typedef ap_fixed<DATA_BW + 1, INT_BITS + 1> OPB_FX;   // op(B) = conj-format (W+1, I+1)
-    typedef std::complex<OPB_FX> OPB_CX;
+    typedef ap_fixed<DATA_BW + 1, INT_BITS + 1> RT_FX;    // right-term format (W+1, I+1): conj / widened alpha
+    typedef std::complex<RT_FX> RT_CX;
     static const int F_IN = DATA_BW - INT_BITS;
     static const int OUT_INT = OUT_BW - F_IN;             // F_out = F_in (structural)
     static const ap_q_mode QMODE = Q_RND ? AP_RND : AP_TRN;
     static const ap_o_mode OMODE = O_SAT ? AP_SAT : AP_WRAP;
-    typedef ap_fixed<OUT_BW, OUT_INT, QMODE, OMODE> REQ_FX;     // requantize target (structural Q/O)
-    typedef ap_fixed<ACC_BW, ACC_BW - 3 * F_IN> ACC_FX;        // accumulator component, frac = 3*F_in
+    typedef ap_fixed<OUT_BW, OUT_INT, QMODE, OMODE> REQ_FX;       // requantize target (structural Q/O)
+    typedef ap_fixed<ACC_BW, ACC_BW - 2 * F_IN> ACC_FX;          // accumulator component, frac = 2*F_in
     typedef std::complex<ACC_FX> ACC_CX;
-    static constexpr int PF = vmac_in_au::pf<MEM_BW>();       // complex columns / word (power of 2)
+    static constexpr int PF = vmac_in_au::pf<MEM_BW>();          // complex columns / word (power of 2)
 
-    // alpha_imm / beta_imm arrive as complex values (the wrapper / top build them once via
-    // complex_utils::cx_from_codes); the indirect (per-column) reads override them below.
+    const bool op_sum = (op == VMAC_OP_SUM);
+    const bool op_scalar = (op == VMAC_OP_SCALAR_MULT);
+    const bool need_b = (op != VMAC_OP_SCALAR_MULT);            // inner_prod / sum read B
 
-    // running word indices: row base = addr/PF, advanced by row_stride/PF per row (both exact —
-    // regions are PF-aligned; elem_to_word checks it).
-    const ap_uint<MEM_AWIDTH> a_w0 = elem_to_word<PF>(a_addr), b_w0 = elem_to_word<PF>(b_addr);
-    const ap_uint<MEM_AWIDTH> c_w0 = elem_to_word<PF>(c_addr), d_w0 = elem_to_word<PF>(d_addr);
-    const ap_int<MEM_AWIDTH> a_rsw = elem_to_word<PF>(a_rs), b_rsw = elem_to_word<PF>(b_rs);
-    const ap_int<MEM_AWIDTH> c_rsw = elem_to_word<PF>(c_rs), d_rsw = elem_to_word<PF>(d_rs);
-
-    // per-column complex accumulators (reduce_rows): summed over rows.
+    // per-column complex accumulators (reduce): summed over rows.
     ACC_CX acc[MAX_COLS];
 #pragma HLS ARRAY_PARTITION variable=acc cyclic factor=PF dim=1
-    if (reduce_rows) {
+    if (reduce) {
         for (int j = 0; j < (int)n_cols; ++j) {
 #pragma HLS PIPELINE II=1
             acc[j] = ACC_CX(0, 0);
         }
     }
 
-    // outer loop over rows (running pointers per operand), inner over contiguous columns packed
-    // PF/word (the GEMM accumulation pattern).
-    ap_uint<MEM_AWIDTH> a_row = a_w0, b_row = b_w0, c_row = c_w0, d_row = d_w0;
+    // running word indices: row base = addr/PF, advanced by row_stride/PF per row (both exact —
+    // regions are PF-aligned; elem_to_word checks it).
+    const ap_uint<MEM_AWIDTH> a_w0 = elem_to_word<PF>(a_addr), b_w0 = elem_to_word<PF>(b_addr);
+    const ap_uint<MEM_AWIDTH> y_w0 = elem_to_word<PF>(y_addr);
+    const ap_int<MEM_AWIDTH> a_rsw = elem_to_word<PF>(a_rs), b_rsw = elem_to_word<PF>(b_rs);
+    const ap_int<MEM_AWIDTH> y_rsw = elem_to_word<PF>(y_rs);
+
+    // outer loop over rows (running word pointers per operand), inner over contiguous columns
+    // packed PF/word — the fused canonical lane loop.
+    ap_uint<MEM_AWIDTH> a_row = a_w0, b_row = b_w0, y_row = y_w0;
     for (int i = 0; i < (int)n_rows; ++i) {
 #pragma HLS LOOP_TRIPCOUNT min=1 max=MAX_COLS
-        ap_uint<MEM_AWIDTH> a_w = a_row, b_w = b_row, c_w = c_row, d_w = d_row;
+        // per-row alpha (scalar_mult): direct immediate, or the single element at al_addr +
+        // i*al_stride — read once per row via the element-indexed slice (no e/PF in the kernel).
+        CX alpha = alpha_imm;
+        if (op_scalar && !al_direct) {
+            const int e = (int)al_addr + i * (int)al_stride;
+            vmac_in_au::read_array_slice<MEM_BW>(mem, e, e + 1, &alpha);
+        }
+        // alpha broadcast as the right-term for scalar_mult (widened losslessly to (W+1, I+1)).
+        const RT_CX alpha_rt = RT_CX((RT_FX)alpha.real(), (RT_FX)alpha.imag());
+
+        ap_uint<MEM_AWIDTH> a_w = a_row, b_w = b_row, y_w = y_row;
         for (int col0 = 0; col0 < (int)n_cols; col0 += PF) {
 #pragma HLS PIPELINE II=1
             const int cols = ((int)n_cols - col0 < PF) ? ((int)n_cols - col0) : PF;
-            CX a_lane[PF], b_lane[PF], c_lane[PF];
+            CX a_lane[PF], b_lane[PF];
 #pragma HLS ARRAY_PARTITION variable=a_lane complete dim=1
 #pragma HLS ARRAY_PARTITION variable=b_lane complete dim=1
-#pragma HLS ARRAY_PARTITION variable=c_lane complete dim=1
-            vmac_in_au::read_array_elem<MEM_BW>(mem + a_w, a_lane, cols);
-            if (!b_one)
-                vmac_in_au::read_array_elem<MEM_BW>(mem + b_w, b_lane, cols);
-            if (!c_zero)
-                vmac_in_au::read_array_elem<MEM_BW>(mem + c_w, c_lane, cols);
+            vmac_in_au::read_array_lane<MEM_BW>(mem + a_w, a_lane, cols);
+            if (need_b)
+                vmac_in_au::read_array_lane<MEM_BW>(mem + b_w, b_lane, cols);
 
             CXO y_lane[PF];
 #pragma HLS ARRAY_PARTITION variable=y_lane complete dim=1
@@ -142,55 +150,32 @@ void vmac_compute_core(
                 const int j = col0 + k;
                 if (j >= (int)n_cols) continue;
 
-                // per-column alpha/beta: immediate, or one complex element read from the word
-                // containing it (lane = e & (PF-1), no modulo; PF is a power of two).
-                CX alpha = alpha_imm, beta = beta_imm;
-                if (!al_direct) {
-                    const ap_uint<MEM_AWIDTH> e = al_addr + (ap_uint<MEM_AWIDTH>)(j * (int)al_stride);
-                    CX sb[PF];
-                    vmac_in_au::read_array_elem<MEM_BW>(mem + e / PF, sb, PF);
-                    alpha = sb[e & (PF - 1)];
-                }
-                if (!be_direct && !c_zero) {
-                    const ap_uint<MEM_AWIDTH> e = be_addr + (ap_uint<MEM_AWIDTH>)(j * (int)be_stride);
-                    CX sb[PF];
-                    vmac_in_au::read_array_elem<MEM_BW>(mem + e / PF, sb, PF);
-                    beta = sb[e & (PF - 1)];
-                }
-
-                // alpha * A * op(B):  op(B) = conj(B) or B; the F -> 2F -> 3F chain via cmult.
-                ACC_CX term;
-                if (b_one) {
-                    term = complex_utils::cwiden<ACC_CX>(complex_utils::cmult(alpha, a_lane[k]));
+                // R = A + B (sum) or A * right_term (scalar_mult: alpha broadcast / inner_prod:
+                // conj(B)) — one shared complex multiply for the two product ops.
+                ACC_CX r;
+                if (op_sum) {
+                    r = complex_utils::cwiden<ACC_CX>(complex_utils::cadd(a_lane[k], b_lane[k]));
                 } else {
-                    OPB_CX opb = b_conj
-                        ? complex_utils::conj(b_lane[k])
-                        : OPB_CX((OPB_FX)b_lane[k].real(), (OPB_FX)b_lane[k].imag());
-                    term = complex_utils::cwiden<ACC_CX>(
-                        complex_utils::cmult(alpha, complex_utils::cmult(a_lane[k], opb)));
-                }
-                // + beta * C  (beta*C widened to the accumulator scale, then a complex add)
-                if (!c_zero) {
-                    ACC_CX bc = complex_utils::cwiden<ACC_CX>(complex_utils::cmult(beta, c_lane[k]));
-                    term = complex_utils::cwiden<ACC_CX>(complex_utils::cadd(term, bc));
+                    const RT_CX right = op_scalar ? alpha_rt : complex_utils::conj(b_lane[k]);
+                    r = complex_utils::cwiden<ACC_CX>(complex_utils::cmult(a_lane[k], right));
                 }
 
-                if (reduce_rows)
-                    acc[j] = complex_utils::cwiden<ACC_CX>(complex_utils::cadd(acc[j], term));
+                if (reduce)
+                    acc[j] = complex_utils::cwiden<ACC_CX>(complex_utils::cadd(acc[j], r));
                 else
-                    y_lane[k] = complex_utils::cx_requantize<CXO, REQ_FX>(term);
+                    y_lane[k] = complex_utils::cx_requantize<CXO, REQ_FX>(r);
             }
-            if (!reduce_rows)
-                vmac_out_au::write_array_elem<MEM_BW>(y_lane, mem + d_w, cols);
+            if (!reduce)
+                vmac_out_au::write_array_lane<MEM_BW>(y_lane, mem + y_w, cols);
 
-            a_w += 1; b_w += 1; c_w += 1; d_w += 1;
+            a_w += 1; b_w += 1; y_w += 1;
         }
-        a_row += a_rsw; b_row += b_rsw; c_row += c_rsw; d_row += d_rsw;
+        a_row += a_rsw; b_row += b_rsw; y_row += y_rsw;
     }
 
-    // reduce_rows writeback: one row of n_cols requantized results at the dst.
-    if (reduce_rows) {
-        ap_uint<MEM_AWIDTH> d_w = d_w0;
+    // reduce writeback: one row of n_cols requantized results at the dst.
+    if (reduce) {
+        ap_uint<MEM_AWIDTH> y_w = y_w0;
         for (int col0 = 0; col0 < (int)n_cols; col0 += PF) {
 #pragma HLS PIPELINE II=1
             const int cols = ((int)n_cols - col0 < PF) ? ((int)n_cols - col0) : PF;
@@ -202,33 +187,28 @@ void vmac_compute_core(
                 if (j >= (int)n_cols) continue;
                 y_lane[k] = complex_utils::cx_requantize<CXO, REQ_FX>(acc[j]);
             }
-            vmac_out_au::write_array_elem<MEM_BW>(y_lane, mem + d_w, cols);
-            d_w += 1;
+            vmac_out_au::write_array_lane<MEM_BW>(y_lane, mem + y_w, cols);
+            y_w += 1;
         }
     }
 }
 
-// Struct-taking wrapper — extracts the command's (typed) scalar fields and calls the core.
-// Used by the csim conformance harness (where the by-value struct is fine); the synthesizable
-// top calls vmac_compute_core directly to avoid the nested-struct csynth pitfall above.
+// Struct-taking wrapper — extracts the command's (typed) fields and calls the core.  Used by the
+// csim conformance harness (where the by-value struct is fine); the synthesizable top calls
+// vmac_compute_core directly to avoid the nested-struct csynth pitfall above.
 template <int MEM_BW, int MEM_AWIDTH, int DATA_BW, int INT_BITS, int ACC_BW, int OUT_BW,
           bool Q_RND, bool O_SAT, int MAX_COLS>
 void vmac_compute(VmacCmd cmd, ap_uint<MEM_BW>* mem) {
     typedef typename vmac_in_au::value_type CXIN;
     vmac_compute_core<MEM_BW, MEM_AWIDTH, DATA_BW, INT_BITS, ACC_BW, OUT_BW, Q_RND, O_SAT, MAX_COLS>(
         mem,
-        cmd.n_rows, cmd.n_cols,
-        (bool)cmd.b_one, (bool)cmd.c_zero, (bool)cmd.b_conj, (bool)cmd.reduce_rows,
+        (int)cmd.op, (bool)cmd.reduce, cmd.n_rows, cmd.n_cols,
         cmd.a.addr, cmd.a.row_stride,
         cmd.b.addr, cmd.b.row_stride,
-        cmd.c.addr, cmd.c.row_stride,
-        cmd.d.addr, cmd.d.row_stride,
+        cmd.y.addr, cmd.y.row_stride,
         (bool)cmd.alpha.direct,
-        complex_utils::cx_from_codes<CXIN>(cmd.alpha.value),
-        cmd.alpha.addr, cmd.alpha.stride,
-        (bool)cmd.beta.direct,
-        complex_utils::cx_from_codes<CXIN>(cmd.beta.value),
-        cmd.beta.addr, cmd.beta.stride);
+        complex_utils::cx_from_codes<CXIN>(cmd.alpha.imm),
+        cmd.alpha.addr, cmd.alpha.stride);
 }
 
 }  // namespace vmac_impl

--- a/tests/examples/test_vmac_cmd.py
+++ b/tests/examples/test_vmac_cmd.py
@@ -1,18 +1,19 @@
 """VMAC command/accelerator tests — encode/decode round-trips + the ``specialize`` cascade.
 
 VMAC is **complex-only** and the numeric format is **structural** (on ``VmacAccel``), so
-``VmacCmd`` carries only op flags + geometry — no mode / format fields.  It is a plain
-``DataList`` (nested ``Region`` / ``Scalar`` sub-lists, ``BooleanField`` flags), so it must
-serialize / deserialize back to an identical value across word widths — the wire-format
-contract for the (Phase-3) HLS kernel.  The structural widths live on ``VmacAccel`` (an
-``HwComponent`` with ``HwParam`` fields); its computed ``Cmd`` specializes the command schema
-so a command's field widths track the silicon (``addr`` = ``mem_awidth`` bits; the immediate
-complex ``value`` = ``data_bw`` bits per component); same params → same schema class object.
+``VmacCmd`` carries only the op selector + reduce flag + geometry + operands — no format fields.
+It is a plain ``DataList`` (an ``EnumField`` op, a ``BooleanField`` reduce, nested ``Region`` /
+``Alpha`` sub-lists), so it must serialize / deserialize back to an identical value across word
+widths — the wire-format contract for the HLS kernel.  The structural widths live on
+``VmacAccel`` (an ``HwComponent`` with ``HwParam`` fields); its computed ``Cmd`` specializes the
+command schema so a command's field widths track the silicon (``addr`` = ``mem_awidth`` bits; the
+immediate complex ``imm`` = ``data_bw`` bits per component); same params → same schema object.
 """
+
 import pytest
 
 from examples.vmac.vmac import VmacAccel
-from examples.vmac.vmac_cmd import Region, Scalar, VmacCmd
+from examples.vmac.vmac_cmd import Alpha, OpCode, Region, VmacCmd
 from waveflow.utils.fixputils import OMode, QMode
 
 # a concrete accelerator: 32-bit addresses, 16-bit operands/immediates
@@ -22,14 +23,12 @@ Cmd = ACCEL.Cmd
 
 def _full_cmd():
     cmd = Cmd()
+    cmd.op, cmd.reduce = OpCode.inner_prod, 1
     cmd.n_rows, cmd.n_cols = 6, 4
     cmd.a = {"addr": 0, "row_stride": 4}
-    cmd.b = {"addr": 24, "row_stride": 4}
-    cmd.c = {"addr": 48, "row_stride": 8}          # row pitch wider than n_cols (sub-matrix)
-    cmd.d = {"addr": 72, "row_stride": 4}
-    cmd.alpha = {"direct": 1, "value": (-16, 8), "addr": 0, "stride": 0}
-    cmd.beta = {"direct": 0, "value": (0, 0), "addr": 96, "stride": 1}
-    cmd.b_one, cmd.c_zero, cmd.b_conj, cmd.reduce_rows = 0, 1, 1, 1
+    cmd.b = {"addr": 24, "row_stride": 8}  # row pitch wider than n_cols (sub-matrix)
+    cmd.y = {"addr": 72, "row_stride": 4}
+    cmd.alpha = {"direct": 1, "imm": (-16, 8), "addr": 0, "stride": 0}
     return cmd
 
 
@@ -41,39 +40,54 @@ def test_vmac_cmd_roundtrip(word_bw):
     assert restored.val == cmd.val
 
 
-def test_nested_region_scalar_roundtrip():
-    reg = Region(addr=12, row_stride=-3)                         # negative pitch survives
+def test_nested_region_alpha_roundtrip():
+    reg = Region(addr=12, row_stride=-3)  # negative pitch survives
     r2 = Region().deserialize(reg.serialize(32), 32)
     assert r2.val == reg.val == {"addr": 12, "row_stride": -3}
 
-    sc = Scalar(direct=1, value=(-100, 77), addr=5, stride=-1)
-    s2 = Scalar().deserialize(sc.serialize(32), 32)
-    assert s2.val == sc.val
-    assert s2.direct is True                                     # BooleanField -> Python bool
-    assert int(s2.value["re"]) == -100 and int(s2.value["im"]) == 77
+    al = Alpha(direct=1, imm=(-100, 77), addr=5, stride=-1)
+    a2 = Alpha().deserialize(al.serialize(32), 32)
+    assert a2.val == al.val
+    assert a2.direct is True  # BooleanField -> Python bool
+    assert int(a2.imm["re"]) == -100 and int(a2.imm["im"]) == 77
 
 
 def test_default_cmd_roundtrips():
-    cmd = Cmd()                                                  # all defaults / zeros
+    cmd = Cmd()  # all defaults / zeros
     restored = Cmd().deserialize(cmd.serialize(32), 32)
     assert restored.val == cmd.val
+
+
+def test_op_enum_field_roundtrips_all_members():
+    for op in OpCode:
+        cmd = _full_cmd()
+        cmd.op = op
+        restored = Cmd().deserialize(cmd.serialize(32), 32)
+        assert OpCode(int(restored.op)) is op
 
 
 def test_signed_fields_preserve_negatives():
     cmd = _full_cmd()
     cmd.a = {"addr": 10, "row_stride": -4}
-    cmd.alpha = {"direct": 1, "value": (-32768, -1), "addr": 0, "stride": 0}  # data_bw=16 range
+    cmd.alpha = {
+        "direct": 1,
+        "imm": (-32768, -1),
+        "addr": 0,
+        "stride": 0,
+    }  # data_bw=16 range
     restored = Cmd().deserialize(cmd.serialize(32), 32)
     assert restored.a.row_stride == -4
-    assert int(restored.alpha.value["re"]) == -32768 and int(restored.alpha.value["im"]) == -1
+    assert (
+        int(restored.alpha.imm["re"]) == -32768 and int(restored.alpha.imm["im"]) == -1
+    )
     assert restored.val == cmd.val
 
 
-def test_flags_are_booleanfields():
+def test_reduce_is_booleanfield():
     cmd = _full_cmd()
-    for flag in (cmd.b_one, cmd.c_zero, cmd.b_conj, cmd.reduce_rows):
-        assert isinstance(flag, bool)
-    assert cmd.c_zero is True and cmd.b_one is False
+    assert isinstance(cmd.reduce, bool) and cmd.reduce is True
+    cmd.reduce = 0
+    assert cmd.reduce is False
 
 
 def test_accel_q_o_mode_properties():
@@ -90,7 +104,7 @@ def test_accel_cmd_shared_and_distinct():
     # same widths -> the same cached Cmd class; different widths -> a different one.
     a = VmacAccel(mem_dwidth=512, mem_awidth=32, data_bw=16, acc_bw=48, out_bw=12)
     b = VmacAccel(mem_dwidth=999, mem_awidth=32, data_bw=16, acc_bw=99, out_bw=7)
-    assert a.Cmd is ACCEL.Cmd                                    # Cmd depends only on (mem_awidth, data_bw)
+    assert a.Cmd is ACCEL.Cmd  # Cmd depends only on (mem_awidth, data_bw)
     assert b.Cmd is ACCEL.Cmd
     c = VmacAccel(mem_awidth=24, data_bw=12)
     assert c.Cmd is not ACCEL.Cmd
@@ -98,55 +112,97 @@ def test_accel_cmd_shared_and_distinct():
 
 def test_accel_is_hwcomponent_with_hwparams():
     from waveflow.hw.hw_component import HwComponent, _hw_param_names
+
     assert issubclass(VmacAccel, HwComponent)
     # the extractor sees every structural width — incl. the format moved off the command —
     # as a HwParam template param
     assert _hw_param_names(VmacAccel) >= {
-        "mem_dwidth", "mem_awidth", "data_bw", "int_bits", "acc_bw", "out_bw", "q_rnd", "o_sat"}
+        "mem_dwidth",
+        "mem_awidth",
+        "data_bw",
+        "int_bits",
+        "acc_bw",
+        "out_bw",
+        "q_rnd",
+        "o_sat",
+    }
 
 
 def test_accel_carries_structural_params():
-    assert (int(ACCEL.mem_dwidth), int(ACCEL.mem_awidth), int(ACCEL.data_bw),
-            int(ACCEL.acc_bw), int(ACCEL.out_bw)) == (512, 32, 16, 48, 12)
+    assert (
+        int(ACCEL.mem_dwidth),
+        int(ACCEL.mem_awidth),
+        int(ACCEL.data_bw),
+        int(ACCEL.acc_bw),
+        int(ACCEL.out_bw),
+    ) == (512, 32, 16, 48, 12)
 
 
 def test_cmd_specialize_cached_and_matches_accel():
     assert ACCEL.Cmd is VmacCmd.specialize(mem_awidth=32, data_bw=16)
-    assert VmacCmd.specialize(mem_awidth=32, data_bw=16) is VmacCmd.specialize(mem_awidth=32, data_bw=16)
+    assert VmacCmd.specialize(mem_awidth=32, data_bw=16) is VmacCmd.specialize(
+        mem_awidth=32, data_bw=16
+    )
     assert issubclass(ACCEL.Cmd, VmacCmd)
 
 
 def test_cmd_field_widths_track_mem_awidth_and_data_bw():
     # addr (and strides) follow mem_awidth; the immediate complex value's components follow data_bw
     region = ACCEL.Cmd.get_element_schema("a")
-    scalar = ACCEL.Cmd.get_element_schema("alpha")
+    alpha = ACCEL.Cmd.get_element_schema("alpha")
     assert region.get_element_schema("addr").get_bitwidth() == 32
     assert region.get_element_schema("row_stride").get_bitwidth() == 32
-    value = scalar.get_element_schema("value")
-    assert value.inner_type.get_bitwidth() == 16                 # per-component data_bw
-    assert value.get_bitwidth() == 32                            # packed re/im = 2*data_bw
+    imm = alpha.get_element_schema("imm")
+    assert imm.inner_type.get_bitwidth() == 16  # per-component data_bw
+    assert imm.get_bitwidth() == 32  # packed re/im = 2*data_bw
 
     wide = VmacAccel(mem_dwidth=256, mem_awidth=40, data_bw=24, acc_bw=64, out_bw=24)
-    assert wide.Cmd.get_element_schema("a").get_element_schema("addr").get_bitwidth() == 40
-    assert wide.Cmd.get_element_schema("alpha").get_element_schema("value").inner_type.get_bitwidth() == 24
+    assert (
+        wide.Cmd.get_element_schema("a").get_element_schema("addr").get_bitwidth() == 40
+    )
+    assert (
+        wide.Cmd.get_element_schema("alpha")
+        .get_element_schema("imm")
+        .inner_type.get_bitwidth()
+        == 24
+    )
 
 
-def test_region_scalar_specialize_cached_and_sized():
+def test_region_alpha_specialize_cached_and_sized():
     assert Region.specialize(mem_awidth=32) is Region.specialize(mem_awidth=32)
     assert Region.specialize(mem_awidth=40) is not Region.specialize(mem_awidth=32)
-    assert Region.specialize(mem_awidth=40).get_element_schema("addr").get_bitwidth() == 40
-    assert Scalar.specialize(mem_awidth=32, data_bw=16) is Scalar.specialize(mem_awidth=32, data_bw=16)
-    assert Scalar.specialize(
-        mem_awidth=32, data_bw=16).get_element_schema("value").inner_type.get_bitwidth() == 16
-    assert Scalar.specialize(
-        mem_awidth=32, data_bw=24).get_element_schema("value").inner_type.get_bitwidth() == 24
+    assert (
+        Region.specialize(mem_awidth=40).get_element_schema("addr").get_bitwidth() == 40
+    )
+    assert Alpha.specialize(mem_awidth=32, data_bw=16) is Alpha.specialize(
+        mem_awidth=32, data_bw=16
+    )
+    assert (
+        Alpha.specialize(mem_awidth=32, data_bw=16)
+        .get_element_schema("imm")
+        .inner_type.get_bitwidth()
+        == 16
+    )
+    assert (
+        Alpha.specialize(mem_awidth=32, data_bw=24)
+        .get_element_schema("imm")
+        .inner_type.get_bitwidth()
+        == 24
+    )
 
 
 def test_format_fields_removed_from_cmd():
     fields = set(VmacCmd.elements)
     # all numeric format + mode is structural (on VmacAccel) or derived — none on the command
-    assert {"in_bw", "out_bw", "acc_bw", "int_bits", "shift", "q_rnd", "o_sat",
-            "mode"}.isdisjoint(fields)
-    # the command carries only geometry + op flags
-    assert fields == {"n_rows", "n_cols", "a", "b", "c", "d", "alpha", "beta",
-                      "b_one", "c_zero", "b_conj", "reduce_rows"}
+    assert {
+        "in_bw",
+        "out_bw",
+        "acc_bw",
+        "int_bits",
+        "shift",
+        "q_rnd",
+        "o_sat",
+        "mode",
+    }.isdisjoint(fields)
+    # the command carries only the op + reduce + geometry + operands (no C / beta / op flags)
+    assert fields == {"op", "reduce", "n_rows", "n_cols", "a", "b", "y", "alpha"}

--- a/tests/examples/test_vmac_golden.py
+++ b/tests/examples/test_vmac_golden.py
@@ -1,19 +1,21 @@
-"""VMAC golden tests — bit-level results for every config vs an independent oracle.
+"""VMAC golden tests — bit-level results for every op vs an independent oracle.
 
 VMAC is **complex-only**: every element is an ``(re, im)`` pair, and the numeric format is
 structural (on :class:`~examples.vmac.vmac.VmacAccel`), not in the command.  The production
 golden (:meth:`VmacAccel.execute`) composes the integer-backed numpy ``ComplexField``
-operators.  The **oracle** here is independent: it works in exact rational (``Fraction``)
-space over ``(re, im)`` pairs, computes the accumulator value exactly (full precision), then
-quantizes once with the right-shift → round → saturate spec.  The requantize shift is
-**derived** — the output sits at the input fractional scale ``F_out = F_in`` (so
-``SHIFT = F_acc − F_in``), exactly as :meth:`VmacAccel.output_format` defines.  Two
-independent implementations of the same datapath must agree bit-for-bit.  A few literal
-hand-checked outputs anchor the oracle.
+operators.  The **oracle** here is independent: exact rational (``Fraction``) arithmetic over
+``(re, im)`` pairs, the accumulator value computed exactly (full precision), then quantized once
+with the right-shift → round → saturate spec.  The requantize shift is **derived** — the output
+sits at the input fractional scale ``F_out = F_in`` (``SHIFT = F_acc − F_in``), exactly as
+:meth:`VmacAccel.output_format` defines.  Two independent implementations must agree bit-for-bit;
+a few literal hand-checked outputs anchor the oracle.
 
-Operands are supplied as **stored integers** at fractional scale ``F = in_bw - int_bits``;
-real value = ``stored · 2**-F`` (exact).  Real-valued cases just carry ``im = 0``.
+The three element-wise ops are ``scalar_mult`` (``alpha[i]·A``), ``inner_prod`` (``A·conj(B)``),
+and ``sum`` (``A+B``), each with an optional row reduction ``Y[j] = Σ_i R[i, j]``.  Operands are
+supplied as **stored integers** at fractional scale ``F = in_bw - int_bits``; real value =
+``stored · 2**-F`` (exact).  Real-valued cases just carry ``im = 0``.
 """
+
 import math
 from fractions import Fraction
 
@@ -21,6 +23,7 @@ import numpy as np
 import pytest
 
 from examples.vmac.vmac import VmacAccel
+from examples.vmac.vmac_cmd import OpCode
 from waveflow.utils import complexutils as cx
 from waveflow.utils.fixputils import Format
 
@@ -29,14 +32,6 @@ from waveflow.utils.fixputils import Format
 def _cmul(a, b):
     (ar, ai), (br, bi) = a, b
     return (ar * br - ai * bi, ar * bi + ai * br)
-
-
-def _cadd(a, b):
-    return (a[0] + b[0], a[1] + b[1])
-
-
-def _conj(a):
-    return (a[0], -a[1])
 
 
 def _q_real(value: Fraction, out_frac: int, W: int, q_rnd: bool, o_sat: bool) -> int:
@@ -50,12 +45,13 @@ def _q_real(value: Fraction, out_frac: int, W: int, q_rnd: bool, o_sat: bool) ->
 
 
 # --- the oracle (independent of the production golden) ------------------------
-def oracle(cfg, a, b, c, alpha, beta):
-    """a/b/c: (n, m) stored-int pairs (re, im arrays); alpha/beta: (re, im) scalars or
-    per-column (m,) arrays.  Returns the expected dst stored ints — (n,m) or (m,) reduced —
-    as a pair (re, im) of int arrays (im all-zero for real mode)."""
+def oracle(cfg, a, b, alpha):
+    """a/b: (n, m) stored-int pairs (re, im arrays); alpha: a scalar (re, im) or per-row (n,)
+    array (scalar_mult only).  Returns the expected dst stored ints — (n, m) or (m,) reduced —
+    as a pair (re, im) of int arrays."""
     F = cfg["in_bw"] - cfg["int_bits"]
     scale = Fraction(2) ** F
+    op = cfg["op"]
     n, m = a[0].shape
 
     def fr(stored):
@@ -64,120 +60,123 @@ def oracle(cfg, a, b, c, alpha, beta):
     def at(operand, i, j):
         return (fr(operand[0][i, j]), fr(operand[1][i, j]))
 
-    def scal(s, j):
-        if np.ndim(s[0]) == 0:
-            return (fr(s[0]), fr(s[1]))
-        return (fr(s[0][j]), fr(s[1][j]))
+    def alpha_at(i):
+        if np.ndim(alpha[0]) == 0:
+            return (fr(alpha[0]), fr(alpha[1]))
+        return (fr(alpha[0][i]), fr(alpha[1][i]))
 
-    # output at the structural input scale F_out = F_in (the derived shift = F_acc - F_in).
-    out_frac = F
-
+    out_frac = F  # F_out = F_in (derived shift = F_acc - F_in)
     cols_re, cols_im = [], []
     for j in range(m):
         terms = []
         for i in range(n):
             av = at(a, i, j)
-            if cfg["b_one"]:
-                ab = av
-            else:
+            if op is OpCode.scalar_mult:
+                t = _cmul(alpha_at(i), av)
+            elif op is OpCode.inner_prod:
                 bv = at(b, i, j)
-                if cfg["b_conj"]:
-                    bv = _conj(bv)
-                ab = _cmul(av, bv)
-            t = _cmul(scal(alpha, j), ab)
-            if not cfg["c_zero"]:
-                t = _cadd(t, _cmul(scal(beta, j), at(c, i, j)))
+                t = _cmul(av, (bv[0], -bv[1]))  # A · conj(B)
+            else:  # sum
+                bv = at(b, i, j)
+                t = (av[0] + bv[0], av[1] + bv[1])
             terms.append(t)
-        acc = terms[0]
-        if cfg["reduce_rows"]:
+        if cfg["reduce"]:
+            acc = terms[0]
             for t in terms[1:]:
-                acc = _cadd(acc, t)
+                acc = (acc[0] + t[0], acc[1] + t[1])
             rows = [acc]
         else:
             rows = terms
-        col_re = [_q_real(r[0], out_frac, cfg["out_bw"], cfg["q_rnd"], cfg["o_sat"]) for r in rows]
-        col_im = [_q_real(r[1], out_frac, cfg["out_bw"], cfg["q_rnd"], cfg["o_sat"]) for r in rows]
-        cols_re.append(col_re)
-        cols_im.append(col_im)
-    re = np.array(cols_re, dtype=np.int64).T          # (rows, m)
+        cols_re.append(
+            [
+                _q_real(r[0], out_frac, cfg["out_bw"], cfg["q_rnd"], cfg["o_sat"])
+                for r in rows
+            ]
+        )
+        cols_im.append(
+            [
+                _q_real(r[1], out_frac, cfg["out_bw"], cfg["q_rnd"], cfg["o_sat"])
+                for r in rows
+            ]
+        )
+    re = np.array(cols_re, dtype=np.int64).T  # (rows, m)
     im = np.array(cols_im, dtype=np.int64).T
-    if cfg["reduce_rows"]:
-        re, im = re[0], im[0]                          # (m,)
+    if cfg["reduce"]:
+        re, im = re[0], im[0]  # (m,)
     return re, im
 
 
 # --- harness: lay operands into mem + build the matching VmacCmd --------------
 def _flat(pair):
-    """Flatten a complex operand to structured mem slots (row-major re/im)."""
     re = np.asarray(pair[0]).ravel()
     im = np.asarray(pair[1]).ravel()
-    return cx.make_complex(re, im, Format(8, 4, True))   # dtype only; format irrelevant here
+    return cx.make_complex(
+        re, im, Format(8, 4, True)
+    )  # dtype only; format irrelevant here
 
 
 def _accel(cfg):
-    """The accelerator carrying the structural widths + format for this config."""
     return VmacAccel(
-        mem_dwidth=512, mem_awidth=32,
-        data_bw=cfg["in_bw"], int_bits=cfg["int_bits"],
-        acc_bw=cfg.get("acc_bw", 48), out_bw=cfg["out_bw"],
-        q_rnd=cfg["q_rnd"], o_sat=cfg["o_sat"],
+        mem_dwidth=512,
+        mem_awidth=32,
+        data_bw=cfg["in_bw"],
+        int_bits=cfg["int_bits"],
+        acc_bw=cfg.get("acc_bw", 48),
+        out_bw=cfg["out_bw"],
+        q_rnd=cfg["q_rnd"],
+        o_sat=cfg["o_sat"],
     )
 
 
-def build(accel, cfg, a, b, c, alpha, beta):
-    """Lay a/b/c (+ per-column alpha/beta) into mem and build the Cmd. Returns (cmd, mem)."""
+def _alpha_field(op, alpha, addr):
+    if op is OpCode.scalar_mult and np.ndim(alpha[0]) > 0:  # per-row indirect
+        return {"direct": 0, "imm": (0, 0), "addr": int(addr), "stride": 1}
+    re = int(alpha[0]) if np.ndim(alpha[0]) == 0 else 0
+    im = int(alpha[1]) if np.ndim(alpha[0]) == 0 else 0
+    return {"direct": 1, "imm": (re, im), "addr": 0, "stride": 0}
+
+
+def build(accel, cfg, a, b, alpha):
+    """Lay a (+ b for inner_prod/sum, + per-row alpha for indirect scalar_mult) into mem and
+    build the Cmd. Returns (cmd, mem)."""
+    op = cfg["op"]
     n, m = a[0].shape
     nm = n * m
-    blocks, addr = [], {}
-    cur = 0
-    for name, op in (("a", a), ("b", b), ("c", c)):
-        addr[name] = cur
-        blocks.append(_flat(op))
+    need_b = op in (OpCode.inner_prod, OpCode.sum)
+    alpha_pr = op is OpCode.scalar_mult and np.ndim(alpha[0]) > 0
+
+    blocks, addr, cur = [], {}, 0
+    addr["a"] = cur
+    blocks.append(_flat(a))
+    cur += nm
+    if need_b:
+        addr["b"] = cur
+        blocks.append(_flat(b))
         cur += nm
-    alpha_pc = np.ndim(alpha[0]) > 0
-    beta_pc = np.ndim(beta[0]) > 0
-    if alpha_pc:
+    if alpha_pr:
         addr["alpha"] = cur
-        blocks.append(_flat((alpha[0], alpha[1])))
-        cur += m
-    if beta_pc:
-        addr["beta"] = cur
-        blocks.append(_flat((beta[0], beta[1])))
-        cur += m
-    addr["d"] = cur
+        blocks.append(_flat(alpha))
+        cur += n
+    addr["y"] = cur
     cur += nm
     mem = cx.make_complex(np.zeros(cur), np.zeros(cur), Format(8, 4, True))
-    # write each block at its address (row-major)
-    order = ["a", "b", "c"] + (["alpha"] if alpha_pc else []) + (["beta"] if beta_pc else [])
+    order = ["a"] + (["b"] if need_b else []) + (["alpha"] if alpha_pr else [])
     for name, blk in zip(order, blocks):
-        mem[addr[name]:addr[name] + len(blk)] = blk
+        mem[addr[name] : addr[name] + len(blk)] = blk
 
     cmd = accel.Cmd()
-    cmd.n_rows, cmd.n_cols = n, m
-    cmd.a = {"addr": addr["a"], "row_stride": m}
-    cmd.b = {"addr": addr["b"], "row_stride": m}
-    cmd.c = {"addr": addr["c"], "row_stride": m}
-    cmd.d = {"addr": addr["d"], "row_stride": m}
-    cmd.alpha = _scalar_field(alpha, addr.get("alpha"))
-    cmd.beta = _scalar_field(beta, addr.get("beta"))
-    # format (in_bw / int_bits / out_bw / acc_bw / q_rnd / o_sat) is structural (on the
-    # accelerator); the command carries only the op flags + geometry.
-    for f in ("b_one", "c_zero", "b_conj", "reduce_rows"):
-        setattr(cmd, f, cfg[f])
+    cmd.op, cmd.reduce, cmd.n_rows, cmd.n_cols = op, int(cfg["reduce"]), n, m
+    for name in ("a", "b", "y"):
+        setattr(cmd, name, {"addr": addr.get(name, 0), "row_stride": m})
+    cmd.alpha = _alpha_field(op, alpha, addr.get("alpha"))
     return cmd, mem
 
 
-def _scalar_field(s, addr):
-    if np.ndim(s[0]) == 0:
-        return {"direct": 1, "value": (int(s[0]), int(s[1])), "addr": 0, "stride": 0}
-    return {"direct": 0, "value": (0, 0), "addr": int(addr), "stride": 1}
-
-
-def run(cfg, a, b, c, alpha, beta):
+def run(cfg, a, b, alpha):
     accel = _accel(cfg)
-    cmd, mem = build(accel, cfg, a, b, c, alpha, beta)
+    cmd, mem = build(accel, cfg, a, b, alpha)
     dst = accel.execute(cmd, mem)
-    exp_re, exp_im = oracle(cfg, a, b, c, alpha, beta)
+    exp_re, exp_im = oracle(cfg, a, b, alpha)
     got_re, got_im = np.asarray(dst.val["re"]), np.asarray(dst.val["im"])
     return (got_re, got_im), (exp_re, exp_im)
 
@@ -190,132 +189,130 @@ def _pair(re, im=None):
 
 
 def _cfg(**kw):
-    # VMAC is complex-only; the command carries only flags + geometry. The numeric
-    # format (in_bw / int_bits / out_bw / acc_bw / q_rnd / o_sat) is structural (passed
-    # to the accelerator via _accel); the requantize shift is derived (F_acc - F_in).
-    base = dict(in_bw=8, int_bits=4, out_bw=8, acc_bw=48,
-                b_one=0, c_zero=0, b_conj=0, reduce_rows=0, q_rnd=0, o_sat=0)
+    # VMAC is complex-only; the command carries only op + reduce + geometry. The numeric
+    # format (in_bw / int_bits / out_bw / acc_bw / q_rnd / o_sat) is structural (passed to
+    # the accelerator via _accel); the requantize shift is derived (F_acc - F_in).
+    base = dict(
+        op=OpCode.sum,
+        reduce=0,
+        in_bw=8,
+        int_bits=4,
+        out_bw=8,
+        acc_bw=48,
+        q_rnd=0,
+        o_sat=0,
+    )
     base.update(kw)
     return base
 
 
 # --- literal hand-checked anchors --------------------------------------------
-def test_scaled_copy_literal():
-    # dst = 1.0 * a, F=4: alpha=16 (=1.0); a=[1.5,2.0]=[24,32] -> dst=[24,32]
-    # b_one -> F_acc=2*4=8, derived shift=F_acc-F_in=4 -> F_out=4.
-    cfg = _cfg(b_one=1, c_zero=1)
-    a = _pair([[24, 32]])
-    (gr, _), (er, _) = run(cfg, a, _pair([[0, 0]]), _pair([[0, 0]]), _pair(16), _pair(0))
-    np.testing.assert_array_equal(gr, [[24, 32]])
+def test_scalar_mult_literal():
+    # R = alpha · A, alpha = 2.0 (code 32), A = [1.5, 2.0] = [24, 32] -> [3.0, 4.0] = [48, 64].
+    cfg = _cfg(op=OpCode.scalar_mult)
+    (gr, _), (er, _) = run(cfg, _pair([[24, 32]]), _pair([[0, 0]]), _pair(32, 0))
+    np.testing.assert_array_equal(gr, [[48, 64]])
     np.testing.assert_array_equal(gr, er)
 
 
-def test_hadamard_literal():
-    # dst = a*b, alpha=1.0, c_zero. a=[2.0]=32, b=[1.5]=24 -> 3.0; F_acc=3*4=12, shift=8 -> F_out=4
-    cfg = _cfg(c_zero=1)
+def test_inner_prod_literal():
+    # R = A · conj(B): A = 2.0 = 32, B = 1.5 = 24 -> 3.0 = 48 (im 0).
+    cfg = _cfg(op=OpCode.inner_prod)
     a, b = _pair([[32]]), _pair([[24]])
-    (gr, _), (er, _) = run(cfg, a, b, _pair([[0]]), _pair(16), _pair(0))
-    np.testing.assert_array_equal(gr, [[48]])      # 3.0 at F=4 = 48
+    (gr, _), (er, _) = run(cfg, a, b, _pair(16, 0))
+    np.testing.assert_array_equal(gr, [[48]])
     np.testing.assert_array_equal(gr, er)
 
 
-def test_column_sum_literal():
-    # b_one, c_zero, alpha=1, reduce=rows: dst = sum_rows(a). a col=[1.0,2.0,0.5]=[16,32,8] -> 3.5=56
-    cfg = _cfg(b_one=1, c_zero=1, reduce_rows=1)
+def test_sum_literal():
+    # R = A + B: same scale, codes add. A = [1.0, 2.0] = [16, 32], B = [0.5, 0.5] = [8, 8].
+    cfg = _cfg(op=OpCode.sum)
+    (gr, _), (er, _) = run(cfg, _pair([[16, 32]]), _pair([[8, 8]]), _pair(0, 0))
+    np.testing.assert_array_equal(gr, [[24, 40]])
+    np.testing.assert_array_equal(gr, er)
+
+
+def test_sum_reduce_literal():
+    # R = A + B, reduce over rows. col A = [1.0, 2.0, 0.5] = [16, 32, 8], B = 0 -> sum 3.5 = 56.
+    cfg = _cfg(op=OpCode.sum, reduce=1)
     a = _pair([[16], [32], [8]])
-    (gr, _), (er, _) = run(cfg, a, _pair(np.zeros((3, 1))), _pair(np.zeros((3, 1))),
-                           _pair(16), _pair(0))
+    (gr, _), (er, _) = run(cfg, a, _pair(np.zeros((3, 1))), _pair(0, 0))
     np.testing.assert_array_equal(gr, [56])
     np.testing.assert_array_equal(gr, er)
 
 
-# --- config sweep vs the oracle (complex-only) --------------------------------
+def test_scalar_mult_per_row_indirect_literal():
+    # R[i,j] = alpha[i] · A[i,j], alpha = [1.0, 2.0] = [16, 32] (per row).
+    cfg = _cfg(op=OpCode.scalar_mult)
+    a = _pair([[16, 32], [16, 16]])  # rows 1.0,2.0 / 1.0,1.0
+    (gr, _), (er, _) = run(cfg, a, _pair(np.zeros((2, 2))), _pair([16, 32]))
+    np.testing.assert_array_equal(gr, [[16, 32], [32, 32]])  # row0·1, row1·2
+    np.testing.assert_array_equal(gr, er)
+
+
+# --- op × reduce × alpha-mode sweep vs the oracle (complex-only) ---------------
 @pytest.mark.parametrize("q_rnd,o_sat", [(0, 0), (1, 0), (0, 1), (1, 1)])
-def test_configs_vs_oracle(q_rnd, o_sat):
+def test_ops_vs_oracle(q_rnd, o_sat):
     rng = np.random.default_rng(2)
     n, m = 4, 3
+
     def cop():
         return _pair(rng.integers(-60, 61, (n, m)), rng.integers(-60, 61, (n, m)))
-    a, b, c = cop(), cop(), cop()
+
+    a, b = cop(), cop()
     alpha_s = _pair(20, -8)
-    beta_s = _pair(-12, 5)
-    alpha_pc = _pair(rng.integers(-30, 31, m), rng.integers(-30, 31, m))
-    beta_pc = _pair(rng.integers(-30, 31, m), rng.integers(-30, 31, m))
-    configs = [
-        _cfg(b_one=1, c_zero=1, q_rnd=q_rnd, o_sat=o_sat),                       # scaled copy
-        _cfg(c_zero=1, q_rnd=q_rnd, o_sat=o_sat),                                # hadamard
-        _cfg(b_conj=1, c_zero=1, q_rnd=q_rnd, o_sat=o_sat),                      # conj hadamard
-        _cfg(q_rnd=q_rnd, o_sat=o_sat),                                          # full MAC
-        _cfg(b_one=1, q_rnd=q_rnd, o_sat=o_sat),                                 # alpha*a + beta*c
-        _cfg(b_one=1, c_zero=1, reduce_rows=1, q_rnd=q_rnd, o_sat=o_sat),        # column sum
-        _cfg(b_conj=1, c_zero=1, reduce_rows=1, q_rnd=q_rnd, o_sat=o_sat),       # conj inner product
-        _cfg(reduce_rows=1, q_rnd=q_rnd, o_sat=o_sat),                           # reduced MAC
-    ]
-    for cfg in configs:
-        for al, be in [(alpha_s, beta_s), (alpha_pc, beta_pc)]:      # scalar + per-column
-            got, exp = run(cfg, a, b, c, al, be)
-            np.testing.assert_array_equal(got[0], exp[0], err_msg=f"{cfg} re")
-            np.testing.assert_array_equal(got[1], exp[1], err_msg=f"{cfg} im")
+    alpha_pr = _pair(rng.integers(-30, 31, n), rng.integers(-30, 31, n))
+    for reduce in (0, 1):
+        for op in (OpCode.scalar_mult, OpCode.inner_prod, OpCode.sum):
+            alphas = [alpha_s, alpha_pr] if op is OpCode.scalar_mult else [alpha_s]
+            for alpha in alphas:
+                cfg = _cfg(op=op, reduce=reduce, q_rnd=q_rnd, o_sat=o_sat)
+                got, exp = run(cfg, a, b, alpha)
+                np.testing.assert_array_equal(got[0], exp[0], err_msg=f"{cfg} re")
+                np.testing.assert_array_equal(got[1], exp[1], err_msg=f"{cfg} im")
 
 
 # --- saturation + rounding are actually exercised -----------------------------
 def test_saturation_triggered():
-    # large product saturates at OUT_BW=8 signed (range +-8 at F_out=4). alpha=1.0, a=b=7.0
-    # -> 49.0, way over range. c_zero, not b_one -> F_acc=12, derived shift=8 -> F_out=4.
-    cfg = _cfg(c_zero=1, o_sat=1)
-    a, b = _pair([[112]]), _pair([[112]])               # 7.0 * 7.0 = 49 >> way over +-8 range
-    (gr, _), (er, _) = run(cfg, a, b, _pair([[0]]), _pair(16), _pair(0))
-    assert gr[0, 0] == 127                                # saturated to OUT_BW max
+    # inner_prod: 7.0 * 7.0 = 49.0, way over the +-8 OUT_BW=8 range -> saturate to max.
+    cfg = _cfg(op=OpCode.inner_prod, o_sat=1)
+    a, b = _pair([[112]]), _pair([[112]])
+    (gr, _), (er, _) = run(cfg, a, b, _pair(16, 0))
+    assert gr[0, 0] == 127
     np.testing.assert_array_equal(gr, er)
 
 
 def test_rounding_triggered():
-    # a value landing between LSBs differs under TRN vs RND (derived shift = 8 here)
+    # a value landing between LSBs differs under TRN vs RND (derived shift = F_in = 4 here).
     rng = np.random.default_rng(9)
     a = _pair(rng.integers(-120, 121, (3, 2)))
     b = _pair(rng.integers(-120, 121, (3, 2)))
-    trn = run(_cfg(c_zero=1, q_rnd=0), a, b, _pair(np.zeros((3, 2))), _pair(16), _pair(0))
-    rnd = run(_cfg(c_zero=1, q_rnd=1), a, b, _pair(np.zeros((3, 2))), _pair(16), _pair(0))
+    trn = run(_cfg(op=OpCode.inner_prod, q_rnd=0), a, b, _pair(16, 0))
+    rnd = run(_cfg(op=OpCode.inner_prod, q_rnd=1), a, b, _pair(16, 0))
     np.testing.assert_array_equal(trn[0][0], trn[1][0])
     np.testing.assert_array_equal(rnd[0][0], rnd[1][0])
-    assert not np.array_equal(trn[0][0], rnd[0][0])      # the two modes genuinely differ
+    assert not np.array_equal(trn[0][0], rnd[0][0])  # the two modes genuinely differ
 
 
-# --- CG op coverage (the complex configs the CG matrix inverse needs) ----------
-def test_cg_complex_axpy_steps():
-    # X = X - P·α[col]:  a=P, b_one, α=-vec (per-col), c=X, β=1
-    rng = np.random.default_rng(11)
-    n, m = 5, 3
-    P = _pair(rng.integers(-100, 101, (n, m)), rng.integers(-100, 101, (n, m)))
-    X = _pair(rng.integers(-100, 101, (n, m)), rng.integers(-100, 101, (n, m)))
-    neg_alpha = _pair(-rng.integers(-30, 31, m), -rng.integers(-30, 31, m))   # -α per column
-    beta_one = _pair(16, 0)                              # β = 1.0 in F4
-    cfg = _cfg(b_one=1)                                  # alpha·P + 1·X, no reduce
-    got, exp = run(cfg, P, _pair(np.zeros((n, m)), np.zeros((n, m))), X, neg_alpha, beta_one)
-    np.testing.assert_array_equal(got[0], exp[0])
-    np.testing.assert_array_equal(got[1], exp[1])
-
-
-def test_cg_complex_inner_product_conj():
-    # ps = Σ conj(P)·S:  a=S, b=P, b_conj, c_zero, reduce=rows (complex)
+# --- complex-op coverage ------------------------------------------------------
+def test_conj_inner_product_reduce():
+    # ps[j] = Σ_i S[i,j]·conj(P[i,j]) (the column inner product).
     rng = np.random.default_rng(13)
     n, m = 6, 2
     S = _pair(rng.integers(-50, 51, (n, m)), rng.integers(-50, 51, (n, m)))
     P = _pair(rng.integers(-50, 51, (n, m)), rng.integers(-50, 51, (n, m)))
-    cfg = _cfg(b_conj=1, c_zero=1, reduce_rows=1)
-    got, exp = run(cfg, S, P, _pair(np.zeros((n, m)), np.zeros((n, m))), _pair(16, 0), _pair(0, 0))
+    got, exp = run(_cfg(op=OpCode.inner_prod, reduce=1), S, P, _pair(16, 0))
     np.testing.assert_array_equal(got[0], exp[0])
     np.testing.assert_array_equal(got[1], exp[1])
 
 
-def test_cg_rnorm_sum_abs_sq_is_real():
-    # rnorm = Σ |R|²:  a=R, b=R, b_conj, c_zero, reduce=rows -> result is REAL (im == 0)
+def test_rnorm_sum_abs_sq_is_real():
+    # rnorm[j] = Σ_i |R[i,j]|² (R·conj(R), reduced) -> REAL (im == 0), non-negative.
     rng = np.random.default_rng(14)
     n, m = 6, 2
     R = _pair(rng.integers(-50, 51, (n, m)), rng.integers(-50, 51, (n, m)))
-    # saturate so the (non-negative) magnitude clamps to OUT_BW max rather than wrapping
-    cfg = _cfg(b_conj=1, c_zero=1, reduce_rows=1, out_bw=12, o_sat=1)
-    got, exp = run(cfg, R, R, _pair(np.zeros((n, m)), np.zeros((n, m))), _pair(16, 0), _pair(0, 0))
+    cfg = _cfg(op=OpCode.inner_prod, reduce=1, out_bw=12, o_sat=1)
+    got, exp = run(cfg, R, R, _pair(16, 0))
     np.testing.assert_array_equal(got[0], exp[0])
-    np.testing.assert_array_equal(got[1], np.zeros_like(got[1]))   # |R|² is real
-    assert np.all(got[0] >= 0)                                     # and non-negative (no wrap)
+    np.testing.assert_array_equal(got[1], np.zeros_like(got[1]))  # |R|² is real
+    assert np.all(got[0] >= 0)

--- a/tests/examples/test_vmac_numeric.py
+++ b/tests/examples/test_vmac_numeric.py
@@ -4,11 +4,12 @@ VMAC is **complex-only** and the format is **structural** (on :class:`VmacAccel`
 things are proven here, all in Python (no Vitis):
 
 1. **The datapath format derivation** — ``VmacAccel.accumulator_format`` / ``output_format``
-   match an *independent*, hand-derived format algebra (product widens; the β·C add grows an
-   integer bit; the row reduction adds ``⌈log₂ n_rows⌉``; complex's ``cmult`` / ``conj`` add
-   their extra bit in the *integer* part).  The output sits at the input fractional scale
-   ``F_out = F_in`` (so ``I_out = out_bw − F_in``), and the requantize shift is *derived*:
-   ``SHIFT = F_acc − F_in`` (= ``F_in`` when ``b_one`` else ``2·F_in``).
+   match an *independent*, hand-derived format algebra per op (``scalar_mult`` / ``inner_prod``
+   are one complex multiply → ``F_acc = 2·F_in``; ``sum`` is an aligned add → ``F_acc = F_in``;
+   ``conj`` adds its bit in the *integer* part; the row reduction adds ``⌈log₂ n_rows⌉``).  The
+   output sits at the input fractional scale ``F_out = F_in`` (so ``I_out = out_bw − F_in``), and
+   the requantize shift is *derived*: ``SHIFT = F_acc − F_in`` (``F_in`` for the products, ``0``
+   for ``sum``).
 
 2. **requantize == an ap_fixed assignment** — the golden's requantize (a ``fixputils.quantize``
    format conversion that drops ``SHIFT`` fractional bits) is bit-identical to the hardware
@@ -19,6 +20,7 @@ things are proven here, all in Python (no Vitis):
 Plus the fail-loud guards (ACC_BW too small, out_bw too small) and a width × (q, o)
 end-to-end sweep against the independent oracle.
 """
+
 import math
 from fractions import Fraction
 
@@ -26,6 +28,7 @@ import numpy as np
 import pytest
 
 from examples.vmac.vmac import VmacAccel
+from examples.vmac.vmac_cmd import OpCode
 from waveflow.hw.dataschema import DataArray
 from waveflow.hw.fixpoint import FixedField
 from waveflow.utils import complexutils as cx
@@ -41,13 +44,13 @@ def hw_shift_round_sat(acc_stored, shift, out_bw, q_rnd, o_sat):
     if shift == 0:
         q = acc_stored
     else:
-        q = acc_stored >> shift                          # arithmetic floor (toward -inf)
+        q = acc_stored >> shift  # arithmetic floor (toward -inf)
         if q_rnd:
-            q += (acc_stored >> (shift - 1)) & 1         # round half up (tie -> +inf)
+            q += (acc_stored >> (shift - 1)) & 1  # round half up (tie -> +inf)
     lo, hi = -(1 << (out_bw - 1)), (1 << (out_bw - 1)) - 1
     if o_sat:
         return max(lo, min(hi, q))
-    y = q & ((1 << out_bw) - 1)                          # two's-complement wrap
+    y = q & ((1 << out_bw) - 1)  # two's-complement wrap
     return y - (1 << out_bw) if (y >> (out_bw - 1)) & 1 else y
 
 
@@ -66,28 +69,38 @@ def frac_value_quant(acc_stored, acc_frac, out_frac, out_bw, q_rnd, o_sat):
 
 def _craft_values(acc_W, shift):
     """Stored-int accumulator values that stress the requantize: rounding ties (and ±1
-    around them), negatives, and large magnitudes that overflow out_bw into saturation."""
+    around them), negatives, and large magnitudes that overflow out_bw into saturation.
+    """
     half = (1 << (shift - 1)) if shift > 0 else 0
     vals = set()
     for base in range(-6, 7):
         v = base << shift
         vals.update([v, v + half, v - half, v + half - 1, v + half + 1, v + 1, v - 1])
     lo, hi = -(1 << (acc_W - 1)), (1 << (acc_W - 1)) - 1
-    vals.update([lo, hi, lo // 2, hi // 2, 0, -1, 1])    # extremes -> saturation
+    vals.update([lo, hi, lo // 2, hi // 2, 0, -1, 1])  # extremes -> saturation
     return np.array(sorted(v for v in vals if lo <= v <= hi), dtype=np.int64)
 
 
 # (acc_W, acc_I, out_bw, shift) — all valid: 0 <= out_frac = (acc_W-acc_I)-shift <= out_bw
 _REQUANT_CONFIGS = [
-    (16, 8, 12, 0),     # SHIFT = 0 (no rounding; pure narrow + saturate)
+    (16, 8, 12, 0),  # SHIFT = 0 (no rounding; pure narrow + saturate)
     (16, 8, 8, 4),
-    (16, 8, 8, 8),      # out_frac = 0 (integer output)
+    (16, 8, 8, 8),  # out_frac = 0 (integer output)
     (24, 12, 8, 8),
     (24, 12, 10, 4),
-    (12, 6, 8, 6),      # out_frac = 0
+    (12, 6, 8, 6),  # out_frac = 0
     (20, 4, 8, 12),
     (32, 16, 12, 10),
 ]
+
+
+def _qo(q_rnd, o_sat):
+    from waveflow.utils.fixputils import OMode, QMode
+
+    return (
+        QMode.AP_RND if q_rnd else QMode.AP_TRN,
+        OMode.AP_SAT if o_sat else OMode.AP_WRAP,
+    )
 
 
 @pytest.mark.parametrize("acc_W,acc_I,out_bw,shift", _REQUANT_CONFIGS)
@@ -99,100 +112,134 @@ def test_requantize_complex_equals_ap_fixed(acc_W, acc_I, out_bw, shift, q_rnd, 
     acc_fmt = Format(acc_W, acc_I, True)
     acc_frac = acc_fmt.frac_bits
     out_frac = acc_frac - shift
-    out_cls = FixedField.specialize(out_bw, out_bw - out_frac, True, *(_qo(q_rnd, o_sat)))
+    out_cls = FixedField.specialize(
+        out_bw, out_bw - out_frac, True, *(_qo(q_rnd, o_sat))
+    )
     re = _craft_values(acc_W, shift)
     im = np.roll(re, 3)
     from waveflow.hw.complexfield import ComplexField
-    t = DataArray.specialize(ComplexField.specialize(FixedField.specialize(acc_W, acc_I, True)),
-                             max_shape=(len(re),))(cx.make_complex(re, im, acc_fmt))
+
+    t = DataArray.specialize(
+        ComplexField.specialize(FixedField.specialize(acc_W, acc_I, True)),
+        max_shape=(len(re),),
+    )(cx.make_complex(re, im, acc_fmt))
     out = VmacAccel._requantize(t, out_cls).val
     for comp, src in (("re", re), ("im", im)):
         hw = [hw_shift_round_sat(s, shift, out_bw, q_rnd, o_sat) for s in src]
-        frac = [frac_value_quant(s, acc_frac, out_frac, out_bw, q_rnd, o_sat) for s in src]
-        np.testing.assert_array_equal(np.asarray(out[comp]), hw)    # int-domain shift/round/sat
-        np.testing.assert_array_equal(np.asarray(out[comp]), frac)  # value-domain quantize
-
-
-def _qo(q_rnd, o_sat):
-    from waveflow.utils.fixputils import OMode, QMode
-    return (QMode.AP_RND if q_rnd else QMode.AP_TRN, OMode.AP_SAT if o_sat else OMode.AP_WRAP)
+        frac = [
+            frac_value_quant(s, acc_frac, out_frac, out_bw, q_rnd, o_sat) for s in src
+        ]
+        np.testing.assert_array_equal(
+            np.asarray(out[comp]), hw
+        )  # int-domain shift/round/sat
+        np.testing.assert_array_equal(
+            np.asarray(out[comp]), frac
+        )  # value-domain quantize
 
 
 # --- format derivation: independent hand-derived algebra ----------------------
-def _expected_acc(data_bw, int_bits, b_one, b_conj, c_zero, reduce_rows, n_rows):
+def _expected_acc(op, reduce, data_bw, int_bits, n_rows):
     """Independent (W, I) accumulator-format derivation (complex), the rules by hand."""
-    def mul(A, B):                                       # cmult: +1 int bit (sub_format)
+
+    def mul(A, B):  # cmult: +1 int bit (sub_format)
         return (A[0] + B[0] + 1, A[1] + B[1] + 1)
 
-    def add(A, B):                                       # aligned add (+1 int bit)
+    def add(A, B):  # aligned add (+1 int bit)
         frac = max(A[0] - A[1], B[0] - B[1])
         ints = max(A[1], B[1]) + 1
         return (ints + frac, ints)
 
     in_f = (data_bw, int_bits)
-    if b_one:
-        ab = in_f
-    else:
-        op_b = (data_bw + 1, int_bits + 1) if b_conj else in_f   # conj = sub_format(in, in)
-        ab = mul(in_f, op_b)
-    acc = mul(in_f, ab)
-    if not c_zero:
-        acc = add(acc, mul(in_f, in_f))
-    if reduce_rows:
-        growth = (n_rows - 1).bit_length()               # ceil(log2 n_rows)
+    if op is OpCode.scalar_mult:
+        acc = mul(in_f, in_f)
+    elif op is OpCode.inner_prod:
+        acc = mul(
+            in_f, (data_bw + 1, int_bits + 1)
+        )  # conj = sub_format(in, in) -> (W+1, I+1)
+    else:  # sum
+        acc = add(in_f, in_f)
+    if reduce:
+        growth = (n_rows - 1).bit_length()  # ceil(log2 n_rows)
         acc = (acc[0] + growth, acc[1] + growth)
     return acc
 
 
-_FLAG_COMBOS = [
-    dict(b_one=0, b_conj=0, c_zero=0, reduce_rows=0),
-    dict(b_one=1, b_conj=0, c_zero=0, reduce_rows=0),
-    dict(b_one=0, b_conj=0, c_zero=1, reduce_rows=0),
-    dict(b_one=1, b_conj=0, c_zero=1, reduce_rows=1),
-    dict(b_one=0, b_conj=1, c_zero=1, reduce_rows=1),
-    dict(b_one=0, b_conj=1, c_zero=0, reduce_rows=0),
-    dict(b_one=0, b_conj=0, c_zero=0, reduce_rows=1),
+_OP_COMBOS = [
+    (OpCode.scalar_mult, 0),
+    (OpCode.scalar_mult, 1),
+    (OpCode.inner_prod, 0),
+    (OpCode.inner_prod, 1),
+    (OpCode.sum, 0),
+    (OpCode.sum, 1),
 ]
 
 
-@pytest.mark.parametrize("flags", _FLAG_COMBOS)
+@pytest.mark.parametrize("op,reduce", _OP_COMBOS)
 @pytest.mark.parametrize("data_bw,int_bits,n_rows", [(8, 4, 5), (12, 8, 8), (6, 3, 4)])
-def test_accumulator_format_matches_hand_derivation(flags, data_bw, int_bits, n_rows):
-    accel = VmacAccel(mem_dwidth=512, mem_awidth=32, data_bw=data_bw,
-                      int_bits=int_bits, acc_bw=128, out_bw=data_bw)
+def test_accumulator_format_matches_hand_derivation(
+    op, reduce, data_bw, int_bits, n_rows
+):
+    accel = VmacAccel(
+        mem_dwidth=512,
+        mem_awidth=32,
+        data_bw=data_bw,
+        int_bits=int_bits,
+        acc_bw=128,
+        out_bw=data_bw,
+    )
     cmd = accel.Cmd()
-    cmd.n_rows, cmd.n_cols = n_rows, 2
-    for k, v in flags.items():
-        setattr(cmd, k, v)
+    cmd.op, cmd.reduce, cmd.n_rows, cmd.n_cols = op, reduce, n_rows, 2
     acc = accel.accumulator_format(cmd)
-    exp_W, exp_I = _expected_acc(data_bw, int_bits, **flags, n_rows=n_rows)
+    exp_W, exp_I = _expected_acc(op, reduce, data_bw, int_bits, n_rows)
     assert (acc.W, acc.int_bits) == (exp_W, exp_I)
     assert acc.signed is True
-    assert acc.frac_bits == (2 if flags["b_one"] else 3) * (data_bw - int_bits)  # F = depth·F_in
+    depth = 1 if op is OpCode.sum else 2  # F_acc = depth · F_in
+    assert acc.frac_bits == depth * (data_bw - int_bits)
 
 
 def test_output_format_structural_scale_and_codegen_target():
     # F_out = F_in (structural); derived shift = F_acc - F_in.
-    accel = VmacAccel(mem_dwidth=512, mem_awidth=32, data_bw=8, int_bits=4, acc_bw=64, out_bw=12)
+    accel = VmacAccel(
+        mem_dwidth=512, mem_awidth=32, data_bw=8, int_bits=4, acc_bw=64, out_bw=12
+    )
     cmd = accel.Cmd()
-    cmd.n_rows, cmd.n_cols = 4, 2
-    cmd.b_one, cmd.c_zero = 0, 1                          # F_acc = 3·4 = 12 (complex)
+    cmd.op, cmd.reduce, cmd.n_rows, cmd.n_cols = (
+        OpCode.inner_prod,
+        0,
+        4,
+        2,
+    )  # F_acc = 2·4 = 8
     acc = accel.accumulator_format(cmd)
     out = accel.output_format(cmd)
     f_in = int(accel.data_bw) - int(accel.int_bits)
-    assert out.get_format().frac_bits == f_in                       # F_out = F_in (structural)
-    assert out.int_bits == accel.out_bw - f_in                      # I_out = out_bw - F_in
-    assert accel.derived_shift(cmd) == acc.frac_bits - f_in         # SHIFT = F_acc - F_in
+    assert out.get_format().frac_bits == f_in  # F_out = F_in (structural)
+    assert out.int_bits == accel.out_bw - f_in  # I_out = out_bw - F_in
+    assert accel.derived_shift(cmd) == acc.frac_bits - f_in  # SHIFT = F_acc - F_in
     assert out.get_bitwidth() == accel.out_bw
-    assert out.cpp_type == f"ap_fixed<12, {out.int_bits}, AP_TRN, AP_WRAP>"   # Phase-3 target
+    assert (
+        out.cpp_type == f"ap_fixed<12, {out.int_bits}, AP_TRN, AP_WRAP>"
+    )  # codegen target
+
+
+def test_sum_derived_shift_is_zero():
+    # sum: F_acc = F_in, so the requantize is a pure narrow (no shift), just round/saturate.
+    accel = VmacAccel(
+        mem_dwidth=512, mem_awidth=32, data_bw=8, int_bits=4, acc_bw=48, out_bw=8
+    )
+    cmd = accel.Cmd()
+    cmd.op, cmd.reduce, cmd.n_rows, cmd.n_cols = OpCode.sum, 0, 4, 2
+    assert accel.derived_shift(cmd) == 0
 
 
 def test_accumulator_format_matches_execute_invariant():
     # execute() asserts (and would raise) if the derived accumulator format disagrees with
     # the operator-composed actual; a passing run proves the two coincide.
-    got, exp = run(_cfg(in_bw=8, int_bits=4, out_bw=8, b_conj=1, reduce_rows=1),
-                   _pair([[3, -4]], [[1, 2]]), _pair([[2, 1]], [[-1, 1]]),
-                   _pair([[0, 0]], [[0, 0]]), _pair(16, 0), _pair(0, 0))
+    got, exp = run(
+        _cfg(op=OpCode.inner_prod, reduce=1, in_bw=8, int_bits=4, out_bw=8),
+        _pair([[3, -4]], [[1, 2]]),
+        _pair([[2, 1]], [[-1, 1]]),
+        _pair(16, 0),
+    )
     np.testing.assert_array_equal(got[0], exp[0])
     np.testing.assert_array_equal(got[1], exp[1])
 
@@ -216,34 +263,44 @@ def test_width_sweep_matches_oracle(data_bw, int_bits, out_bw, acc_bw, q_rnd, o_
     def op():
         return _pair(_rand(rng, data_bw, (n, m)), _rand(rng, data_bw, (n, m)))
 
-    aimm, bimm = (8, -4), (-6, 3)               # immediates must fit data_bw
-    base = dict(in_bw=data_bw, int_bits=int_bits, out_bw=out_bw, acc_bw=acc_bw,
-                q_rnd=q_rnd, o_sat=o_sat)
-    for flags in ({"c_zero": 1}, {}, {"b_one": 1}, {"reduce_rows": 1, "c_zero": 1},
-                  {"b_conj": 1, "c_zero": 1, "reduce_rows": 1}):
-        cfg = _cfg(**base, **flags)
-        got, exp = run(cfg, op(), op(), op(), _pair(*aimm), _pair(*bimm))
-        np.testing.assert_array_equal(got[0], exp[0], err_msg=f"re {cfg} {flags}")
-        np.testing.assert_array_equal(got[1], exp[1], err_msg=f"im {cfg} {flags}")
+    a, b = op(), op()
+    alpha = _pair(8, -4)  # immediate must fit data_bw
+    base = dict(
+        in_bw=data_bw,
+        int_bits=int_bits,
+        out_bw=out_bw,
+        acc_bw=acc_bw,
+        q_rnd=q_rnd,
+        o_sat=o_sat,
+    )
+    for opcode in (OpCode.scalar_mult, OpCode.inner_prod, OpCode.sum):
+        for reduce in (0, 1):
+            cfg = _cfg(op=opcode, reduce=reduce, **base)
+            got, exp = run(cfg, a, b, alpha)
+            np.testing.assert_array_equal(got[0], exp[0], err_msg=f"re {cfg}")
+            np.testing.assert_array_equal(got[1], exp[1], err_msg=f"im {cfg}")
 
 
 # --- fail-loud guards ---------------------------------------------------------
 def _accel(**kw):
-    base = dict(mem_dwidth=512, mem_awidth=32, data_bw=8, int_bits=4, acc_bw=64, out_bw=8)
+    base = dict(
+        mem_dwidth=512, mem_awidth=32, data_bw=8, int_bits=4, acc_bw=64, out_bw=8
+    )
     base.update(kw)
     return VmacAccel(**base)
 
 
-def _cmd(accel, *, b_one=0, c_zero=1, reduce_rows=0, n_rows=4):
+def _cmd(accel, *, op=OpCode.inner_prod, reduce=0, n_rows=4):
     cmd = accel.Cmd()
-    cmd.n_rows, cmd.n_cols = n_rows, 2
-    cmd.b_one, cmd.c_zero, cmd.reduce_rows = b_one, c_zero, reduce_rows
+    cmd.op, cmd.reduce, cmd.n_rows, cmd.n_cols = op, reduce, n_rows, 2
     return cmd
 
 
 def test_failloud_acc_bw_too_small():
-    accel = _accel(data_bw=8, int_bits=4, acc_bw=10, out_bw=8)   # full-MAC acc ~ 25 bits > 10
-    cmd = _cmd(accel, b_one=0, c_zero=0)
+    accel = _accel(
+        data_bw=8, int_bits=4, acc_bw=10, out_bw=8
+    )  # inner_prod acc ~ 18 bits > 10
+    cmd = _cmd(accel, op=OpCode.inner_prod)
     with pytest.raises(ValueError, match="exceeds acc_bw"):
         accel.output_format(cmd)
 
@@ -251,20 +308,18 @@ def test_failloud_acc_bw_too_small():
 def test_failloud_out_bw_too_small_for_fraction():
     # F_in = data_bw - int_bits = 8; out_bw = 4 < F_in -> I_out < 0.
     accel = _accel(data_bw=8, int_bits=0, acc_bw=64, out_bw=4)
-    cmd = _cmd(accel, b_one=1)
+    cmd = _cmd(accel, op=OpCode.sum)
     with pytest.raises(ValueError, match="too small"):
         accel.output_format(cmd)
 
 
 def test_failloud_propagates_through_execute():
     accel = _accel(data_bw=8, int_bits=4, acc_bw=10, out_bw=8)
-    cmd = _cmd(accel, b_one=0, c_zero=0)
-    mem = np.zeros(256, dtype=np.int64)
+    cmd = _cmd(accel, op=OpCode.inner_prod)
     cmd.a = {"addr": 0, "row_stride": 2}
     cmd.b = {"addr": 8, "row_stride": 2}
-    cmd.c = {"addr": 16, "row_stride": 2}
-    cmd.d = {"addr": 24, "row_stride": 2}
-    cmd.alpha = {"direct": 1, "re": 1, "im": 0, "addr": 0, "stride": 0}
-    cmd.beta = {"direct": 1, "re": 1, "im": 0, "addr": 0, "stride": 0}
+    cmd.y = {"addr": 16, "row_stride": 2}
+    cmd.alpha = {"direct": 1, "imm": (16, 0), "addr": 0, "stride": 0}
+    mem = cx.make_complex(np.zeros(64), np.zeros(64), Format(8, 4, True))
     with pytest.raises(ValueError, match="exceeds acc_bw"):
         accel.execute(cmd, mem)


### PR DESCRIPTION
Replaces VMAC's general fused op `D = α·A·op(B) + β·C [reduce]` with three named **element-wise** complex ops plus an optional row reduce — sufficient for the conjugate-gradient demonstrator, a cleaner reusable primitive, and a much simpler kernel.

## The op model
- `scalar_mult`: `Y[i,j] = α[i]·A[i,j]` (per-row scalar)
- `inner_prod`:  `Y[i,j] = A[i,j]·conj(B[i,j])`
- `sum`:         `Y[i,j] = A[i,j] + B[i,j]`
- optional `reduce`: `Y[j] = Σ_i R[i,j]` (reduce over rows)

CG coverage: `inner_prod + reduce` = the complex contraction; `scalar_mult` = vector scale; `sum` (with sign-folded α) = the residual update.

## Implementation
- **One multiplier, source-selected `right_term`**: `scalar_mult` / `inner_prod` share the `PF` complex multipliers (right operand = α broadcast / `conj(B)`); `sum` is the add path.
- **Operands via the fused `read_array_lane` loop** (running word pointer) — the latency-hidden canonical loop, so throughput scales with bus width. `read_array_slice` is used only for the per-row `α[i]` (read once per row, out of the hot loop).
- Complex-typed datapath end-to-end (`complex_utils` cmult/cadd/conj/cwiden/cx_requantize); the requantize shift is derived from the op + structural format.
- New `OpCode` command schema drops `C` / `β` / `b_one` / `c_zero` / `b_conj`.

## Verification (Vitis HLS 2025.1)
- **csim 60/60 bit-exact** vs the new golden — every op × {reduce, no-reduce} × {direct, indirect} α × pf ∈ {1,2,4} × {trn/rnd, wrap/sat}.
- **cosim** (8×64 inner_prod): pf 1/2/4 → 13373 / 6445 / 3246 cycles = 1.0× / 2.07× / 4.12× (near-ideal bus-width scaling).
- Golden validated against an independent `Fraction` oracle (non-Vitis suite green); complex conformance 47/47; non-Vitis baseline unchanged.

The general fused-op kernel is preserved at tag `vmac-general-fused` for recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)