### PR TITLE
docs: serialization reference + vectorization pages on the lane/slice API (Phase 3)

### DIFF
--- a/docs/guide/schema/serialization.md
+++ b/docs/guide/schema/serialization.md
@@ -6,102 +6,155 @@ nav_order: 8
 
 # Serialization & Deserialization
 
-A central property of Waveflow is that every schema knows how to **serialize** itself — to convert
-its value to and from a flat sequence of fixed-width words — and that the *same* packing rule is
-generated for Python (simulation, golden vectors) and for C++ (the synthesizable kernel). Because
-both sides are generated from one definition, they agree bit-for-bit.
+Every schema knows how to **serialize** itself — convert its value to and from a flat sequence of
+fixed-width words — and the *same* packing rule is generated for Python (simulation, golden vectors) and for
+C++ (the synthesizable kernel), so the two agree **bit-for-bit**.
 
-This page explains the packing model and the generated methods. For *what files and classes* are
-generated, see [Code Generation](./codegen.md); for *vectorized arrays* in a kernel — the packing
-factor, lanes, and the throughput loop — see the Vitis vectorization guide
-([raw](../vectorization/vitis_raw.md) / [struct](../vectorization/vitis_struct.md) /
-[complex](../vectorization/vitis_complex.md)).
+This page is the **methods reference**: the calls for moving a single schema, and an array of schemas, over
+each interface. For the *why* (the lane loop in depth, with-vs-without pipelining, the pragmas, storage
+modes), see the linked vectorization pages.
 
 ## The channel and the word width
 
-Hardware moves data over a **channel** — an AXI-Stream, an `m_axi` memory port, a FIFO — whose data
-path is some fixed width `word_bw` (e.g. 32, 64, 512). Serialization lays a schema value out into
-`ap_uint<word_bw>` words for that channel; deserialization reads it back.
+Data moves over a **channel** — an AXI-Stream, an `m_axi` memory port, a FIFO — of some fixed width
+`word_bw`. Bits pack **LSB-first, no padding**, so the layout is independent of `word_bw` — only where the
+word *boundaries* fall changes. A value of `B` bits occupies `n_words = ⌈B / word_bw⌉` words.
 
-Crucially, `word_bw` is a property of the **channel**, not of the data: it may be **larger or
-smaller** than the schema. Bits are packed **least-significant-bit first, with no padding**, so the
-layout is independent of `word_bw` — only where the word *boundaries* fall changes. The number of
-words a value of `B` bits occupies is:
+For an **array**, several elements share a word: `pf = ⌊word_bw / element_bits⌋` of them, each a **lane**. So
+`word_bw` is a *parallelism* knob (process `pf` lanes/cycle), not just a transfer-time knob. The two geometry
+constants:
 
-```
-n_words = ceil(B / word_bw)
-```
-
-## Serializing a schema over an interface
-
-Take the `PolyCmdHdr` command header from [Code Generation](./codegen.md):
-
-```python
-class PolyCmdHdr(DataList):
-    elements = {
-        "cmd_type": {"schema": PolyCmdTypeField, "description": "DATA or END"},   #  1 bit
-        "tx_id":    {"schema": TxIdField,         "description": "Transaction ID"}, # 16 bits
-        "nsamp":    {"schema": NsampField,        "description": "Sample count"},   # 16 bits
-    }
+```cpp
+au::pf<WORD_BW>()            // elements per word (lanes)
+au::get_nwords<WORD_BW>(N)   // words occupied by N elements
 ```
 
-The generated `poly_cmd_hdr.h` gives the struct a set of **templated serialize/deserialize methods**,
-one pair per kind of interface. Each is templated on the channel width `word_bw`:
+## (1) A single schema — across interfaces
 
-| Interface | Serialize / Deserialize | Backing channel |
+The generated struct has **one read/write pair per interface**, each templated on the channel width `W`
+(`= word_bw`). The schema's total bit width is the compile-time constant **`<Schema>::bitwidth`** (`B`), and
+a value spans `⌈B/W⌉` words.
+
+| Interface | Read | Write |
 |---|---|---|
-| Packed integer | `pack_to_uint` / `unpack_from_uint` | the whole schema as one `ap_uint<bitwidth>` |
-| Memory (`m_axi`) | `write_array<word_bw>` / `read_array<word_bw>` | an `ap_uint<word_bw>` array in external memory |
-| FIFO stream | `write_stream<word_bw>` / `read_stream<word_bw>` | an `hls::stream<ap_uint<word_bw>>` |
-| AXI4-Stream | `write_axi4_stream<word_bw>` / `read_axi4_stream<word_bw>` | a stream with `TLAST` framing |
-
-For example, a producer serializes a header onto an AXI-Stream and a consumer deserializes it back —
-bit-for-bit identical, and identical to what the Python model produces:
+| Packed integer | `unpack_from_uint(u)` | `pack_to_uint()` |
+| Memory (`m_axi`) | `read_array<W>(words)` | `write_array<W>(words)` |
+| FIFO stream | `read_stream<W>(s)` | `write_stream<W>(s)` |
+| AXI4-Stream | `read_axi4_stream<W>(s, tl)` | `write_axi4_stream<W>(s, /*tlast=*/...)` |
 
 ```cpp
 #include "include/poly_cmd_hdr.h"
