### PR TITLE
docs: reorg Vectorization into Python / HLS subsections (reorg pilot, Phase 2)

### DIFF
--- a/docs/guide/schema/hls/codegen.md
+++ b/docs/guide/schema/hls/codegen.md
@@ -113,10 +113,10 @@ dag.run(cfg)
 
 Because the helpers are keyed on the element type, the same `float32_array_utils` serves every `float`
 array. Using them in a kernel — the lane loop, with and without pipelining, and the wide-element (`pf = 0`)
-case — is covered in [Vectorization](../../vectorization/vitis_raw.md).
+case — is covered in [Vectorization](../../vectorization/hls/raw.md).
 
 ## See also
 
 - [Serialization](./serialization.md) — moving a single schema value over each interface.
-- [Vitis: raw arrays](../../vectorization/vitis_raw.md) — *using* the array utils: the lane loop and `read_array_slice`.
+- [Vitis: raw arrays](../../vectorization/hls/raw.md) — *using* the array utils: the lane loop and `read_array_slice`.
 - [Build System](../../build/) — the full `BuildDag` walkthrough.

--- a/docs/guide/schema/hls/serialization.md
+++ b/docs/guide/schema/hls/serialization.md
@@ -100,5 +100,5 @@ pipelining, and the wide-element `pf = 0` case).
 
 - [Code Generation](./codegen.md) — the files and classes that get generated for a schema.
 - [Test Data Files](./tbutils.md) — `serialize` / `deserialize` to the on-disk `uint32` exchange format.
-- [Vitis: raw arrays](../../vectorization/vitis_raw.md) — packing **arrays** of schemas: the lane loop,
+- [Vitis: raw arrays](../../vectorization/hls/raw.md) — packing **arrays** of schemas: the lane loop,
   `read_array_lane` / `read_array_slice`, and wide-element (`pf = 0`) handling.

--- a/docs/guide/schema/python/complex.md
+++ b/docs/guide/schema/python/complex.md
@@ -195,7 +195,7 @@ is never loosened. Run it with `pytest -m vitis -k complex`.
 
 - [Fixed-point (`FixedField`)](./fixpoint.md) — the integer-backed inner whose arithmetic
   `ComplexField` composes for the fixed/int case.
-- [Fixed-point vectorization](../../vectorization/fixed.md) and the
+- [Fixed-point vectorization](../../vectorization/python/fixed.md) and the
   [Vectorization](../../vectorization/) section — `DataArray` compute and result-format
   propagation (a complex-vectorization page is a planned follow-on).
 - [Data Fields and Lists](./datalists.md) — the scalar field bases and the serialization

--- a/docs/guide/schema/python/fixpoint.md
+++ b/docs/guide/schema/python/fixpoint.md
@@ -16,7 +16,7 @@ summary: "FixedField — ap_fixed-compatible fixed-point: total width, integer b
 hardware **bit-for-bit** — for quantization *and* arithmetic. It is defined in
 [`waveflow/hw/fixpoint.py`](../../../../waveflow/hw/fixpoint.py); vector operations (the
 **compute**) are covered on the
-[Fixed-point vectorization](../../vectorization/fixed.md) page in the
+[Fixed-point vectorization](../../vectorization/python/fixed.md) page in the
 [Vectorization](../../vectorization/) section.
 
 ## The `ap_fixed` model
@@ -63,7 +63,7 @@ class:
 `FixedField.specialize(W, I)` already matches the default hardware type.
 
 A single `FixedField` is a scalar; arrays use `DataArray[FixedField]` (see
-[Fixed-point vectorization](../../vectorization/fixed.md)).
+[Fixed-point vectorization](../../vectorization/python/fixed.md)).
 
 ## Quantization (`QMode`) and overflow (`OMode`) modes
 
@@ -120,7 +120,7 @@ comparison is never loosened. Run it with `pytest -m vitis -k fixedpoint`.
 
 ## See also
 
-- [Fixed-point vectorization](../../vectorization/fixed.md) — the compute:
+- [Fixed-point vectorization](../../vectorization/python/fixed.md) — the compute:
   `DataArray[FixedField]`, the `a*b + c` operators / `mult`/`add`/`quantize`,
   result-format propagation, and a worked FIR.
 - [Data Fields and Lists](./datalists.md) — the `IntField` base and serialization.

--- a/docs/guide/vectorization/hls/complex.md
+++ b/docs/guide/vectorization/hls/complex.md
@@ -1,7 +1,12 @@
 ---
 title: "Vitis: complex arrays"
-parent: Vectorization
-nav_order: 12
+parent: HLS
+grand_parent: Vectorization
+nav_order: 3
+audience: hls
+applies_to: [ComplexField]
+api: [read_array_lane, read_array_slice]
+summary: "Vectorized complex arrays in Vitis — the std::complex / wf_cint element storage and the lane loop over complex values, building on the raw-array pattern."
 ---
 
 # Vectorized arrays in Vitis — complex
@@ -9,9 +14,9 @@ nav_order: 12
 Complex samples are the workhorse of wireless signal processing — IQ data, channel estimates, beamforming
 weights. Waveflow's `ComplexField` is a first-class element type, which means **a complex array serializes
 and vectorizes through exactly the same machinery as a scalar array** — the `<type>_array_utils` helpers
-from [raw](./vitis_raw.md) / [struct](./vitis_struct.md) — with complex arithmetic supplied by a generated
+from [raw](./raw.md) / [struct](./struct.md) — with complex arithmetic supplied by a generated
 `complex_utils.hpp`. This page is the complex-specific walkthrough; for the Python-side numpy model see
-[Complex vectorization](./complex.md).
+[Complex vectorization](../python/complex.md).
 
 ## The complex element type
 
@@ -50,7 +55,7 @@ with Waveflow:
 
 ## Reading, computing, writing
 
