### PR TITLE
docs: Component reorg (Phase 4, light reorg) — Python-only + metadata frontmatter

### DIFF
--- a/docs/guide/components/hwconst.md
+++ b/docs/guide/components/hwconst.md
@@ -1,7 +1,11 @@
 ---
 title: HwConst
 parent: Hardware Components
-nav_order: 3
+nav_order: 2
+audience: python
+applies_to: [HwComponent, DataArray]
+api: [HwConst, discover_hw_const]
+summary: "HwConst[T] — class-level compile-time structural constants (e.g. static array extents); contrast with the per-instance HwParam."
 ---
 
 # HwConst
@@ -9,6 +13,10 @@ nav_order: 3
 ## Concept
 
 `HwConst[T]` marks class-level constants intended to represent compile-time values attached to schema/component definitions. It communicates intent to readers and codegen paths that treat the value as fixed for the class.
+
+> The codegen side — emitting a `HwConst` as a C++ `static constexpr` — is deferred and belongs to
+> the forthcoming **component codegen** section; in Python simulation a `HwConst` is a regular class
+> attribute.
 
 Use `HwConst` for structural constants that do not vary across instances (for example static array extents). Use `HwParam` when a value should vary per instance and potentially per generated kernel variant.
 

--- a/docs/guide/components/hwparam.md
+++ b/docs/guide/components/hwparam.md
@@ -1,7 +1,11 @@
 ---
 title: HwParam
 parent: Hardware Components
-nav_order: 2
+nav_order: 1
+audience: python
+applies_to: [HwComponent]
+api: [HwParam, HwParamValue]
+summary: "HwParam[T] — per-instance synthesis-parameter fields: int-like in simulation, identity-preserving for codegen (wrapped as HwParamValue), immutable after construction."
 ---
 
 # HwParam
@@ -11,6 +15,10 @@ nav_order: 2
 `HwParam[T]` marks component fields that should be treated as synthesis parameters. These fields behave like Python integers in simulation but preserve parameter identity for code generation.
 
 During `HwComponent.__post_init__`, raw values for `HwParam` fields are wrapped as `HwParamValue`. This wrapper preserves which parameter name produced the value so emitters can substitute template-aware expressions where needed.
+
+> The codegen side — how a `HwParam` lowers to a C++ template parameter / kernel-signature
+> argument — belongs to the forthcoming **component codegen** section; it is interim-documented
+> under [Synthesis templating](../synthesis/templating.md).
 
 ## API
 

--- a/docs/guide/components/hwtestbench.md
+++ b/docs/guide/components/hwtestbench.md
@@ -1,14 +1,22 @@
 ---
 title: HwTestbench
 parent: Hardware Components
-nav_order: 4
+nav_order: 3
+audience: python
+applies_to: [HwComponent]
+api: [HwTestbench]
+summary: "HwTestbench — a HwComponent subclass whose sequential main() (stream push/pop, dut.run()) defines a test sequence in Python; the codegen source for a C++ testbench main()."
 ---
 
 # HwTestbench
 
 ## Concept
 
-`HwTestbench` is a `HwComponent` subclass for codegen-source testbenches. Its `main(self)` method is extracted and lowered into C++ testbench code by `HlsCodegenStep` testbench mode.
+`HwTestbench` is a `HwComponent` subclass for codegen-source testbenches. You write the test sequence as a Python `main(self)` method; that method is the source the codegen extracts.
+
+> The codegen side — extracting and lowering `main()` into a C++ testbench `main()` (the
+> `HlsCodegenStep` testbench mode) — belongs to the forthcoming **component codegen** section; the
+> emitter behavior is interim-documented under [Synthesis testbench](../synthesis/testbench.md).
 
 The v1 model is sequential: blocking file I/O, stream push/pop operations, and `dut.run()` are supported in `main()`. Concurrent SimPy-style stimulus/capture (`env.process(...)`) is not currently supported in this pathway.
 

--- a/docs/guide/components/index.md
+++ b/docs/guide/components/index.md
@@ -3,9 +3,13 @@ title: Hardware Components
 parent: Guide
 nav_order: 5
 has_children: true
+audience: python
+summary: "The Python HwComponent model — declaring typed ports/endpoints, HwParam/HwConst fields, and the pre_sim/run_proc/post_sim lifecycle in the SimPy simulation."
 ---
 
 # Hardware Components
+
+This section is the **Python `HwComponent` model**: how you declare a hardware component in the SimPy simulation — its typed ports (endpoints), its `HwParam` / `HwConst` fields, and its lifecycle. It is Python-only by design; a component's **synthesizable C++ realization** — the generated kernel structure, parameterization, and hand-written hooks — is the codegen arc (see the forward-pointers below).
 
 ## Concept
 
@@ -46,3 +50,15 @@ From [`examples/stream_inband/poly.py`](../../../examples/stream_inband/poly.py)
 - [HwConst](./hwconst.md)
 - [HwTestbench](./hwtestbench.md)
 - [Lifecycle](./lifecycle.md)
+
+## See also
+
+**Prerequisites** — a component is built from these:
+
+- [Interfaces](../interface/) — the typed ports (stream / MM / regmap endpoints) a component declares.
+- [Data Schemas](../schema/) — the payloads those ports carry.
+
+**The synthesizable side** (the C++ realization of a component):
+
+- **component codegen** *(forthcoming section)* — what a full component generates: the kernel structure, how `HwParam` becomes C++ template parameters, and `main()`→testbench emission. It does not exist yet; the codegen flow is interim-documented under [Synthesis](../synthesis/).
+- **Custom Hooks** *(forthcoming section)* — the hand-written synthesizable kernel bodies that plug into a generated component.