-static const int WORD_BW = 32;
+PolyCmdHdr hdr; hdr.tx_id = 42; hdr.nsamp = 1024;
+hdr.write_axi4_stream<32>(out_stream, /*tlast=*/false);   // serialize onto a stream
 
-// producer: serialize a header onto the stream
-PolyCmdHdr hdr;
-hdr.cmd_type = PolyCmdType::DATA;
-hdr.tx_id    = 42;
-hdr.nsamp    = 1024;
-hdr.write_axi4_stream<WORD_BW>(out_stream, /*tlast=*/false);
-
-// consumer: deserialize it back off the stream
-PolyCmdHdr rx;
-streamutils::tlast_status tl;
-rx.read_axi4_stream<WORD_BW>(in_stream, tl);   // rx == hdr
+PolyCmdHdr rx; streamutils::tlast_status tl;
+rx.read_axi4_stream<32>(in_stream, tl);                   // rx == hdr, bit-for-bit
 ```
 
-Switching the channel to a different width is a one-constant change to `WORD_BW`; the packing rule
-(and the agreement with the Python golden) is invariant.
+Switching the channel width is a one-constant change to `W`; the packing rule (and agreement with the Python
+golden) is invariant.
 
-### How `word_bw` sets the transfer time
+- **Argument types.** `words` is an `ap_uint<W> words[nwords]` array; `s` is the channel's `hls::stream`.
+- **Word count.** Size `words` with **`<Schema>::nwords<W>()`** (`= ⌈B/W⌉`).
+- **Packed-integer limit.** `pack_to_uint` / `unpack_from_uint` move the whole schema as one **`ap_uint<B>`**.
+  Vitis HLS caps `ap_uint` at **8192 bits**, so for `B > 8192` the packed form is unavailable — use the
+  memory or stream methods instead.
 
-Because a stream moves one word per cycle, the channel width directly sets how long a value takes to
-transfer. `PolyCmdHdr` is `B = 33` bits (1 + 16 + 16), so:
+## (2) An array of schemas — across interfaces
 
-| `word_bw` | `n_words = ⌈33 / word_bw⌉` | cycles to transfer |
+Array packing is generated as `<element>_array_utils::` free functions, keyed on the **element type**. The
+caller works entirely in **element coordinates** — the methods do the word/lane mapping, the alignment, and
+the partial-word ends internally, so there is **no manual `÷PF` or `& (PF-1)`** in kernel code.
+
+### Geometry
+
+- **`pf<W>()`** — elements per word; **`0`** when the element is wider than the word.
+- **`lane_capacity<W>()`** — `= max(1, pf)`, the **lane-buffer size and loop step** (call it `LW`): it is `pf`
+  in the vectorized regime and `1` in the wide-element regime.
+- **`get_nwords<W>(N)`** — words occupied by `N` elements (`1` for one vectorized word; `⌈elem/W⌉` for one
+  wide element).
+
+### The lane methods — the sequential workhorse (all interfaces)
+
+Each call reads/writes the **next `LW = max(1, pf)` elements**, regardless of regime:
+
+| Read | Write | Channel |
 |---|---|---|
-| 32 | 2 | 2 |
-| 64 | 1 | 1 |
+| `read_array_lane<W>(src, dst, n)` | `write_array_lane<W>(src, dst, n)` | memory — a word pointer |
+| `read_stream_lane<W>(s, dst, n)` | `write_stream_lane<W>(src, s, n)` | FIFO stream |
+| `read_axi4_stream_lane<W>(s, dst, n, tl)` | `write_axi4_stream_lane<W>(src, s, tlast, n)` | AXI4-Stream (`TLAST`) |
 
-The 33rd bit spills past a 32-bit word, so a 32-bit channel needs two words while a 64-bit channel
-fits the header in one — halving the transfer time. For wider schemas (or arrays) the saving scales
-with the word count.
+- **`dst` is a buffer of length `LW`.** One call moves `LW` elements:
+  - **`pf ≥ 1` (`LW = pf`):** one word/beat → `pf` lanes; **`n`** (`1 ≤ n ≤ LW`) is the **valid count** — `pf`
+    for a full word, fewer only for the final partial one.
+  - **`pf = 0` (`LW = 1`, wide element):** one element spanning `⌈elem/W⌉` words/beats → `dst[0]`; **`n` is
+    ignored** (it is always 1).
+- **Memory** is positioned by the caller: after each call advance the pointer by `get_nwords<W>(LW)` words
+  (`1` when `pf ≥ 1`, `⌈elem/W⌉` when `pf = 0`). **Streams** sequence themselves — nothing to advance.
 
-## Arrays add a second dimension: lanes
+### Random range (memory only) — `read_array_slice`
 
-When the schema is a [`DataArray`](./dataarrays.md), serialization packs **multiple elements per
-word** — `pf = word_bw / element_bits` of them, each a *lane*. That turns the channel width into a
-*parallelism* knob, not just a transfer-time knob: a kernel can process all `pf` lanes per cycle. The
-packing factor, the lane loop, and the unrolling pragmas are covered in the Vitis vectorization guide,
-starting with [raw arrays](../vectorization/vitis_raw.md).
+For an **arbitrary element range** `[i0, i1)` — random access, a mid-array start, a strided row — use
+`read_array_slice`; it locates `i0`'s word for you, so the kernel never writes `i0/PF`:
+
+- **`read_array_slice<W>(words, i0, i1, out)`** — read elements `[i0, i1)` into `out[0 .. i1-i0)`.
+  Division-free (a running offset + a wrapping lane counter, correct for any `pf`), handling partial-word ends
+  *and* wide elements internally. The whole array is `[0, N)`; overload **`read_array_slice<W>(words, out)`**
+  for a statically-sized `out`. Write: **`write_array_slice<W>(in, words, i0, i1)`** — unaligned ends
+  read-modify-write the shared boundary words.
+- `words` is an `ap_uint<W>*` — an **`m_axi` port** *or* a **local BRAM array**; word-indexed (`words[k]` =
+  the k-th `W`-bit word, not a byte offset), lowering to bursts or local reads respectively, so one kernel
+  body serves both.
+
+### The canonical loop — one shape, both regimes, stream or memory
+
+Step by `LW`; the lane method delivers `LW` elements whether they are `pf` lanes of a word or one wide element:
+
+```cpp
+namespace au = cfixed_array_utils;
+static const int PF = au::pf<WORD_BW>();              // 0 if element wider than word
+static const int LW = au::lane_capacity<WORD_BW>();   // = max(1, PF): elements per step and per buffer
+
+au::value_type x_lane[LW], y_lane[LW];
+#pragma HLS ARRAY_PARTITION variable=x_lane complete dim=1
+#pragma HLS ARRAY_PARTITION variable=y_lane complete dim=1
+const int WPU = au::get_nwords<WORD_BW>(LW);          // words per step (memory only; streams self-advance)
+const ap_uint<WORD_BW>* xp = x_words;                 // running pointers (memory only)
+ap_uint<WORD_BW>*       yp = y_words;
+
+for (int i = 0; i < N; i += LW) {
+#pragma HLS PIPELINE II=1                              // II=1 when PF>=1; HLS relaxes it for wide elements
+    const int n = (N - i < LW) ? (N - i) : LW;        // valid this step
+    au::read_array_lane<WORD_BW>(xp, x_lane, n);       // LW elements in   (read_stream_lane(s_in, ...) for a stream)
+    for (int k = 0; k < LW; ++k) {
+#pragma HLS UNROLL
+        if (k < n) y_lane[k] = f(x_lane[k]);          // one element per lane
+    }
+    au::write_array_lane<WORD_BW>(y_lane, yp, n);      // LW elements out
+    xp += WPU; yp += WPU;                             // memory only — drop for streams
+}
+```
+
+The regime **falls out of `LW`** — no branch, no `i0/PF`, no `PF == 0` special case:
+
+- **`PF ≥ 1`:** `LW = PF`, `WPU = 1`, `II = 1` → `PF` elements per cycle.
+- **`PF = 0`:** `LW = 1`, `WPU = ⌈elem/W⌉`; each step pulls one wide element, so HLS relaxes `II` to `WPU` —
+  one element per `WPU` cycles, the honest cost of a wide element.
+
+For a **stream**, drop `xp`/`yp`/`WPU` and use `read_stream_lane(s_in, …)` / `write_stream_lane(…, s_out, …)`
+(or the `axi4_stream` variants with `TLAST`) — the stream sequences itself; everything else is identical. The
+three pragmas vectorize the body: `ARRAY_PARTITION complete` (lanes in parallel registers), `UNROLL` (`LW`
+parallel compute copies), `PIPELINE II=1`.
+
+**Rule of thumb.** Sequential processing (elementwise, accumulation) → the lane loop above. An arbitrary range
+or random start → `read_array_slice`. *If you find yourself writing `i0/PF` or special-casing `PF == 0` in a
+kernel, reach for `read_array_slice` (range) or `lane_capacity` (loop) instead — those exist precisely so the
+kernel never does that arithmetic.*
 
 ## See also
 
+- [Vitis: raw arrays](../vectorization/vitis_raw.md) — the lane loop in depth: **with vs without
+  pipelining**, the pragma reasoning, and wide-element (`pf = 0`) handling.
+- [Vitis: struct arrays](../vectorization/vitis_struct.md) / [complex](../vectorization/vitis_complex.md) —
+  storage modes and complex elements, with worked examples.
 - [Code Generation](./codegen.md) — the files and classes that get generated.
-- [Data Arrays](./dataarrays.md) — declaring arrays and the `struct` vs `raw` storage modes.
-- [Vitis: raw arrays](../vectorization/vitis_raw.md) — the packing factor, lanes, and throughput loop.

--- a/docs/guide/vectorization/vitis_complex.md
+++ b/docs/guide/vectorization/vitis_complex.md
@@ -39,8 +39,8 @@ CFixed = ComplexField.specialize(FixedField.specialize(16, 4, signed=True))
 dag.add(ArrayUtilsStep(CFixed, [64, 128]))    # generates <type>_array_utils.h for the complex element
 ```
 