-Because the element is first-class, the kernel is the same shape as the scalar [raw](./vitis_raw.md) case —
+Because the element is first-class, the kernel is the same shape as the scalar [raw](./raw.md) case —
 just a complex element type and `complex_utils::` arithmetic. A complex multiply over two arrays:
 
 ```cpp
@@ -74,7 +79,7 @@ au::write_array_slice<WORD_BW>(y, y_words, 0, N);
 (`complex_utils::conj`): an unqualified `conj` on a `std::complex` argument resolves to `std::conj` via ADL,
 which is not the full-precision Waveflow operator.
 
-For lane-level throughput, the [raw lane loop](./vitis_raw.md#the-lane-loop)
+For lane-level throughput, the [raw lane loop](./raw.md#the-lane-loop)
 works unchanged — `read_array_lane<WORD_BW>` delivers `LW` complex lanes per word and you unroll
 `complex_utils::cmult` across them. Note that because a complex element is `2·data_bw` bits, a *real* array
 of the same `data_bw` packs **twice** the lanes per word — the real-vs-complex throughput difference is just
@@ -89,6 +94,6 @@ bit-for-bit, on real Vitis.
 
 ## See also
 
-- [Complex vectorization](./complex.md) — the Python-side numpy complex model.
-- [`vitis_raw.md`](./vitis_raw.md) — the packing factor and lane loop (apply to complex unchanged).
-- [Serialization](../schema/hls/serialization.md) — the schema-level packing model.
+- [Complex vectorization](../python/complex.md) — the Python-side numpy complex model.
+- [`raw`](./raw.md) — the packing factor and lane loop (apply to complex unchanged).
+- [Serialization](../../schema/hls/serialization.md) — the schema-level packing model.

--- a/docs/guide/vectorization/hls/index.md
+++ b/docs/guide/vectorization/hls/index.md
@@ -1,0 +1,19 @@
+---
+title: HLS
+parent: Vectorization
+nav_order: 2
+has_children: true
+audience: hls
+summary: "Vectorized arrays in synthesizable Vitis C++ — the packing factor and lanes, the canonical lane loop, read_array_slice, and the raw / struct / complex storage modes."
+---
+
+# Vectorization — HLS
+
+The **HLS** side is how a `DataArray` lowers to synthesizable Vitis C++: the packing factor `pf` and
+lanes, the canonical lane loop (`read_array_lane` / `read_array_slice`), and the storage modes.
+These pages cover the three modes — [raw](./raw.md) (a flat C array, explicit per-cycle control),
+[struct](./struct.md) (a generated wrapper type), and [complex](./complex.md) (complex elements) —
+each over a *local* array.
+
+Moving an array over a real **stream or `m_axi` port** — the stream/`TLAST` variants and the
+pipelined loop patterns over a port — is detailed in [Interfaces](../../interface/).

--- a/docs/guide/vectorization/hls/raw.md
+++ b/docs/guide/vectorization/hls/raw.md
@@ -1,20 +1,24 @@
 ---
 title: "Vitis: raw arrays"
-parent: Vectorization
-nav_order: 10
+parent: HLS
+grand_parent: Vectorization
+nav_order: 1
+audience: hls
+api: [pf, lane_capacity, get_nwords, read_array_lane, write_array_lane, read_array_slice, write_array_slice]
+summary: "Vectorized arrays in raw storage — a flat C array; the packing factor and lanes, read_array_slice over a local buffer, and the canonical lane loop (with the pf=0 wide-element case)."
 ---
 
 # Vectorized arrays in Vitis — `raw` storage
 
-Just as each [data schema](../schema/hls/codegen.md) has a bit-exact Vitis C++ counterpart, so does each
+Just as each [data schema](../../schema/hls/codegen.md) has a bit-exact Vitis C++ counterpart, so does each
 `DataArray`: Waveflow generates the include files and helper methods that let a synthesizable kernel
 manipulate the array — pack it, unpack it, process it lane-by-lane — using the *same* layout the Python
 model uses.
 
-A `DataArray` lowers to C++ in one of two **storage modes** (see [Data Arrays](../schema/python/dataarrays.md)).
+A `DataArray` lowers to C++ in one of two **storage modes** (see [Data Arrays](../../schema/python/dataarrays.md)).
 This page covers **`raw` mode** — a flat C array — the one you reach for when you want explicit, per-cycle
-control of the vectorized loop. The [`struct`](./vitis_struct.md) mode (a wrapper with methods) and the
-[`complex`](./vitis_complex.md) element are covered separately.
+control of the vectorized loop. The [`struct`](./struct.md) mode (a wrapper with methods) and the
+[`complex`](./complex.md) element are covered separately.
 
 ## Code generation in `raw` mode
 
@@ -47,7 +51,7 @@ per-call lane methods `read_array_lane`/`write_array_lane`, and the stream varia
 
 The defining property of `raw` mode: **the generated code is keyed on the element type, not on a particular
 array.** There is no per-array struct — the same `float32_array_utils` helpers serve *every* `raw` array of
-`float` elements, of any length. (The [`struct`](./vitis_struct.md) mode is the opposite: it generates a
+`float` elements, of any length. (The [`struct`](./struct.md) mode is the opposite: it generates a
 wrapper type per array.)
 
 ## Declaring vectors in C++
@@ -55,7 +59,7 @@ wrapper type per array.)
 Once the header files are generated, any Vitis C++ function can write code using these helpers.
 Th Vitis HLS equivalent of the `raw` array is simply a flat C array of the element's `value_type`. (On the Python side this is
 `cpp_storage="raw"`, which requires `static=True` and a 1-D shape — see
-[Data Arrays](../schema/python/dataarrays.md).) In a kernel you declare it directly:
+[Data Arrays](../../schema/python/dataarrays.md).) In a kernel you declare it directly:
 
 ```cpp
 #include "float32_array_utils.h"
@@ -70,7 +74,7 @@ element type in Python, regenerate, and the C++ follows.
 
 ## Packing factors
 
-As discussed in the section on [serialization](../schema/hls/serialization.md),  arrays must be transferred over **channels**, such as AXI4-streams, or memory-mapped interfaces.  These channels may have **word bitwidth**, typically denoted `word_bw`, that may be larger or smaller than the bitwidth of each element of the array.  The generated include files provide methods to **serialize** and **deserialize** arrays of elements over channels of any width. 
+As discussed in the section on [serialization](../../schema/hls/serialization.md),  arrays must be transferred over **channels**, such as AXI4-streams, or memory-mapped interfaces.  These channels may have **word bitwidth**, typically denoted `word_bw`, that may be larger or smaller than the bitwidth of each element of the array.  The generated include files provide methods to **serialize** and **deserialize** arrays of elements over channels of any width. 
 
 Given a `word_bw`, two dual quantities describe how the elements line up with the words:
 
@@ -118,7 +122,7 @@ does `pf` elements of work per cycle — so **`WORD_BW` is the throughput lever*
 
 At `WORD_BW = 32` the element is wider than the word, so `pf` is 0 and each `Point2D` occupies two words;
 from `WORD_BW = 64` up, whole elements fit per word. (For the schema-level view — `n_words` and the
-per-transfer cycle cost — see [Serialization](../schema/hls/serialization.md).)
+per-transfer cycle cost — see [Serialization](../../schema/hls/serialization.md).)
 
 
 
