### PR TITLE
docs: Interface reorg (Phase 3, light pass) — Python-only + metadata frontmatter

### DIFF
--- a/docs/guide/interface/array_transfer.md
+++ b/docs/guide/interface/array_transfer.md
@@ -1,8 +1,10 @@
 ---
 title: Array Transfer Interface
 parent: Interfaces
-nav_order: 5
-has_children: false
+nav_order: 6
+audience: python
+api: [ArrayTransferIF, ArrayTransferIFMaster, ArrayTransferIFSlave, StreamTransport]
+summary: "The logical interface that carries a variable-length typed array over a transport — write(elements) with a numpy fast path, push (rx_proc) vs pull (get(count)) receive, and TLAST length validation."
 ---
 
 # Array Transfer Interface
@@ -256,6 +258,10 @@ Both `cmd_slave` and `samp_slave` share the same `transport` (and therefore the 
 ---
 
 ## Synthesis mapping
+
+> The synthesizable side — using this interface inside a kernel body (the `m_axi` / stream port and
+> the `read_array` / `write_array` calls on it) — is covered in the forthcoming **Custom Hooks**
+> section. This mapping table is a pointer to that C++; it is documented in full there.
 
 When generating Vitis HLS code, `ArrayTransferIF` maps to the utilities produced by `ArrayUtilsStep`:
 

--- a/docs/guide/interface/aximm.md
+++ b/docs/guide/interface/aximm.md
@@ -2,7 +2,9 @@
 title: MM Interfaces
 parent: Interfaces
 nav_order: 3
-has_children: false
+audience: python
+api: [MMIFMaster, MMIFSlave, AXIMMCrossBarIF, DirectMMIF, AXIMMProtocol, assign_address_ranges]
+summary: "Memory-mapped interfaces in the SimPy model — MMIFMaster/MMIFSlave endpoints, the AXIMMCrossBarIF (FULL/LITE, address routing) and DirectMMIF, and read/write/read_schema/read_array."
 ---
 
 # Memory-Mapped (MM) Interfaces

--- a/docs/guide/interface/index.md
+++ b/docs/guide/interface/index.md
@@ -3,14 +3,27 @@ title: Interfaces
 parent: Guide
 nav_order: 4
 has_children: true
+audience: python
+summary: "The Python transactional interface model — how components communicate over streams, memory-mapped ports, register maps, and schema/array transfers in the SimPy simulation."
 ---
 
 # Hardware Interfaces
 
 Waveflow models hardware communication channels as **interfaces** — transactional connections between `SimObj` instances in a SimPy discrete-event simulation. Interfaces decouple the timing model of a bus from the functional logic of the components connected to it.
 
-- [Overview](./overview.md)
-- [Streaming Interfaces](./stream.md)
-- [AXI4 Memory Mapped interfaces](./aximm.md)
-- [Register Maps](./regmap.md)
+This section is the **Python transactional model**: the interface classes, their master/slave endpoints, the `write` / `read` / `get` calls, binding, and the cycle-based latency model. It is Python-only by design — an interface is not a standalone synthesizable artifact but a *port of a component*, so its synthesizable side is documented where the kernel is.
+
+## Pages
+
+- [Overview](./overview.md) — the core model: `Interface` vs endpoint, the `Words` type, latency, and the SimPy lifecycle.
+- [Stream Interfaces](./stream.md) — unidirectional streams (`StreamIF`, `CrossBarIF`) and pipelined transfer.
+- [MM Interfaces](./aximm.md) — memory-mapped read/write (`AXIMMCrossBarIF`, `DirectMMIF`).
+- [Register Maps](./regmap.md) — AXI-Lite control/status fields (`RegMap`, `VitisRegMap`).
+- [Schema Transfer Interface](./schema_transfer.md) — carrying serializable schema objects over a transport.
+- [Array Transfer Interface](./array_transfer.md) — carrying a variable-length typed array over a transport.
+
+## See also
+
+- [Hardware Components](../components/) — declaring the ports (these endpoints) on a component.
+- **Custom Hooks** *(forthcoming section)* — the synthesizable side: using an interface inside a kernel body (the `#pragma HLS INTERFACE` ports and the `read_stream` / `m_axi` calls). It does not exist yet; the kernel-facing C++ for these interfaces lands there.
 

--- a/docs/guide/interface/overview.md
+++ b/docs/guide/interface/overview.md
@@ -2,7 +2,9 @@
 title: Overview
 parent: Interfaces
 nav_order: 1
-has_children: false
+audience: python
+api: [Interface, InterfaceEndpoint, StreamIF, MMIFMaster, MMIFSlave, Words]
+summary: "The transactional interface model — Interface vs master/slave endpoint, the Words type, the cycle-based latency model, and the SimPy write/read/bind lifecycle."
 ---
 
 # Overview

--- a/docs/guide/interface/regmap.md
+++ b/docs/guide/interface/regmap.md
@@ -2,7 +2,9 @@
 title: Register Maps
 parent: Interfaces
 nav_order: 4
-has_children: false
+audience: python
+api: [RegMap, RegField, RegAccess, RegMapMMIFSlave, VitisRegMap, VitisRegMapMMIFSlave, BoundRegMap]
+summary: "AXI-Lite register maps in the SimPy model — RegField/RegAccess, the RegMap slave dispatch, the VitisRegMap ap_ctrl_hs (ap_start/ap_done) launch lifecycle, and the BoundRegMap host surface."
 ---
 
 # Register Maps

--- a/docs/guide/interface/schema_transfer.md
+++ b/docs/guide/interface/schema_transfer.md
@@ -1,8 +1,10 @@
 ---
 title: Schema Transfer Interface
 parent: Interfaces
-nav_order: 4
-has_children: false
+nav_order: 5
+audience: python
+api: [SchemaTransferIF, SchemaTransferIFMaster, SchemaTransferIFSlave, PhysicalTransport, StreamTransport]
+summary: "The logical interface that carries serializable schema objects (DataList / DataUnion) over a transport — write(obj) / rx_proc, the layered transport model, and single- vs multi-type framing."
 ---
 
 # Schema Transfer Interface

--- a/docs/guide/interface/stream.md
+++ b/docs/guide/interface/stream.md
@@ -2,7 +2,9 @@
 title: Stream Interfaces
 parent: Interfaces
 nav_order: 2
-has_children: false
+audience: python
+api: [StreamIF, StreamIFMaster, StreamIFSlave, CrossBarIF, CrossBarIFInput, CrossBarIFOutput]
+summary: "Unidirectional stream interfaces in the SimPy model — point-to-point StreamIF (write/rx_proc), the CrossBarIF switching fabric, and pipelined get/write timing."
 ---
 
 # Stream Interfaces


### PR DESCRIPTION
Phase 3 of the docs reorg — **Interface (light pass)**. Per `plans/docs_reorg.md`, Interface is **Arc 2: Python-only and flat** — *no* `python/`//`hls/` subsections. An HLS interface isn't a standalone artifact (it's a port of a component; its synthesizable usage belongs to the future **Custom Hooks** section, Phase 7). So this is **frontmatter + framing + forward-notes only — no page moves**.

## Frontmatter added (per page)
`audience: python` + `api` + a one-line answer-shaped `summary` on all seven pages. Also fixed a **nav_order collision** (`regmap` and `schema_transfer` were both `4`):

| page | nav_order | api (frontmatter) |
|---|---|---|
| index | 4 (under Guide) | — (section summary) |
| overview | 1 | Interface, InterfaceEndpoint, StreamIF, MMIFMaster, MMIFSlave, Words |
| stream | 2 | StreamIF, StreamIFMaster/Slave, CrossBarIF(+In/Out) |
| aximm | 3 | MMIFMaster/Slave, AXIMMCrossBarIF, DirectMMIF, AXIMMProtocol, assign_address_ranges |
| regmap | 4 | RegMap, RegField, RegAccess, RegMapMMIFSlave, VitisRegMap(+Slave), BoundRegMap |
| schema_transfer | 5 | SchemaTransferIF(+Master/Slave), PhysicalTransport, StreamTransport |
| array_transfer | 6 | ArrayTransferIF(+Master/Slave), StreamTransport |

## Python-focus assessment (per page)
All seven describe the **SimPy transactional model** (interface classes, master/slave endpoints, `write`/`read`/`get`/`bind`, the cycle latency model). No synthesizable C++ / HLS port snippets — **no `#pragma HLS`, no `m_axi` / `read_stream` kernel bodies anywhere**.
- **overview / stream / aximm / schema_transfer**: pure Python model. (stream's `@synthesizable evaluate` skeleton is Python hook code with `proc_ii`/`proc_latency` timing hints, not C++.)
- **regmap**: pure Python; the many "Vitis" mentions are prose describing how the model matches `ap_ctrl_hs`/`s_axilite`. The `to_c_header` example is the regmap's **own planned host-driver codegen** (`#define` offsets), not a synthesizable kernel — not Custom-Hooks material.

## HLS content found → flagged for Phase 7 / Custom Hooks
- **`array_transfer.md` — "Synthesis mapping" section (lines ~258–267):** a 2-row table mapping the Python `ArrayTransferIF` calls → the generated C++ `float32_array_utils::write_array/read_array`. This is the only HLS-side content. **Left in place** with a one-line forward-note added; flagged here so Phase 7 can extract it into Custom Hooks.

(No other file:line carries synthesizable C++.)

## Forward-pointers added
- `index.md`: → **Hardware Components** (`../components/`, link — declaring the ports) and → **Custom Hooks** *(forthcoming; plain text, not a link — the section doesn't exist yet, so linking it would break the link gate)* for the synthesizable side.
- `array_transfer.md` "Synthesis mapping": one-line note that the kernel-side C++ is documented in Custom Hooks.

## Validation (docs-only)
No Ruby/Jekyll locally and no docs-build CI → **structural**:
- **Link gate (the exact task sweep over every relative `.md` / `.py` / directory target): `broken total: 0`.**
- `audience: python` on every interface page; `parent: Interfaces` chain consistent; no nav_order collisions among leaves.

No page moves (flat section preserved). Do not merge yet — reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