-This emits the usual `<type>_array_utils::` namespace (`pf<>`, `read_array`/`read_array_elem`,
-`write_array`/`write_array_elem`, …) — complex elements pack/unpack like any other, re in the low
+This emits the usual `<type>_array_utils::` namespace (`pf<>` / `lane_capacity<>`, `read_array_slice` /
+`read_array_lane`, and the write/stream variants) — complex elements pack/unpack like any other, re in the low
 `data_bw` bits and im in the high `data_bw` bits of each slot. The arithmetic comes from two headers shipped
 with Waveflow:
 
@@ -58,24 +58,24 @@ just a complex element type and `complex_utils::` arithmetic. A complex multiply
 #include "complex_utils.hpp"
 namespace au = cfixed_array_utils;
 
-au::value_type a[N], b[N], y[N];           // complex elements (std::complex<ap_fixed>)
-au::read_array<WORD_BW>(a_words, a, N);
-au::read_array<WORD_BW>(b_words, b, N);
+au::value_type a[N], b[N], y[N];               // complex elements (std::complex<ap_fixed>)
+au::read_array_slice<WORD_BW>(a_words, a);     // whole array resident (static-size overload)
+au::read_array_slice<WORD_BW>(b_words, b);
 
 for (int i = 0; i < N; ++i) {
 #pragma HLS PIPELINE II=1
     y[i] = complex_utils::cmult(a[i], b[i]);   // full-precision complex multiply
 }
 