@@ -200,6 +204,9 @@ bus-width → throughput relationship made concrete (and what the VMAC `mem_dwid
 
 ### Streams instead of memory
 
+> Transfer over a real stream/port — the stream/`TLAST` variants and the `m_axi`-port loop patterns — is
+> detailed in [Interfaces](../../interface/); this section is the local-buffer sketch.
+
 For an AXI-Stream port the shape is identical, but you **drop the running pointers** (`xp`/`yp`/`WPU` — the
 stream sequences itself) and use the stream lane variants, which also carry `TLAST`:
 
@@ -214,7 +221,7 @@ au::write_axi4_stream_lane<WORD_BW>(s_out, lane, /*tlast=*/last, n);
 
 ## See also
 
-- [Serialization](../schema/hls/serialization.md) — the schema-level packing model and `word_bw`.
-- [Data Arrays](../schema/python/dataarrays.md) — declaring `DataArray`, `struct` vs `raw`.
-- [`vitis_struct.md`](./vitis_struct.md) — the same packing behind a generated struct's methods.
-- [`vitis_complex.md`](./vitis_complex.md) — complex elements (wireless).
+- [Serialization](../../schema/hls/serialization.md) — the schema-level packing model and `word_bw`.
+- [Data Arrays](../../schema/python/dataarrays.md) — declaring `DataArray`, `struct` vs `raw`.
+- [`struct`](./struct.md) — the same packing behind a generated struct's methods.
+- [`complex`](./complex.md) — complex elements (wireless).

--- a/docs/guide/vectorization/hls/struct.md
+++ b/docs/guide/vectorization/hls/struct.md
@@ -1,12 +1,16 @@
 ---
 title: "Vitis: struct arrays"
-parent: Vectorization
-nav_order: 11
+parent: HLS
+grand_parent: Vectorization
+nav_order: 2
+audience: hls
+api: [read_array, write_array]
+summary: "Vectorized arrays in struct storage — a generated per-array wrapper type carrying its own packing methods, the same lane layout behind an object interface."
 ---
 
 # Vectorized arrays in Vitis — `struct` storage
 
-The default `cpp_storage` for a `DataArray` is `"struct"`. Where [`raw` mode](./vitis_raw.md) gives you a
+The default `cpp_storage` for a `DataArray` is `"struct"`. Where [`raw` mode](./raw.md) gives you a
 flat C array and the free-function packing helpers for explicit lane control, **`struct` mode wraps the
 array in a generated type whose methods do the packing for you** — the whole array in, the whole array out,
 the lanes hidden. Reach for it when the array is a *field* of a larger schema, a port payload, or an object
@@ -16,7 +20,7 @@ you pass around, and you don't need cycle-level control of the loop.
 
 A `struct`-mode `DataArray` lowers to a generated struct — a `data[N]` member plus serialization methods —
 emitted by `DataSchemaStep` as part of the schema's C++ type (the same build flow as any schema header; see
-[Code Generation](../schema/hls/codegen.md)). The element's packing still comes from `ArrayUtilsStep`: the
+[Code Generation](../../schema/hls/codegen.md)). The element's packing still comes from `ArrayUtilsStep`: the
 struct's methods **delegate to the element's `<elem>_array_utils` free functions**, so both storage modes
 share one packing implementation. A generated array struct looks like:
 
@@ -61,11 +65,11 @@ retargeting the channel width is a one-constant change, and the bytes match the 
 | Best for | a field of a schema, a port payload, whole-array I/O | throughput kernels, per-cycle lane scheduling |
 
 If you find yourself wanting to unroll across lanes (the throughput pattern), reach for
-[`raw`](./vitis_raw.md). If you just want to move an array in and out as one typed object, `struct` is the
+[`raw`](./raw.md). If you just want to move an array in and out as one typed object, `struct` is the
 simpler default.
 
 ## See also
 
-- [`vitis_raw.md`](./vitis_raw.md) — the flat array, lane loop, and throughput pattern.
-- [Serialization](../schema/hls/serialization.md) — the schema-level packing model.
-- [Data Arrays](../schema/python/dataarrays.md) — declaring `DataArray` and `cpp_storage`.
+- [`raw`](./raw.md) — the flat array, lane loop, and throughput pattern.
+- [Serialization](../../schema/hls/serialization.md) — the schema-level packing model.
+- [Data Arrays](../../schema/python/dataarrays.md) — declaring `DataArray` and `cpp_storage`.

--- a/docs/guide/vectorization/index.md
+++ b/docs/guide/vectorization/index.md
@@ -13,12 +13,15 @@ are all `ndarray`s — so a whole vector of values flows through one C-level Num
 call instead of a Python loop over elements. The numbers Waveflow computes match
 the Vitis HLS datapath **bit-for-bit**, and they are computed at NumPy speed.
 
-This page is the entry point: the selling point, the **two ways to compute** on
-array data, when to use each, and an honest framing of the tradeoff. The section
-splits in two:
+## Outline
 
-**[Python](./python/)** — the NumPy-backed value model, per element kind:
+We describe how to implement arrays in two sections:
 
+**[Python](./python/)** — defining NumPy-backed vectors in the Python model and computing on them:
+
+- [Numerical operations](./python/numerical.md) — the shared model for **every** element type:
+  defining vectors, the `.val` NumPy escape hatch, and the type-preserving operators (`a*b + c`,
+  then `quantize`).
 - [Integer vectorization](./python/integer.md) — NumPy integer arrays, growth-aware
   operators, the width-tracking caveat.
 - [Float vectorization](./python/float.md) — NumPy passthrough and golden references.
@@ -28,14 +31,14 @@ splits in two:
 - [Complex vectorization](./python/complex.md) — complex arithmetic and the
   numpy-vs-hardware multiply edge.
 
-**[HLS](./hls/)** — the generated array helpers in a synthesizable Vitis kernel (the
-schema-level packing model is in [Serialization](../schema/hls/serialization.md)):
+**[HLS](./hls/)** — Vectors can also be used in the generated Vitis HLS code using the synthesizable Vitis kernel (the
+schema-level packing model is in [Serialization](../schema/hls/serialization.md)).  These are described in three parts:
 
-- [Vitis: raw arrays](./hls/raw.md) — the flat array, packing factor, lanes, and the
+- [Raw arrays](./hls/raw.md) — the flat array, packing factor, lanes, and the
   throughput lane loop.
-- [Vitis: struct arrays](./hls/struct.md) — the generated wrapper struct's whole-array
+- [Struct arrays](./hls/struct.md) — the generated wrapper struct's whole-array
   methods.
-- [Vitis: complex arrays](./hls/complex.md) — complex elements end-to-end (the wireless
+- [Complex arrays](./hls/complex.md) — complex elements end-to-end (the wireless
   vertical).
 
 ## Why vectorization is the differentiator
@@ -62,79 +65,10 @@ Waveflow sits at the **transaction level with vectorized data**: it gives fast
 "are my bits right, fast, over a lot of data," vectorized functional sim is the
 sweet spot.
 
-## The two paths
-
-There are two ways to compute on array data, and the distinction matters most for
-fixed-point:
-
-### 1. The NumPy escape hatch — `.val`
-
-`DataArray.val` is the raw underlying `ndarray`. Reach through it and you get plain
-NumPy: maximum speed, every NumPy function available, and **you** manage the result
-width and dtype.
-
-```python
-import numpy as np
-from waveflow.hw.dataschema import DataArray, FloatField
-
-F32 = FloatField.specialize(32)
-a = DataArray.specialize(F32, max_shape=(3,))(np.array([1.5, 2.5, -3.0], np.float32))
-b = DataArray.specialize(F32, max_shape=(3,))(np.array([2.0, -1.5, 0.5], np.float32))
-
-y = a.val * b.val + 0.25          # raw numpy float32 — you own the dtype
-y                                  # array([ 3.25, -3.5 , -1.25], dtype=float32)
-```
-
-### 2. Type-preserving operators — `a*b + c`, then `quantize`
-
-The operators (`+`, `-`, `*`) on a `DataArray` are **type-preserving**: they read
-the operands' formats, run the vectorized NumPy op underneath, and **derive the
-result format** with full precision — no silent loss. They are sugar over the
-underlying `mult`/`add`/`sub` functions. Rounding back to a working format is an
-**explicit** `quantize(x, fmt)` — exactly mirroring `ap_fixed<...> y = a*b + c;` in
-HLS, where the product and sum grow to full width and the assignment is the one
-lossy step.
-
-```python
-from waveflow.hw.fixpoint import FixedField, from_real, quantize, to_real
-
-Q = FixedField.specialize(8, 4)                  # ap_fixed<8, 4>
-a = from_real([1.5, -2.0, 0.5], Q)
-b = from_real([2.0,  1.5, -1.0], Q)
-c = from_real([0.5,  0.25, -0.5], Q)
-
-full = a * b + c                                  # ap_fixed<17, 9> — full precision, no loss
-y    = quantize(full, Q)                          # ap_fixed<8, 4>  — the one explicit rounding
-to_real(y)                                        # array([ 3.5 , -2.75, -1.  ])
-```
-
-### When to use which
-
-| Path | Use it when | Cost you own |
-|------|-------------|--------------|
-| `.val` (numpy escape) | **float** math; or you genuinely want raw NumPy and will manage widths yourself | result dtype/width is on you |
-| operators + `quantize` | **fixed-point** (and growth-aware **integer**) math you want bit-exact with HLS | nothing — formats are derived, loss is explicit |
-
-The short rule:
-
-- **Float** — `.val` is fine. IEEE-754 `float32`/`float64` don't grow, so raw NumPy
-  *is* the bit-exact model; the operators are just NumPy passthrough over the same
-  arrays.
-- **Fixed-point** — use the **operators**. Fixed-point arithmetic grows bits
-  (`a*b` is `Wa+Wb` wide) and rounds on assignment; the operators track that growth
-  and keep the one rounding explicit, so your Python matches `ap_fixed` exactly.
-  Doing fixed-point by hand through `.val` means re-deriving formats and rounding
-  yourself — easy to get subtly wrong.
-- **Integer** — either works; the operators add growth-aware width tracking
-  (`a*b` → `Wa+Wb` bits, `a+b` → `+1`) with a fail-fast guard above 64 bits, which
-  raw `.val` NumPy won't give you (it silently wraps). See
-  [Integer vectorization](./python/integer.md).
-
-Both paths keep data in NumPy arrays the whole way — that's what makes the
-simulation fast. The operators just add the bit-growth bookkeeping on top.
-
 ## See also
 
+- [Numerical operations](./python/numerical.md) — the two compute paths (`.val` vs the
+  type-preserving operators) in depth.
 - [FixedField](../schema/python/fixpoint.md) — the fixed-point *type* (the `ap_fixed`
   model, `QMode`/`OMode`, defaults-match-Vitis).
 - [`examples/basic_vec`](../../examples/basic_vec/) — the worked front-door: one MAC,

--- a/docs/guide/vectorization/index.md
+++ b/docs/guide/vectorization/index.md
@@ -14,24 +14,28 @@ call instead of a Python loop over elements. The numbers Waveflow computes match
 the Vitis HLS datapath **bit-for-bit**, and they are computed at NumPy speed.
 
 This page is the entry point: the selling point, the **two ways to compute** on
-array data, when to use each, and an honest framing of the tradeoff. The per-kind
-pages drill in:
+array data, when to use each, and an honest framing of the tradeoff. The section
+splits in two:
 
-- [Integer vectorization](./integer.md) — NumPy integer arrays, growth-aware
+**[Python](./python/)** — the NumPy-backed value model, per element kind:
+
+- [Integer vectorization](./python/integer.md) — NumPy integer arrays, growth-aware
   operators, the width-tracking caveat.
-- [Float vectorization](./float.md) — NumPy passthrough and golden references.
-- [Fixed-point vectorization](./fixed.md) — full-precision `a*b + c`, one explicit
+- [Float vectorization](./python/float.md) — NumPy passthrough and golden references.
+- [Fixed-point vectorization](./python/fixed.md) — full-precision `a*b + c`, one explicit
   `quantize`, bit-exact with `ap_fixed`. (The fixed-point *type* itself is on the
   [FixedField](../schema/python/fixpoint.md) page.)
+- [Complex vectorization](./python/complex.md) — complex arithmetic and the
+  numpy-vs-hardware multiply edge.
 
-The **Vitis C++** pages cover the generated array helpers in a synthesizable kernel
-(the schema-level packing model is in [Serialization](../schema/hls/serialization.md)):
+**[HLS](./hls/)** — the generated array helpers in a synthesizable Vitis kernel (the
+schema-level packing model is in [Serialization](../schema/hls/serialization.md)):
 
-- [Vitis: raw arrays](./vitis_raw.md) — the flat array, packing factor, lanes, and the
+- [Vitis: raw arrays](./hls/raw.md) — the flat array, packing factor, lanes, and the
   throughput lane loop.
-- [Vitis: struct arrays](./vitis_struct.md) — the generated wrapper struct's whole-array
+- [Vitis: struct arrays](./hls/struct.md) — the generated wrapper struct's whole-array
   methods.
-- [Vitis: complex arrays](./vitis_complex.md) — complex elements end-to-end (the wireless
+- [Vitis: complex arrays](./hls/complex.md) — complex elements end-to-end (the wireless
   vertical).
 
 ## Why vectorization is the differentiator
@@ -124,7 +128,7 @@ The short rule:
 - **Integer** — either works; the operators add growth-aware width tracking
   (`a*b` → `Wa+Wb` bits, `a+b` → `+1`) with a fail-fast guard above 64 bits, which
   raw `.val` NumPy won't give you (it silently wraps). See
-  [Integer vectorization](./integer.md).
+  [Integer vectorization](./python/integer.md).
 
 Both paths keep data in NumPy arrays the whole way — that's what makes the
 simulation fast. The operators just add the bit-growth bookkeeping on top.

--- a/docs/guide/vectorization/python/complex.md
+++ b/docs/guide/vectorization/python/complex.md
@@ -1,24 +1,28 @@
 ---
 title: Complex vectorization
-parent: Vectorization
-nav_order: 5
-has_children: false
+parent: Python
+grand_parent: Vectorization
+nav_order: 4
+audience: python
+applies_to: [ComplexField]
+api: [ComplexField]
+summary: "The complex vectorized model — ComplexField arrays, complex arithmetic (cmult/cadd/conj), and the NumPy-vs-hardware complex-multiply edge."
 ---
 
 # Complex Vectorization
 
-This is the [vectorization](./index.md) story for complex — the **compute**. The complex
+This is the [vectorization](../index.md) story for complex — the **compute**. The complex
 *type* itself (the per-inner value representation, the C++ `std::complex` / `wf_cint`
 mapping, the bit-exactness contract) lives on the
-[ComplexField type page](../schema/python/complex.md); read that first if you haven't.
+[ComplexField type page](../../schema/python/complex.md); read that first if you haven't.
 
-Complex arrays use [`DataArray[ComplexField]`](../schema/python/dataarrays.md), generic over a scalar
+Complex arrays use [`DataArray[ComplexField]`](../../schema/python/dataarrays.md), generic over a scalar
 inner field — `FloatField`, `FixedField`, or `IntField`. The key idea for *speed*: complex
 arithmetic **composes the inner field's own vectorized ops** on the real and imaginary
 components, so a complex array stays as loop-free and NumPy-fast as a real one — and stays
 **bit-exact with the matching Vitis complex type**. For a fixed/int inner, that means complex
 math is just integer NumPy over the stored components; it inherits the `ap_fixed` growth rules
-and the single-64-bit guard from [`FixedField`](../schema/python/fixpoint.md), with no fixed-point math
+and the single-64-bit guard from [`FixedField`](../../schema/python/fixpoint.md), with no fixed-point math
 reimplemented.
 
 ## Arrays of complex values
@@ -56,7 +60,7 @@ The `.val` representation depends on the inner, because **numpy has no integer-c
 
 ## Arithmetic: full-precision growth, composed on the components
 
-The [operators](./index.md#the-two-paths) `*` / `+` / `-` (and the free function `conj`) are
+The [operators](../index.md#the-two-paths) `*` / `+` / `-` (and the free function `conj`) are
 **type-preserving**: each runs the inner field's vectorized op on the real/imag components and
 **derives the result inner format** with full precision. For a fixed/int inner the formats
 follow the `ap_fixed` rules — products widen, sums grow an integer bit — so intermediates never
@@ -92,13 +96,13 @@ multiply is FMA-based, while Vitis HLS `std::complex<float>` evaluates the **nai
 `(ar·br − ai·bi)` formula. `ComplexField` follows the naive, hardware-faithful formula so it
 stays bit-exact with Vitis on rounding-triggering operands; raw numpy FMA semantics remain
 available via `.val`. The full story is on the
-[ComplexField type page](../schema/python/complex.md#the-float-complex-multiply-edge).
+[ComplexField type page](../../schema/python/complex.md#the-float-complex-multiply-edge).
 
 ### Rounding back to a working format
 
 There is no single complex `quantize`: rounding is done **per component** through the inner
 field, since complex arithmetic composes that field. Take the grown result's components and
-`quantize` each with [`FixedField`](../schema/python/fixpoint.md)'s `quantize`, then recombine:
+`quantize` each with [`FixedField`](../../schema/python/fixpoint.md)'s `quantize`, then recombine:
 
 ```python
 import numpy as np
@@ -147,9 +151,9 @@ asserts the emitted bits equal these Python ops — run `pytest -m vitis -k comp
 
 ## See also
 
-- [Complex (ComplexField)](../schema/python/complex.md) — the complex *type*: value representations,
+- [Complex (ComplexField)](../../schema/python/complex.md) — the complex *type*: value representations,
   the C++ mapping, and the bit-exactness contract.
 - [Fixed-point vectorization](./fixed.md) — the inner field's growth-then-`quantize` story that
   complex composes for a fixed/int inner.
-- [Vectorization overview](./index.md) — the two paths and when to use each.
-- [Data arrays](../schema/python/dataarrays.md) — the `DataArray` container these build on.
+- [Vectorization overview](../index.md) — the two paths and when to use each.
+- [Data arrays](../../schema/python/dataarrays.md) — the `DataArray` container these build on.

--- a/docs/guide/vectorization/python/complex.md
+++ b/docs/guide/vectorization/python/complex.md
@@ -2,7 +2,7 @@
 title: Complex vectorization
 parent: Python
 grand_parent: Vectorization
-nav_order: 4
+nav_order: 5
 audience: python
 applies_to: [ComplexField]
 api: [ComplexField]
@@ -60,7 +60,7 @@ The `.val` representation depends on the inner, because **numpy has no integer-c
 
 ## Arithmetic: full-precision growth, composed on the components
 
-The [operators](../index.md#the-two-paths) `*` / `+` / `-` (and the free function `conj`) are
+The [operators](./numerical.md#type-preserving-operators) `*` / `+` / `-` (and the free function `conj`) are
 **type-preserving**: each runs the inner field's vectorized op on the real/imag components and
 **derives the result inner format** with full precision. For a fixed/int inner the formats
 follow the `ap_fixed` rules — products widen, sums grow an integer bit — so intermediates never

--- a/docs/guide/vectorization/python/complex.md
+++ b/docs/guide/vectorization/python/complex.md
@@ -145,7 +145,7 @@ top.element_type.inner_type.cpp_type   # 'ap_fixed<34, 18, AP_TRN, AP_WRAP>'
 
 The products and sums grow to full precision (no overflow, no rounding); a hardware butterfly
 that declares the same widened `ap_fixed` intermediates computes the identical bits. The
-[conformance harness](../../../examples/schemas/complex/complex_build.py) runs `cmult` / `cadd`
+[conformance harness](../../../../examples/schemas/complex/complex_build.py) runs `cmult` / `cadd`
 / `csub` / `conj` (fixed, int, and float — including the float multiply edge) in Vitis C-sim and
 asserts the emitted bits equal these Python ops — run `pytest -m vitis -k complex`.
 

--- a/docs/guide/vectorization/python/fixed.md
+++ b/docs/guide/vectorization/python/fixed.md
@@ -22,7 +22,7 @@ array access, and codegen for free. This is the case that most needs the
 [type-preserving operators](../index.md#the-two-paths): fixed-point grows bits and
 rounds on assignment, so working through `.val` by hand is easy to get wrong. The
 operators (`*`, `+`, `-`) are sugar over the **free functions** in
-[`waveflow/hw/fixpoint.py`](../../../waveflow/hw/fixpoint.py) (not methods — the
+[`waveflow/hw/fixpoint.py`](../../../../waveflow/hw/fixpoint.py) (not methods — the
 container stays a plain container): `mult`, `add`, `sub`, `shift`, `fixed_sum`, and
 `quantize`. They run entirely in the **integer domain** and match the Vitis `ap_fixed`
 datapath bit-for-bit.
@@ -89,7 +89,7 @@ y    = quantize(full, Q8_4)            # ap_fixed<8, 4>   -- the one explicit ro
 to_real(y)                             # array([ 3.5 , -2.75, -1.  ])
 ```
 
-This is exactly the fixed case of [`examples/basic_vec`](../../examples/basic_vec/), checked
+This is exactly the fixed case of [`examples/basic_vec`](../../../examples/basic_vec/), checked
 bit-for-bit against a Vitis kernel.
 
 ## Single 64-bit dtype, fail-fast above it
@@ -154,7 +154,7 @@ to_real(y)                         # array([1.15625])   == numpy dot, exactly
 The accumulator is sized (`fixed_sum` grows the integer bits by `ceil(log2 N)`) so the
 sum is exact; the matching Vitis kernel declares an `ap_fixed<34, 18>` accumulator so
 `acc += taps[i] * samples[i]` never rounds either. The
-[conformance harness](../../../examples/schemas/fixedpoint/fixedpoint_build.py) runs
+[conformance harness](../../../../examples/schemas/fixedpoint/fixedpoint_build.py) runs
 exactly this `s24_12` sum-of-products (plus `mult`/`add`/`quantize`) in Vitis C-sim and
 asserts the bits match the Python ops — run `pytest -m vitis -k fixedpoint`.
 

--- a/docs/guide/vectorization/python/fixed.md
+++ b/docs/guide/vectorization/python/fixed.md
@@ -2,7 +2,7 @@
 title: Fixed-point vectorization
 parent: Python
 grand_parent: Vectorization
-nav_order: 3
+nav_order: 4
 audience: python
 applies_to: [FixedField]
 api: [FixedField]
@@ -19,7 +19,7 @@ defaults-match-Vitis contract) lives on the
 Fixed-point arrays use [`DataArray[FixedField]`](../../schema/python/dataarrays.md) — the same
 numpy-backed array schema as every other element type, so they get flat storage,
 array access, and codegen for free. This is the case that most needs the