--- a/docs/guide/components/lifecycle.md
+++ b/docs/guide/components/lifecycle.md
@@ -1,7 +1,11 @@
 ---
 title: Lifecycle
 parent: Hardware Components
-nav_order: 5
+nav_order: 4
+audience: python
+applies_to: [HwComponent]
+api: [pre_sim, run_proc, post_sim, on_start, sim_only]
+summary: "The component lifecycle — pre_sim / run_proc / post_sim, plus on_start for regmap-launched kernels and @sim_only to exclude helpers from synthesis extraction."
 ---
 
 # Lifecycle
@@ -11,6 +15,10 @@ nav_order: 5
 Waveflow simulation objects follow a standard lifecycle: `pre_sim`, `run_proc`, and `post_sim`. `HwComponent` participates in the same lifecycle through inheritance from `Component`/`SimObj`, while synthesis extraction targets selected methods (`run_proc` or `on_start`) depending on component structure.
 
 For regmap-driven kernels, `on_start` is used as the invocation-style body triggered by host `ap_start`. Free-running simulation components usually implement `run_proc` as the long-running process body.
+
+> The codegen side — which method is extracted as the kernel entry (`extract_kernel`'s
+> selection policy) and how `@sim_only` excludes a helper — belongs to the forthcoming
+> **component codegen** section; it is interim-documented under [Synthesis extractor](../synthesis/extractor.md).
 
 ## API
 


### PR DESCRIPTION
Phase 4 of the docs reorg — **Component (light reorg)**. Per `plans/docs_reorg.md`, Component is **Arc 2: Python-only and flat** — its C++ realization is Arc 3 (component codegen, Phase 6; custom_hooks, Phase 7). So this is **frontmatter + framing + forward-notes only — no `python/`//`hls/` subsections, no page moves**.

## Frontmatter added (per page)
`audience: python` + `applies_to` + `api` + a one-line answer-shaped `summary` on all five pages. Closed the nav_order gap (leaves were 2,3,4,5 → 1,2,3,4; relative order preserved, no collisions):

| page | nav | api |
|---|---|---|
| index | 5 (under Guide) | — (section summary) |
| hwparam | 1 | HwParam, HwParamValue |
| hwconst | 2 | HwConst, discover_hw_const |
| hwtestbench | 3 | HwTestbench |
| lifecycle | 4 | pre_sim, run_proc, post_sim, on_start, sim_only |

## Python-focus assessment (per page)
All five describe the **Python `HwComponent` model**. No synthesizable C++ snippets — **no `#pragma HLS`, no `.tpp` / `m_axi` / `hls::stream` kernel bodies**. The codegen-adjacent content is prose, left in place with a one-line forward-note.

- **index** — pure model (endpoints, HwParam/HwConst, lifecycle).
- **hwparam** — model; codegen prose about HwParam→C++.
- **hwconst** — model; codegen prose about `static constexpr` (deferred).
- **hwtestbench** — model (write `main()` as a Python test sequence); codegen prose about `main()`→C++ testbench.
- **lifecycle** — model (pre_sim/run_proc/post_sim/on_start/@sim_only); codegen prose about extraction.

## Codegen/synthesizable passages found → tagged for Arc 3
All are **prose** (no kernel snippets); all belong to **component codegen (Phase 6)**; **none** are custom_hooks (no hand-written kernel C++ present):

| file:line | passage | → |
|---|---|---|
| `index.md:14` (orig 12) | "extractor-compatible methods … codegen metadata" | comp_codegen (Phase 6) |
| `hwparam.md:11,13,32` | "for code generation"; "emitters can substitute template-aware expressions"; "drive generated kernel signatures and stream/regmap bitwidths" (HwParam → C++ template param) | comp_codegen (Phase 6) |
| `hwconst.md:11,35` | "codegen paths that treat the value as fixed"; "C++ `static constexpr` emission is deferred" | comp_codegen (Phase 6) |
| `hwtestbench.md` (whole Concept) | `main()` extracted + lowered to a C++ testbench by `HlsCodegenStep` testbench mode; the sequential `main()` example as "reference … for generated C++ testbench mains" | comp_codegen (Phase 6) |
| `lifecycle.md:11` | "synthesis extraction targets selected methods (`run_proc`/`on_start`)"; `extract_kernel` selection; `@sim_only` excluded from extraction | comp_codegen (Phase 6) |

(Line numbers are post-edit unless noted. Nothing was moved or deleted.)

## Forward-pointers / notes added
- `index.md` **See also**: prerequisites → [Interfaces](../interface/) and [Data Schemas](../schema/) (real links); synthesizable side → **component codegen** and **Custom Hooks** as *plain text (forthcoming)* — those Arc-3 sections don't exist, so linking would break the gate — noting codegen is interim-documented under [Synthesis](../synthesis/).
- One-line forward-note on each leaf (`hwparam`, `hwconst`, `hwtestbench`, `lifecycle`) pointing the codegen side to the forthcoming **component codegen** section, with the interim Synthesis link (`../synthesis/templating.md` / `testbench.md` / `extractor.md` — all exist).

## Validation (docs-only)
No Ruby/Jekyll locally and no docs-build CI → **structural**:
- **Link gate (the exact task sweep over every relative `.md` / `.py` / directory target): `broken total: 0`.**
- `audience: python` on every components page; `parent: Hardware Components` chain consistent; no nav_order collisions among leaves.

No page moves (flat section preserved). Do not merge yet — reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