-au::write_array<WORD_BW>(y, y_words, N);
+au::write_array_slice<WORD_BW>(y, y_words, 0, N);
 ```
 
 `conj` / `cadd` / `csub` follow the same shape (`complex_utils::conj(a[i])`, etc.). Call them **qualified**
 (`complex_utils::conj`): an unqualified `conj` on a `std::complex` argument resolves to `std::conj` via ADL,
 which is not the full-precision Waveflow operator.
 
-For lane-level throughput, the [raw lane loop](./vitis_raw.md#serialization-and-deserialization-of-a-lane)
-works unchanged — `read_array_elem<WORD_BW>` delivers `pf` complex lanes per word and you unroll
+For lane-level throughput, the [raw lane loop](./vitis_raw.md#the-lane-loop)
+works unchanged — `read_array_lane<WORD_BW>` delivers `LW` complex lanes per word and you unroll
 `complex_utils::cmult` across them. Note that because a complex element is `2·data_bw` bits, a *real* array
 of the same `data_bw` packs **twice** the lanes per word — the real-vs-complex throughput difference is just
 the packing factor.
@@ -83,7 +83,7 @@ the packing factor.
 ## Worked example
 
 `examples/schemas/complex` is the bit-exact conformance: it lays operands out with `arrayutils.write_array`,
-runs `cmult` / `cadd` / `csub` / `conj` kernels built from `<type>_array_utils::read_array` +
+runs `cmult` / `cadd` / `csub` / `conj` kernels built from the `<type>_array_utils` serialization helpers +
 `complex_utils.hpp`, and checks the C++ words against the Python `DataArray[ComplexField]` model —
 bit-for-bit, on real Vitis.
 

--- a/docs/guide/vectorization/vitis_raw.md
+++ b/docs/guide/vectorization/vitis_raw.md
@@ -41,8 +41,9 @@ dag.run(cfg)
 -  `include/float32_array_utils.h` containing the class definition and helpers to be used in synthesizable code
 - `float32_array_utils_tb.h` for helpers that may not be synthesizable (like file I/O) that can the testbench. 
 
-The first file declares the `float32_array_utils::` namespace with `pf<>`, the bulk `read_array`/`write_array`, the
-per-word `read_array_elem`/`write_array_elem`, and the stream variants.
+The first file declares the `float32_array_utils::` namespace with the geometry constants
+(`pf<>` / `lane_capacity<>` / `get_nwords<>`), the element-range `read_array_slice`/`write_array_slice`, the
+per-call lane methods `read_array_lane`/`write_array_lane`, and the stream variants.
 
 The defining property of `raw` mode: **the generated code is keyed on the element type, not on a particular
 array.** There is no per-array struct — the same `float32_array_utils` helpers serve *every* `raw` array of
@@ -98,9 +99,10 @@ After we generate the include file `point_2d.hpp`:  We can obtain the parameters
 ```cpp
 #include "point_2d_array_utils.h"
 namespace point2d = point2d_array_utils;