-[type-preserving operators](../index.md#the-two-paths): fixed-point grows bits and
+[type-preserving operators](./numerical.md#type-preserving-operators): fixed-point grows bits and
 rounds on assignment, so working through `.val` by hand is easy to get wrong. The
 operators (`*`, `+`, `-`) are sugar over the **free functions** in
 [`waveflow/hw/fixpoint.py`](../../../../waveflow/hw/fixpoint.py) (not methods — the
@@ -74,7 +74,7 @@ quantize(mult(a, b), Q8_4)             # DataArray[ap_fixed<8, 4>]
 
 ### Operator form (the primary spelling)
 
-The [operators](../index.md#2-type-preserving-operators--ab--c-then-quantize) are
+The [operators](./numerical.md#type-preserving-operators) are
 sugar over these functions, so a multiply-add reads like the math — and like the
 HLS `ap_fixed<...> y = a*b + c;` it mirrors. The intermediates grow to full
 precision; the single `quantize` is the only rounding:

--- a/docs/guide/vectorization/python/fixed.md
+++ b/docs/guide/vectorization/python/fixed.md
@@ -1,21 +1,25 @@
 ---
 title: Fixed-point vectorization
-parent: Vectorization
-nav_order: 4
-has_children: false
+parent: Python
+grand_parent: Vectorization
+nav_order: 3
+audience: python
+applies_to: [FixedField]
+api: [FixedField]
+summary: "The fixed-point vectorized model — FixedField arrays, the two paths (.val NumPy escape hatch vs type-preserving operators), and the ap_fixed result-format growth."
 ---
 
 # Fixed-Point Vectorization
 
-This is the [vectorization](./index.md) story for fixed-point — the **compute**.
+This is the [vectorization](../index.md) story for fixed-point — the **compute**.
 The fixed-point *type* itself (the `ap_fixed` model, `QMode`/`OMode`, the
 defaults-match-Vitis contract) lives on the
-[FixedField type page](../schema/python/fixpoint.md); read that first if you haven't.
+[FixedField type page](../../schema/python/fixpoint.md); read that first if you haven't.
 
-Fixed-point arrays use [`DataArray[FixedField]`](../schema/python/dataarrays.md) — the same
+Fixed-point arrays use [`DataArray[FixedField]`](../../schema/python/dataarrays.md) — the same
 numpy-backed array schema as every other element type, so they get flat storage,
 array access, and codegen for free. This is the case that most needs the
-[type-preserving operators](./index.md#the-two-paths): fixed-point grows bits and
+[type-preserving operators](../index.md#the-two-paths): fixed-point grows bits and
 rounds on assignment, so working through `.val` by hand is easy to get wrong. The
 operators (`*`, `+`, `-`) are sugar over the **free functions** in
 [`waveflow/hw/fixpoint.py`](../../../waveflow/hw/fixpoint.py) (not methods — the
@@ -70,7 +74,7 @@ quantize(mult(a, b), Q8_4)             # DataArray[ap_fixed<8, 4>]
 
 ### Operator form (the primary spelling)
 
-The [operators](./index.md#2-type-preserving-operators--ab--c-then-quantize) are
+The [operators](../index.md#2-type-preserving-operators--ab--c-then-quantize) are
 sugar over these functions, so a multiply-add reads like the math — and like the
 HLS `ap_fixed<...> y = a*b + c;` it mirrors. The intermediates grow to full
 precision; the single `quantize` is the only rounding:
@@ -156,9 +160,9 @@ asserts the bits match the Python ops — run `pytest -m vitis -k fixedpoint`.
 
 ## See also
 
-- [Fixed-point (FixedField)](../schema/python/fixpoint.md) — the fixed-point *type*: the
+- [Fixed-point (FixedField)](../../schema/python/fixpoint.md) — the fixed-point *type*: the
   format, `QMode`/`OMode`, the defaults-match-Vitis contract.
-- [Vectorization overview](./index.md) — the two paths and when to use each.
+- [Vectorization overview](../index.md) — the two paths and when to use each.
 - [Integer vectorization](./integer.md) — the same growth-then-`quantize` story
   without a binary point.
-- [Data arrays](../schema/python/dataarrays.md) — the `DataArray` container these build on.
+- [Data arrays](../../schema/python/dataarrays.md) — the `DataArray` container these build on.

--- a/docs/guide/vectorization/python/float.md
+++ b/docs/guide/vectorization/python/float.md
@@ -2,7 +2,7 @@
 title: Float vectorization
 parent: Python
 grand_parent: Vectorization
-nav_order: 2
+nav_order: 3
 audience: python
 applies_to: [FloatField]
 api: [FloatField]
@@ -13,9 +13,9 @@ summary: "The float vectorized model — FloatField arrays as native NumPy float
 
 Floating-point arrays are `DataArray[FloatField]` — numpy-backed by an IEEE-754
 `float32` or `float64` `ndarray`. Float is the simplest vectorization case: IEEE
-floats **don't grow**, so the [type-preserving operators](../index.md#the-two-paths)
+floats **don't grow**, so the [type-preserving operators](./numerical.md#type-preserving-operators)
 are just **NumPy passthrough** over the same arrays, and the
-[`.val` escape hatch](../index.md#1-the-numpy-escape-hatch--val) is equally correct.
+[`.val` escape hatch](./numerical.md#operations-with-val) is equally correct.
 
 ## Operators are passthrough
 
@@ -54,7 +54,7 @@ y.dtype                                                  # dtype('float32')
 The operators give you nothing extra here beyond keeping the value in a `DataArray`
 (the bit-growth bookkeeping they add for [integer](./integer.md) and
 [fixed-point](./fixed.md) has no float analog). Use whichever reads better;
-[fixed-point is the case that *needs* the operators](../index.md#when-to-use-which).
+[fixed-point is the case that *needs* the operators](./numerical.md#when-to-use-which).
 
 ## Golden references — matching the kernel bit-for-bit
 

--- a/docs/guide/vectorization/python/float.md
+++ b/docs/guide/vectorization/python/float.md
@@ -1,16 +1,21 @@
 ---
 title: Float vectorization
-parent: Vectorization
-nav_order: 3
+parent: Python
+grand_parent: Vectorization
+nav_order: 2
+audience: python
+applies_to: [FloatField]
+api: [FloatField]
+summary: "The float vectorized model — FloatField arrays as native NumPy float arrays, and when float fits versus fixed-point or integer."
 ---
 
 # Float vectorization
 
 Floating-point arrays are `DataArray[FloatField]` — numpy-backed by an IEEE-754
 `float32` or `float64` `ndarray`. Float is the simplest vectorization case: IEEE
-floats **don't grow**, so the [type-preserving operators](./index.md#the-two-paths)
+floats **don't grow**, so the [type-preserving operators](../index.md#the-two-paths)
 are just **NumPy passthrough** over the same arrays, and the
-[`.val` escape hatch](./index.md#1-the-numpy-escape-hatch--val) is equally correct.
+[`.val` escape hatch](../index.md#1-the-numpy-escape-hatch--val) is equally correct.
 
 ## Operators are passthrough
 
@@ -49,7 +54,7 @@ y.dtype                                                  # dtype('float32')
 The operators give you nothing extra here beyond keeping the value in a `DataArray`
 (the bit-growth bookkeeping they add for [integer](./integer.md) and
 [fixed-point](./fixed.md) has no float analog). Use whichever reads better;
-[fixed-point is the case that *needs* the operators](./index.md#when-to-use-which).
+[fixed-point is the case that *needs* the operators](../index.md#when-to-use-which).
 
 ## Golden references — matching the kernel bit-for-bit
 
@@ -73,7 +78,7 @@ asserts the Vitis C-sim output bits match them exactly.
 
 ## See also
 
-- [Vectorization overview](./index.md) — the two paths and when to use each.
+- [Vectorization overview](../index.md) — the two paths and when to use each.
 - [Integer vectorization](./integer.md) / [Fixed-point vectorization](./fixed.md) —
   the cases where the operators' growth tracking matters.
-- [Fields](../schema/python/fields.md) — `FloatField` and the scalar field types.
+- [Fields](../../schema/python/fields.md) — `FloatField` and the scalar field types.

--- a/docs/guide/vectorization/python/float.md
+++ b/docs/guide/vectorization/python/float.md
@@ -37,7 +37,7 @@ np.asarray(y)                                            # array([ 3.25, -2.75, 
 y.element_type.get_bitwidth()                            # 32  (no growth — float32 in, float32 out)
 ```
 
-This is the float case of [`examples/basic_vec`](../../examples/basic_vec/). A `float64` array
+This is the float case of [`examples/basic_vec`](../../../examples/basic_vec/). A `float64` array
 stays 64-bit the same way.
 
 ## When to use `.val` vs the operators

--- a/docs/guide/vectorization/python/index.md
+++ b/docs/guide/vectorization/python/index.md
@@ -1,0 +1,19 @@
+---
+title: Python
+parent: Vectorization
+nav_order: 1
+has_children: true
+audience: python
+summary: "The NumPy-backed vectorized value model — integer, float, fixed-point, and complex arrays — for loop-free Python computation that stays bit-exact with the generated hardware."
+---
+
+# Vectorization — Python model
+
+The **Python model** is how Waveflow holds and computes array values: NumPy-backed, loop-free, and
+bit-exact with the hardware it generates. These pages cover the per-element-type numerics — the
+[integer](./integer.md), [float](./float.md), [fixed-point](./fixed.md), and [complex](./complex.md)
+vectorized models, including the two paths (the `.val` NumPy escape hatch vs. the type-preserving
+operators) and the result-format rules.
+
+For the synthesizable side — packing these arrays into Vitis C++ words, the lane loop, and the
+storage modes — see [HLS](../hls/).

--- a/docs/guide/vectorization/python/integer.md
+++ b/docs/guide/vectorization/python/integer.md
@@ -1,14 +1,19 @@
 ---
 title: Integer vectorization
-parent: Vectorization
-nav_order: 2
+parent: Python
+grand_parent: Vectorization
+nav_order: 1
+audience: python
+applies_to: [IntField]
+api: [IntField]
+summary: "The integer vectorized model — IntField arrays as NumPy integer arrays, stored-integer semantics, and the single-64-bit dtype with a fail-fast guard above it."
 ---
 
 # Integer vectorization
 
 Integer arrays are `DataArray[IntField]` — numpy-backed, so the stored values are a
 plain NumPy integer `ndarray` reachable through `.val`. The
-[type-preserving operators](./index.md#the-two-paths) (`+`, `-`, `*`) compute over
+[type-preserving operators](../index.md#the-two-paths) (`+`, `-`, `*`) compute over
 the whole array in one NumPy call **and track bit growth** the way the HLS `ap_int`
 datapath does, so the Python result width matches the hardware.
 
@@ -95,7 +100,7 @@ ia([1]) * u                              # NotImplementedError: mixed signed/uns
 
 ## See also
 
-- [Vectorization overview](./index.md) — the two paths and when to use each.
+- [Vectorization overview](../index.md) — the two paths and when to use each.
 - [Fixed-point vectorization](./fixed.md) — the same growth-then-`quantize` story
   with a binary point.
-- [Fields](../schema/python/fields.md) — `IntField` and the scalar field types.
+- [Fields](../../schema/python/fields.md) — `IntField` and the scalar field types.

--- a/docs/guide/vectorization/python/integer.md
+++ b/docs/guide/vectorization/python/integer.md
@@ -2,7 +2,7 @@
 title: Integer vectorization
 parent: Python
 grand_parent: Vectorization
-nav_order: 1
+nav_order: 2
 audience: python
 applies_to: [IntField]
 api: [IntField]
@@ -13,7 +13,7 @@ summary: "The integer vectorized model — IntField arrays as NumPy integer arra
 
 Integer arrays are `DataArray[IntField]` — numpy-backed, so the stored values are a
 plain NumPy integer `ndarray` reachable through `.val`. The
-[type-preserving operators](../index.md#the-two-paths) (`+`, `-`, `*`) compute over
+[type-preserving operators](./numerical.md#type-preserving-operators) (`+`, `-`, `*`) compute over
 the whole array in one NumPy call **and track bit growth** the way the HLS `ap_int`
 datapath does, so the Python result width matches the hardware.
 

--- a/docs/guide/vectorization/python/integer.md
+++ b/docs/guide/vectorization/python/integer.md
@@ -36,7 +36,7 @@ y = a * b + c
 np.asarray(y)                                            # array([ 19, -29, -38,  11])
 ```
 
-This is the integer case of [`examples/basic_vec`](../../examples/basic_vec/) — one
+This is the integer case of [`examples/basic_vec`](../../../examples/basic_vec/) — one
 elementwise MAC, no per-element Python loop.
 
 ## Growth-aware result widths

--- a/docs/guide/vectorization/python/numerical.md
+++ b/docs/guide/vectorization/python/numerical.md
@@ -1,0 +1,99 @@
+---
+title: Numerical operations
+parent: Python
+grand_parent: Vectorization
+nav_order: 1
+audience: python
+api: [DataArray, mult, add, sub, quantize]
+summary: "The numerical model shared by every vectorized element type — defining a vector, and the two compute paths: the raw .val NumPy escape hatch, and the type-preserving operators (a*b + c then an explicit quantize). Includes when to use which."
+---
+
+# Numerical operations
+
+Every vectorized value in Waveflow is a **`DataArray`** of some schema element type, backed by a NumPy
+array — so a whole vector flows through one C-level NumPy call, not a Python loop over elements. This page
+covers the numerical model shared by **all** element types (integer, float, fixed-point, complex): how to
+define a vector, and the two ways to compute on one. The per-type specifics are on the
+[integer](./integer.md) / [float](./float.md) / [fixed-point](./fixed.md) / [complex](./complex.md) pages.
+
+## Defining vectors
+
+A vector is `DataArray.specialize(element_type, max_shape=(...))` applied to array-like data; `.val` is the
+underlying NumPy `ndarray`:
+
+```python
+import numpy as np
+from waveflow.hw.dataschema import DataArray, FloatField
+
+F32 = FloatField.specialize(32)
+a = DataArray.specialize(F32, max_shape=(3,))(np.array([1.5, 2.5, -3.0], np.float32))
+a.val                      # array([ 1.5,  2.5, -3. ], dtype=float32)  -- the raw ndarray
+```
+
+The **element type** sets how values are stored and how arithmetic grows — a `float` array is a native
+float `ndarray`, while a [`FixedField`](../../schema/python/fixpoint.md) array is integer-backed *stored
+codes*. Everything below works the same regardless of element type; only the derived result formats differ.
+
+## Operations with `.val`
+
+`DataArray.val` is the raw underlying `ndarray`. Reach through it and you get plain NumPy: maximum speed,
+every NumPy function available, and **you** manage the result width and dtype.
+
+```python
+b = DataArray.specialize(F32, max_shape=(3,))(np.array([2.0, -1.5, 0.5], np.float32))
+y = a.val * b.val + 0.25          # raw numpy float32 — you own the dtype
+y                                  # array([ 3.25, -3.5 , -1.25], dtype=float32)
+```
+
+This is the right path for **float** math (IEEE floats don't grow, so raw NumPy *is* the bit-exact model)
+or any time you genuinely want raw NumPy and will manage widths yourself.
+
+## Type-preserving operators
+
+The operators (`+`, `-`, `*`) on a `DataArray` are **type-preserving**: they read the operands' formats,
+run the vectorized NumPy op underneath, and **derive the result format** with full precision — no silent
+loss. They are sugar over the underlying `mult` / `add` / `sub` functions. Rounding back to a working
+format is an **explicit** `quantize(x, fmt)` — exactly mirroring `ap_fixed<...> y = a*b + c;` in HLS, where
+the product and sum grow to full width and the assignment is the one lossy step.
+
+```python
+from waveflow.hw.fixpoint import FixedField, from_real, quantize, to_real
+
+Q = FixedField.specialize(8, 4)                  # ap_fixed<8, 4>
+a = from_real([1.5, -2.0, 0.5], Q)
+b = from_real([2.0,  1.5, -1.0], Q)
+c = from_real([0.5,  0.25, -0.5], Q)
+
+full = a * b + c                                  # ap_fixed<17, 9> — full precision, no loss
+y    = quantize(full, Q)                          # ap_fixed<8, 4>  — the one explicit rounding
+to_real(y)                                        # array([ 3.5 , -2.75, -1.  ])
+```
+
+### When to use which
+
+| Path | Use it when | Cost you own |
+|------|-------------|--------------|
+| `.val` (numpy escape) | **float** math; or you genuinely want raw NumPy and will manage widths yourself | result dtype/width is on you |
+| operators + `quantize` | **fixed-point** (and growth-aware **integer**) math you want bit-exact with HLS | nothing — formats are derived, loss is explicit |
+
+The short rule:
+
+- **Float** — `.val` is fine. IEEE-754 `float32`/`float64` don't grow, so raw NumPy *is* the bit-exact
+  model; the operators are just NumPy passthrough over the same arrays.
+- **Fixed-point** — use the **operators**. Fixed-point arithmetic grows bits (`a*b` is `Wa+Wb` wide) and
+  rounds on assignment; the operators track that growth and keep the one rounding explicit, so your Python
+  matches `ap_fixed` exactly. Doing fixed-point by hand through `.val` means re-deriving formats and
+  rounding yourself — easy to get subtly wrong.
+- **Integer** — either works; the operators add growth-aware width tracking (`a*b` → `Wa+Wb` bits,
+  `a+b` → `+1`) with a fail-fast guard above 64 bits, which raw `.val` NumPy won't give you (it silently
+  wraps). See [Integer vectorization](./integer.md).
+
+Both paths keep data in NumPy arrays the whole way — that's what makes the simulation fast. The operators
+just add the bit-growth bookkeeping on top.
+
+## See also
+
+- [`examples/basic_vec`](../../../examples/basic_vec/) — the worked MAC `y = a*b + c`, computed with these
+  operators and checked **bit-exact against Vitis** for int / float / fixed.
+- The per-type pages — [integer](./integer.md) / [float](./float.md) / [fixed-point](./fixed.md) /
+  [complex](./complex.md) — for each element type's storage and result-format rules.


### PR DESCRIPTION
Phase 2 of the docs reorg: applies the per-section **Python / HLS** split (`plans/docs_reorg.md`) to `docs/guide/vectorization/`, matching the merged Data Schemas pilot (#82). Three-level just-the-docs nav: **Vectorization → Python|HLS → pages**. Vectorization only — interfaces/components are later phases.

## Before / after
Before: `vectorization/{integer,float,fixed,complex,vitis_raw,vitis_struct,vitis_complex,index}.md` (flat).

After:
- `vectorization/index.md` — updated to frame the Python / HLS subsections
- `vectorization/python/` — `index.md` (new) + `integer, float, fixed, complex`
- `vectorization/hls/` — `index.md` (new) + `raw, struct, complex` (the `vitis_` filename prefix dropped)

## What moved / renamed
- **python/** (numpy model): `integer, float, fixed, complex` — `parent: Python`, `grand_parent: Vectorization`, order preserved (nav 1–4).
- **hls/** (Vitis): `vitis_raw.md → raw.md`, `vitis_struct.md → struct.md`, `vitis_complex.md → complex.md` — `parent: HLS`, `grand_parent: Vectorization` (nav 1–3).
- Metadata frontmatter (`audience`, `applies_to`, `api`, `summary`) on every moved/created page.

## Scope: structural only
Move + split + frontmatter + links; page content left intact, **not** redistributed. `raw.md`'s "Streams instead of memory" subsection stays put (interface-dependent transfer content moves to interfaces/hls in Phase 3) with a one-line forward-note to Interfaces added there.

## Cross-link fixes by category
- **depth** (page moved one level deeper → links leaving the section get `+1 ../`): moved pages' `./index.md → ../index.md` and `../schema/… → ../../schema/…`.
- **rename** (`vitis_* → {raw,struct,complex}`, path **and** name): intra-`hls/` links, the `index.md` child links (`./vitis_raw.md → ./hls/raw.md`, `./integer.md → ./python/integer.md`), and inbound refs.
- **source** (code docstrings / README): none — no code references these pages.
- **examples**: none — no examples page references these pages (bare `…/vectorization/` dir links are unaffected; the section index didn't move).
- **inbound (the class the pilot's first pass missed):** `schema/hls/{codegen,serialization}.md` → `../../vectorization/hls/raw.md`; `schema/python/{complex,fixpoint}.md` → `../../vectorization/python/fixed.md`. Stale `vitis_*.md` "See also" labels updated to the new names.

## Validation (docs-only)
No Ruby/Jekyll locally and no docs-build CI → **structural**:
- **Link-resolution sweep (merge gate):** a repo-wide `realpath` check of every relative `.md` link in `docs/` — **280 links, 0 broken**. `grep` finds no dangling old `vectorization/*.md` paths and no stale `vitis_` tokens anywhere (plans/ left as historical records).
- Frontmatter `parent`/`grand_parent` chain consistent for the 3-level nav (`Vectorization → Python`/`HLS → leaves`); `remote_theme: just-the-docs` supports exactly this; the `Python`/`HLS` subsection titles disambiguate from the schema ones via `grand_parent`.
- `vectorization/hls/*` are git-tracked (the `!docs/guide/**/hls/**` negation from #82 covers them).

Do not merge yet — pattern-rollout PR, reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
