### PR TITLE
VMAC: static_assert power-of-two PF in elem_to_word

### DIFF
--- a/examples/vmac/vmac_compute_impl.tpp
+++ b/examples/vmac/vmac_compute_impl.tpp
@@ -53,12 +53,17 @@ static const int VMAC_OP_INNER_PROD = 1;
 static const int VMAC_OP_SUM = 2;
 
 // Map an *element* index/stride to its *word* index for PF-packed memory (PF elements/word):
-// the divide is a shift (PF is a compile-time power of two), with a PF-alignment check — the
-// per-row operand regions (bases + strides) must be word-aligned.  (The per-row indirect alpha
-// is genuinely element-addressed and is read via read_array_slice, not this aligned helper.)
+// elem / PF — a shift when PF is a power of two (a static_assert enforces that, so a non-power-
+// of-two config fails loud at compile time rather than silently synthesizing a real divider),
+// plus a PF-alignment check — the per-row operand regions (bases + strides) must be word-aligned.
+// (The per-row indirect alpha is genuinely element-addressed and is read via read_array_slice,
+// not this aligned helper.)
 template <int PF, typename T>
 static inline T elem_to_word(T elem) {
 #pragma HLS INLINE
+    static_assert(PF > 0 && (PF & (PF - 1)) == 0,
+                  "VMAC requires a power-of-two PF (MEM_BW / element_bits) so the element->word "
+                  "map is a shift; a non-power-of-two PF would synthesize a real hardware divider.");
     assert(elem % PF == 0 && "VMAC operand region must be PF-aligned (word-packed rows)");
     return elem / PF;
 }


### PR DESCRIPTION
Follow-up to the VMAC three-op redesign (#79). The `elem_to_word` helper maps an element index/stride to a word index for PF-packed memory via `elem / PF`. That synthesizes to a free shift **only when PF is a power of two**; for a non-power-of-two PF (e.g. a 12-bit complex element on a 72-bit bus → PF=3) it would silently become a real multi-cycle hardware divider.

`PF = MEM_BW / element_bits` is not guaranteed power-of-two, so make the assumption explicit:

- **`static_assert(PF > 0 && (PF & (PF - 1)) == 0, …)`** in `elem_to_word` — a non-power-of-two config now fails loud at compile time instead of quietly synthesizing a divider.
- Comment made honest ("a shift when PF is a power of two … fails loud rather than synthesizing a real divider").

Closes the remaining `vmac_cleanup` item 10 caveat. Note this is the operand-row addressing only — the per-row indirect `α[i]` already uses the division-free `read_array_slice`.

**No behavior change** — csim **60/60 bit-exact** (all current configs have PF ∈ {1,2,4,16}, which pass the assert). Doc/guard only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)