-static constexpr int PF      = point2d::pf<WORD_BW>();           // WORD_BW / 64 (0 if WORD_BW < 64)
-static constexpr int elem_bw = point2d::value_bitwidth;         // 64
-static constexpr int wpe     = point2d::get_nwords<WORD_BW>(1);  // ceil(64 / WORD_BW): words per element
+static constexpr int PF      = point2d::pf<WORD_BW>();             // WORD_BW / 64 (0 if WORD_BW < 64)
+static constexpr int LW      = point2d::lane_capacity<WORD_BW>();  // max(1, PF): lane-buffer size + loop step
+static constexpr int elem_bw = point2d::value_bitwidth;           // 64
+static constexpr int wpe     = point2d::get_nwords<WORD_BW>(1);    // ceil(64 / WORD_BW): words per element
 ```
 
 Each `pf` element slot in a word is a **lane**. When `pf ≥ 1`, a loop that touches all `pf` lanes per cycle
@@ -120,100 +122,95 @@ per-transfer cycle cost — see [Serialization](../schema/serialization.md).)
 
 
 
-## Serialization and deserialization of a full vector
+## Reading and writing a range — `read_array_slice`
 
-Conceptually this is the same serialization described for [data schemas](../schema/serialization.md): bits
-to and from `ap_uint<WORD_BW>` words. For an array, the **bulk** helpers move the whole array in one call:
+When you want the array (or a sub-range) resident — a coefficient table loaded once, a strided row — and
+don't need cycle-level scheduling, `read_array_slice` moves an arbitrary element range `[i0, i1)` in one
+call, working entirely in **element coordinates**:
 
 ```cpp
-static const int NWORDS = au::get_nwords<WORD_BW>(N);   // packed words for N elements
-ap_uint<WORD_BW> words[NWORDS];  
 float x[N];
-au::read_array<WORD_BW>(words, x, N);    // words: const ap_uint<WORD_BW>*  → x[0..N)
-// ... compute on x ...
-au::write_array<WORD_BW>(x, words, N);   // x → words
+au::read_array_slice<WORD_BW>(x_words, x);            // whole array → x[0..N)   (static-size overload)
+au::read_array_slice<WORD_BW>(x_words, i0, i1, x);    // elements [i0, i1)  → x[0 .. i1-i0)
+au::write_array_slice<WORD_BW>(x, x_words, i0, i1);   // x → words [i0, i1)
 ```
 
-The packed word count is `get_nwords<WORD_BW>(N) = ⌈N · element_bits / WORD_BW⌉` — the array-utils helper
-that mirrors the schema-level `n_words`. The whole-array helpers are pipelined: they retire `pf` elements
-per cycle when `WORD_BW ≥ element_bits`, and one element per `words_per_elem` cycles when the element is
-wider than the word.
+It locates `i0`'s word for you and is **division-free** — a running bit offset plus a wrapping lane counter,
+correct for *any* `pf` (including non-powers-of-two, where `i / pf` and `i % pf` would otherwise synthesize as
+real hardware dividers). It handles partial-word ends and wide elements (`pf = 0`) internally, so the kernel
+never writes `i0 / pf` or `i % pf`. An unaligned `write_array_slice` read-modify-writes the shared boundary
+words rather than clobbering the neighbor elements packed beside the range.
 
-Random access into the packed words depends on how the element lines up with the word, so there is no
-single index formula:
+The packed word count for `N` elements is `get_nwords<WORD_BW>(N) = ⌈N · element_bits / WORD_BW⌉` — the
+array-utils helper that mirrors the schema-level `n_words`.
 
-- **`WORD_BW ≥ element_bits`** (and a multiple of it): element `i` is lane `i % pf` of word `⌊i / pf⌋`. A
-  slice that starts on a word boundary (`start % pf == 0`) is then just a pointer offset:
+Use `read_array_slice` when you want the data resident; when you want **throughput**, drop to the lane loop
+below.
 
-  ```cpp
-  const int pf = au::pf<WORD_BW>();
-  au::read_array<WORD_BW>(words + start / pf, x, len);   // elements [start, start+len), start % pf == 0
-  ```
+## The lane loop
 
-- **`element_bits > WORD_BW`**: element `i` occupies words `[i · words_per_elem, (i+1) · words_per_elem)`.
-
-When `WORD_BW` is not a multiple of `element_bits`, elements straddle word boundaries — compute the bit
-offset `i · element_bits` and locate the word yourself rather than relying on a per-element word index.
-
-Use the whole-array helpers when you want the array resident and don't need cycle-level scheduling (a
-coefficient table loaded once, say). When you *do* want throughput, drop to the lane primitives below.
-
-## Serialization and deserialization of a lane
-
-The lane primitives expose one word — `pf` lanes — at a time, which is what you unroll over. This is the
-pattern for the **vectorized regime** (`WORD_BW ≥ element_bits`, so `pf ≥ 1`); for a wide element (`pf = 0`)
-the loop below is invalid — use the bulk `read_array` above. Walk the array in steps of `pf`, read a word
-into a **partitioned** lane array, `UNROLL` the compute across the lanes, and write the word back. Here the
-kernel computes `y[i] = x[i] * x[i]`:
+The **lane methods** move the next `LW = lane_capacity<WORD_BW>() = max(1, pf)` elements per call — `pf`
+lanes of a word in the vectorized regime (`WORD_BW ≥ element_bits`), or one wide element spanning
+`⌈element_bits / WORD_BW⌉` words when `pf = 0`. You step the loop by `LW`, read into a **partitioned** lane
+buffer, `UNROLL` the compute across the lanes, and write back — **one shape that covers both regimes with no
+branch**. Here the kernel computes `y[i] = x[i] * x[i]`:
 
 ```cpp
 #include "float32_array_utils.h"
 namespace au = float32_array_utils;
-static const int PF = au::pf<WORD_BW>();   // >= 1 in this regime (WORD_BW >= element_bits)
+static const int PF  = au::pf<WORD_BW>();              // 0 if element wider than the word
+static const int LW  = au::lane_capacity<WORD_BW>();   // = max(1, PF): elements per step and per buffer
+const int WPU = au::get_nwords<WORD_BW>(LW);           // words advanced per step
 
-int iword = 0;                             // word index — incremented, so no per-iteration divide
-for (int i = 0; i < N; i += PF) {
+const ap_uint<WORD_BW>* xp = x_words;                  // running pointers — no per-iteration divide
+ap_uint<WORD_BW>*       yp = y_words;
+for (int i = 0; i < N; i += LW) {
 #pragma HLS PIPELINE II=1
-    float lane[PF];
+    float lane[LW];
 #pragma HLS ARRAY_PARTITION variable=lane complete dim=1     // lanes in parallel registers
-    const int n = (N - i < PF) ? (N - i) : PF;               // tail: last (partial) word
+    const int n = (N - i < LW) ? (N - i) : LW;               // tail: last (partial) word
 
-    au::read_array_elem<WORD_BW>(&x_words[iword], lane, n);  // one word → pf lanes
-    for (int k = 0; k < PF; ++k) {
+    au::read_array_lane<WORD_BW>(xp, lane, n);               // LW elements in
+    for (int k = 0; k < LW; ++k) {
 #pragma HLS UNROLL
         if (k < n) lane[k] = lane[k] * lane[k];              // one element per lane
     }
-    au::write_array_elem<WORD_BW>(lane, &y_words[iword], n); // pf lanes → one word
-    ++iword;
+    au::write_array_lane<WORD_BW>(lane, yp, n);              // LW elements out
+    xp += WPU; yp += WPU;
 }
 ```
 
 The three pragmas are what vectorize the loop:
 
-- **`ARRAY_PARTITION variable=lane complete`** — splits the lane array into `pf` registers so every lane is
+- **`ARRAY_PARTITION variable=lane complete`** — splits the lane buffer into `LW` registers so every lane is
   live in the same cycle (otherwise it is a BRAM and the `UNROLL` serializes on memory ports).
-- **`UNROLL`** — instantiates `pf` parallel copies of the compute.
-- **`PIPELINE II=1`** — issues one word (so `pf` elements) per cycle.
+- **`UNROLL`** — instantiates `LW` parallel copies of the compute.
+- **`PIPELINE II=1`** — issues one word (so `pf` elements) per cycle in the vectorized regime.
 
-The `iword` counter is a small but real win: advancing it by one word per iteration gives the address
-`&x_words[iword]` rather than `x_words + i / PF`, avoiding a per-iteration hardware divide (and the matching
-`y_words[iword]` for the output).
+The **running pointers** `xp`/`yp` are a small but real win: advancing by a constant `WPU` words per iteration
+gives the address directly, rather than `x_words + i / PF` — avoiding a per-iteration hardware divide.
+
+The same loop covers the **wide-element regime for free**: when `pf = 0`, `LW = 1` and `WPU = ⌈element_bits /
+WORD_BW⌉`, so each step pulls one element across `WPU` words and HLS relaxes `II` to `WPU` — one element per
+`WPU` cycles, the honest cost of a wide element. There is no `pf = 0` special case, and the `n` argument is
+simply ignored (`LW = 1`).
 
 Widen `WORD_BW` and `PF` rises with it; the same loop retires more elements per cycle. That is the
 bus-width → throughput relationship made concrete (and what the VMAC `mem_dwidth` sweep measures).
 
 ### Streams instead of memory
 
-For an AXI-Stream port the shape is identical, but the lane read/write use the stream variants, which also
-carry `TLAST`:
+For an AXI-Stream port the shape is identical, but you **drop the running pointers** (`xp`/`yp`/`WPU` — the
+stream sequences itself) and use the stream lane variants, which also carry `TLAST`:
 
 ```cpp
-au::read_axi4_stream_elem<WORD_BW>(s_in,  lane, n);                 // pf lanes off the stream
-au::write_axi4_stream_elem<WORD_BW>(s_out, lane, /*tlast=*/last, n);
+streamutils::tlast_status tl;
+au::read_axi4_stream_lane<WORD_BW>(s_in,  lane, n, tl);             // LW elements off the stream
+au::write_axi4_stream_lane<WORD_BW>(s_out, lane, /*tlast=*/last, n);
 ```
 
-`examples/stream_inband/poly_evaluate_impl.tpp` is the worked stream example;
-`examples/vmac/vmac_compute_impl.tpp` is the worked `m_axi` example.
+`examples/vmac/vmac_compute_impl.tpp` is the worked `m_axi` example (the lane loop above);
+`examples/stream_inband/poly_evaluate_impl.tpp` is the worked stream example.
 
 ## See also
 

--- a/docs/guide/vectorization/vitis_struct.md
+++ b/docs/guide/vectorization/vitis_struct.md
@@ -56,7 +56,7 @@ retargeting the channel width is a one-constant change, and the bytes match the 
 | | `struct` | `raw` |
 |---|---|---|
 | C++ shape | a wrapper struct (`data[N]` + methods) | a flat `elem_t[N]` |
-| Packing | hidden inside the methods | explicit (`read_array_elem` free functions) |
+| Packing | hidden inside the methods | explicit (`read_array_lane` / `read_array_slice` free functions) |
 | Lane control | no | yes — the unrolled lane loop |
 | Best for | a field of a schema, a port payload, whole-array I/O | throughput kernels, per-cycle lane scheduling |
 


### PR DESCRIPTION
Phase 3 of the array_utils serialization redesign — landing the docs (PRs #77/#78 added the API, #79 migrated VMAC onto it).

## Changes
- **`docs/guide/schema/serialization.md`** — rewritten as the full **methods reference**: a single schema across interfaces (pack/unpack, `m_axi`, FIFO, AXI4-Stream) + the array geometry (`pf` / `lane_capacity` / `get_nwords`), the regime-agnostic lane methods, `read_array_slice` for ranges, the canonical `LW` loop, and the rule of thumb.
- **`vitis_raw.md`** — whole-vector section → `read_array_slice`; lane loop → the unified `LW = lane_capacity` loop (one shape for both `pf ≥ 1` and `pf = 0`, running pointers, streams variant), keeping the pragma / with-vs-without-pipelining teaching.
- **`vitis_struct.md`** / **`vitis_complex.md`** — method names + the lane-loop deep link updated to the new API; the complex worked example moved to `read_array_slice` / `read_array_lane`.

## Scope (docs-only — option A)
The new API (`read_array_lane` / `read_array_slice` / `lane_capacity`) is fully merged and documented here. The old `read_array_elem` / bulk `read_array` / `_stream_elem` methods still exist in the generator, and two examples (`stream_inband/poly_evaluate`, `schemas/complex`) still call them — retiring the old methods and migrating those callers is the deferred **Phase 2b** (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)