### PR TITLE
docs: new Sim section (Phase 5, authoring) — the Python simulation guide

### DIFF
--- a/docs/guide/ai_tooling/index.md
+++ b/docs/guide/ai_tooling/index.md
@@ -1,7 +1,7 @@
 ---
 title: AI Tooling
 parent: Guide
-nav_order: 11
+nav_order: 12
 has_children: true
 ---
 

--- a/docs/guide/build/index.md
+++ b/docs/guide/build/index.md
@@ -1,7 +1,7 @@
 ---
 title: Build System
 parent: Guide
-nav_order: 7
+nav_order: 8
 has_children: true
 ---
 

--- a/docs/guide/developer/index.md
+++ b/docs/guide/developer/index.md
@@ -1,7 +1,7 @@
 ---
 title: Developers
 parent: Guide
-nav_order: 10
+nav_order: 11
 has_children: true
 ---
 

--- a/docs/guide/memory/index.md
+++ b/docs/guide/memory/index.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Modeling
 parent: Guide
-nav_order: 8
+nav_order: 9
 has_children: true
 ---
 

--- a/docs/guide/sim/index.md
+++ b/docs/guide/sim/index.md
@@ -1,0 +1,60 @@
+---
+title: Simulation
+parent: Guide
+nav_order: 6
+has_children: true
+audience: python
+api: [Simulation, SimObj, Clock, Logger]
+summary: "Run a whole system in Python: a SimPy discrete-event simulation that wires components through Interface objects and drives the pre_sim / run_proc / post_sim lifecycle — the milestone of validating a design before any C++."
+---
+
+# Simulation
+
+A Waveflow design is, first, a **Python program you can run**. Before any C++ is generated, you
+assemble your components, wire them together with [interfaces](../interface/), and **simulate the
+whole system** — checking that the data flows, the protocol handshakes, and the results are correct.
+That is the Arc-2 milestone: *simulate a whole system in Python.*
+
+## Discrete-event simulation (PySim)
+
+The simulation is **discrete-event** (DES): nothing advances on a fixed clock tick — instead the
+runtime jumps from one scheduled event to the next, so time only moves when something happens. This
+is what makes a transaction-level model fast: a 1024-word burst is one timed event, not 1024 clock
+steps.
+
+Waveflow builds this on [**SimPy**](https://simpy.readthedocs.io/). The
+[`Simulation`](../../../waveflow/simulation/simulation.py) object owns a single `simpy.Environment`
+and the list of participating objects; every simulation entity is a
+[`SimObj`](../../../waveflow/simulation/simobj.py) that registers itself with that `Simulation` and
+borrows its environment. You rarely touch SimPy directly — `SimObj` wraps the primitives you need
+(`self.timeout(...)`, `self.process(...)`, `self.event()`).
+
+## The three-phase lifecycle (at a glance)
+
+`Simulation.run_sim()` drives every registered object through three phases, in registration order:
+
+1. **`pre_sim()`** — setup / validation before the event loop (bind checks, address ranges, initial state).
+2. **`run_proc()`** — each object's optional SimPy generator process is scheduled (objects returning `None` are *passive* — they participate only via `pre_sim` / `post_sim`).
+3. **`post_sim()`** — collect results, assert invariants, emit reports (after the event loop ends).
+
+If the run raises, `error_cleanup()` is called on every object before the exception propagates (so
+files/loggers close). The **per-object** meaning of these hooks — and `on_start` for regmap-launched
+kernels — is on the [component Lifecycle](../components/lifecycle.md) page; this section is the
+*system* view: how the hooks are driven across all objects at once.
+
+## In this section
+
+- [Running a simulation](./running.md) — instantiate components, wire them with `Interface` objects, build a `Simulation`, and call `run_sim()`.
+- [Timing model](./timing.md) — `Clock` and how components / interfaces express cycle latency (the forward model that produces the timeline).
+- [Logging](./logging.md) — the `Logger` `SimObj`: recording timestamped events to a CSV for inspection and timing analysis.
+
+## See also
+
+- [Interfaces](../interface/) — the transactional connections components are wired through.
+- [Hardware Components](../components/) — declaring the components (ports, `HwParam`, lifecycle) that a simulation runs.
+- [Timing Analysis Tools](../timing/) — *analyzing* the timeline a simulation produces (this section is the model that produces it).
+- [Build System](../build/python.md) — running a simulation as a step in a `BuildDag`.
+
+> The simulation models a design in Python. Turning that design into synthesizable C++ — the
+> generated kernel structure and the hand-written kernel bodies — is the codegen arc: the
+> forthcoming **component codegen** and **Custom Hooks** sections.

--- a/docs/guide/sim/logging.md
+++ b/docs/guide/sim/logging.md
@@ -1,0 +1,88 @@
+---
+title: Logging
+parent: Simulation
+nav_order: 3
+audience: python
+api: [Logger, Logger.log, Logger.get_tv, NullLogger]
+summary: "Record timestamped events during a simulation: Logger is a SimObj that writes a flushed CSV (a leading time column from env.now plus your declared fields); log(**fields) records a row, get_tv(field) reads back (times, values). NullLogger is the no-op default."
+---
+
+# Logging
+
+[`Logger`](../../../waveflow/simulation/logger.py) is a [`SimObj`](../../../waveflow/simulation/simobj.py)
+that writes a **timestamped CSV** as the simulation runs — the standard way to capture *when* events
+happened for inspection and [timing analysis](../timing/). Because it is a `SimObj`, it shares the
+environment and closes its file automatically in `post_sim()` (and on error).
+
+## Creating a logger
+
+You declare the **field columns** up front; a leading `time` column is added automatically:
+
+```python
+from waveflow.simulation.logger import Logger
+
+logger = Logger(name="poly_log", sim=sim,
+                file_path="results/sim_log.csv",
+                fields=["event", "job"])
+```
+
+`Logger` is keyword-only (`name`, `sim`, `file_path`, `fields`). On construction it opens the file
+and writes the header `time,event,job`.
+
+## Recording events
+
+Call `log(**kwargs)` from inside any `run_proc` (or a component method). Only declared fields are
+accepted; unspecified ones are written blank. The row is stamped with the current simulation time
+(`env.now`) and written through a SimPy resource, so concurrent callers never interleave:
+
+```python
+def run_proc(self) -> ProcessGen[None]:
+    self.logger.log(event="start", job=self.job_id)   # -> 1.0e-7,start,3
+    # ... do work ...
+    self.logger.log(event="done")                     # -> 2.5e-7,done,   (job blank)
+    yield self.timeout(0)
+```
+
+Each entry is **flushed immediately**, so the CSV is inspectable even if the run later raises.
+Logging is marked `@sim_only` — it is simulation instrumentation and is excluded from synthesis
+extraction.
+
+## Reading results back
+
+After [`run_sim()`](./running.md), pull a `(times, values)` pair for one field. Only rows where that
+field was explicitly logged are returned; values are cast to `float` when possible, else left as
+strings:
+
+```python
+times, events = logger.get_tv("event")   # times: list[float], events: list
+```
+
+This is the bridge to [timing analysis](../timing/) — e.g. the gap between a `start` event and the
+matching `done` is a measured latency.
+
+## `NullLogger` — the no-op default
+
+[`NullLogger`](../../../waveflow/simulation/logger.py) is a drop-in whose `log(...)` discards
+everything. Components default their `logger` field to a `NullLogger`, so call sites can always write
+`self.logger.log(...)` without an `if self.logger:` guard; you pass a real `Logger` only when you
+want a trace.
+
+```python
+from waveflow.simulation.logger import NullLogger
+
+logger: Logger | NullLogger = field(default_factory=NullLogger)   # on a component
+```
+
+## In a build step
+
+[`examples/stream_inband/poly_build.py`](../../../examples/stream_inband/poly_build.py)'s `PySimStep`
+constructs a `Logger(name="poly_log", sim=sim, file_path=log_path, fields=["event", "job"])`, hands
+it to the accelerator, runs the simulation, and leaves the CSV under `results/` for a later step to
+parse — see [Build System](../build/python.md) for running a simulation inside a `BuildDag`.
+
+## See also
+
+- [Running a simulation](./running.md) — where the `Logger` is constructed and `run_sim()` is called.
+- [Timing model](./timing.md) — the `self.now` timestamps each log row carries.
+- [Timing Analysis Tools](../timing/) — analyzing the recorded timeline.
+- [Build System](../build/python.md) — `PySimStep` and producing logs as build artifacts.

--- a/docs/guide/sim/running.md
+++ b/docs/guide/sim/running.md
@@ -1,0 +1,144 @@
+---
+title: Running a simulation
+parent: Simulation
+nav_order: 1
+audience: python
+api: [Simulation, Simulation.run_sim, SimObj, Clock, StreamIF, DirectMMIF, Interface.bind]
+summary: "Assemble and run a system in Python: instantiate components against one Simulation, wire their ports with Interface objects (.bind), and call run_sim() to drive pre_sim / run_proc / post_sim. Results are read off the objects afterward."
+---
+
+# Running a simulation
+
+Running a simulation is four steps: **(1)** create a `Simulation`, **(2)** instantiate your
+components against it, **(3)** wire their ports together with `Interface` objects, and **(4)** call
+`run_sim()`. Results are read off the component objects after the run returns.
+
+## The shape
+
+```python
+from waveflow.hw.clock import Clock
+from waveflow.simulation.simulation import Simulation
+
+sim = Simulation()                       # owns the SimPy environment
+clk = Clock(freq=100e6)                  # 100 MHz timing domain
+
+producer = Producer(name="prod", sim=sim)     # each SimObj registers itself with sim
+consumer = Consumer(name="cons", sim=sim)
+
+link = StreamIF(sim=sim, clk=clk)             # an Interface object carries the timing model
+link.bind("master", producer.ep)              # wire endpoints by role
+link.bind("slave",  consumer.ep)
+
+sim.run_sim()                                 # pre_sim → run_proc → post_sim, all objects
+```
+
+- Every [`SimObj`](../../../waveflow/simulation/simobj.py) takes `sim=sim` and **registers itself**
+  on construction (`Simulation.add_obj` is called for you) — you never build the object list by hand.
+- [`Simulation.run_sim()`](../../../waveflow/simulation/simulation.py) runs every registered object's
+  `pre_sim()`, schedules each non-`None` `run_proc()` as a SimPy process, advances the event loop,
+  then runs every `post_sim()`. (For what those hooks mean per object, see
+  [Lifecycle](../components/lifecycle.md).)
+
+## Wiring: `Interface` objects, not a `connect()` call
+
+There is **no framework `connect()`**. Components expose typed **endpoints** (a `StreamIFMaster`, an
+`MMIFSlave`, …); you connect two endpoints by creating an [`Interface`](../interface/) object and
+calling **`iface.bind(role, endpoint)`** — `role` is `"master"` / `"slave"` (or `in_0` / `out_0`
+for a crossbar). The interface object — not the endpoint — carries the clock and the latency model.
+
+```python
+from waveflow.hw.interface import StreamIF
+from waveflow.hw.memif import DirectMMIF
+
+in_stream  = StreamIF(sim=sim, clk=clk)
+out_stream = StreamIF(sim=sim, clk=clk)
+lite_link  = DirectMMIF(sim=sim, clk=clk, byte_addressable=True)
+
+in_stream.bind ("master", tb.m_in);    in_stream.bind ("slave", accel.s_in)
+out_stream.bind("master", accel.m_out); out_stream.bind("slave", tb.s_out)
+lite_link.bind ("master", tb.m_lite);  lite_link.bind ("slave", accel.s_lite)
+```
+
+The endpoint classes and their `write` / `read` / `get` calls are documented under
+[Interfaces](../interface/) — [streams](../interface/stream.md), [memory-mapped](../interface/aximm.md),
+[register maps](../interface/regmap.md). This page is only about *assembling and running* the system.
+
+## A minimal complete example
+
+A producer streams three bursts to a consumer over one `StreamIF`:
+
+```python
+from dataclasses import dataclass
+import numpy as np
+
+from waveflow.hw.clock import Clock
+from waveflow.hw.interface import StreamIF, StreamIFMaster, StreamIFSlave, Words
+from waveflow.simulation.simobj import ProcessGen, SimObj
+from waveflow.simulation.simulation import Simulation
+
+
+@dataclass
+class Producer(SimObj):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.ep = StreamIFMaster(sim=self.sim, bitwidth=32)
+
+    def run_proc(self) -> ProcessGen[None]:
+        for i in range(3):
+            yield self.process(self.ep.write(np.array([i, i + 1], dtype=np.uint32)))
+
+
+@dataclass
+class Consumer(SimObj):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.received: list[np.ndarray] = []
+        self.ep = StreamIFSlave(sim=self.sim, bitwidth=32, rx_proc=self.on_rx)
+
+    def on_rx(self, words: Words) -> ProcessGen:
+        self.received.append(words.copy())
+        yield self.env.timeout(0)
+
+    def run_proc(self) -> ProcessGen[None]:
+        yield from self.ep.run_proc()        # start the slave receive loop
+
+    def post_sim(self) -> None:
+        assert len(self.received) == 3       # results checked after the run
+
+
+sim = Simulation()
+clk = Clock(freq=100e6)
+producer = Producer(name="prod", sim=sim)
+consumer = Consumer(name="cons", sim=sim)
+
+link = StreamIF(sim=sim, clk=clk)
+link.bind("master", producer.ep)
+link.bind("slave",  consumer.ep)
+
+sim.run_sim()
+print(consumer.received)   # [array([0,1]), array([1,2]), array([2,3])]
+```
+
+A passive component (one whose `run_proc` returns `None`) still participates through `pre_sim` /
+`post_sim`; a slave that needs an active receive loop delegates to `ep.run_proc()` as `Consumer`
+does. Reading **results** is a `post_sim()` job (or just reading attributes after `run_sim()`
+returns, as the producer/consumer does here).
+
+## Worked example: the poly accelerator
+
+[`examples/stream_inband/poly.py`](../../../examples/stream_inband/poly.py) wires a testbench
+(`PolyTB`) to an accelerator (`PolyAccelComponent`) over two `StreamIF`s and one `DirectMMIF` (the
+AXI-Lite control link) — exactly the `bind` pattern above, collected into an example-local
+`connect(sim, tb, accel, clk)` helper (it is a convenience in that file, *not* a framework API). The
+run itself lives in [`poly_build.py`](../../../examples/stream_inband/poly_build.py)'s `PySimStep`:
+it builds the `Simulation`, a `Clock`, a [`Logger`](./logging.md), the accelerator and testbench,
+calls `connect(...)`, then `sim.run_sim()` — and reads `tb.resp_hdr` / `tb.samp_out` and the regmap
+status off the objects afterward. Running a simulation inside a `BuildStep` like this is covered in
+[Build System](../build/python.md).
+
+## See also
+
+- [Interfaces](../interface/) — the endpoint classes and their transaction calls.
+- [Lifecycle](../components/lifecycle.md) — the per-object `pre_sim` / `run_proc` / `post_sim` hooks `run_sim` drives.
+- [Timing model](./timing.md) — how the `Clock` and interface latencies shape the simulated timeline.
+- [Logging](./logging.md) — recording events during the run.

--- a/docs/guide/sim/timing.md
+++ b/docs/guide/sim/timing.md
@@ -1,0 +1,90 @@
+---
+title: Timing model
+parent: Simulation
+nav_order: 2
+audience: python
+api: [Clock, Clock.period, SimObj.now, SimObj.timeout, SimObj.action]
+summary: "The forward timing model that produces the simulated timeline — Clock (frequency / period), how interfaces charge transfer latency in cycles, and how a component models compute latency with self.timeout / self.action. (Analyzing the result is Timing Analysis.)"
+---
+
+# Timing model
+
+A discrete-event simulation has a clock on the wall: `self.now` is the current time in **seconds**.
+This page is the **forward model** — how that time advances: the `Clock`, how interfaces charge for a
+transfer, and how a component charges for its own compute. *Analyzing* the resulting timeline
+(throughput, latency, overlap) is the separate [Timing Analysis Tools](../timing/) section.
+
+## Clock
+
+A [`Clock`](../../../waveflow/hw/clock.py) is a timing domain — just a frequency:
+
+```python
+from waveflow.hw.clock import Clock
+
+clk = Clock(freq=100e6)   # 100 MHz
+clk.period                # 1e-8  seconds  (== 1.0 / freq)
+```
+
+A `Clock` is passed to each `Interface` object (and usually held on components as a `clk` field). It
+converts **cycle counts** — the natural unit for hardware — into the **seconds** the SimPy
+environment advances in.
+
+## Interfaces charge transfer latency
+
+An `Interface` owns the latency model for data crossing it. The standard model is a fixed setup cost
+plus one cycle per word:
+
+```
+transfer_time = (latency_init + nwords) / clk.freq   [seconds]
+```
+
+`latency_init` captures wire delay / arbitration; each word adds one beat. So `yield`ing a
+`master.write(words)` blocks the caller for `transfer_time` of simulated time. The per-interface
+parameters (`latency_init`, the FULL/LITE read/write formulas, `latency_per_word`) are documented
+with each interface — see [Overview](../interface/overview.md), [streams](../interface/stream.md),
+and [memory-mapped](../interface/aximm.md). This page only notes *that* interfaces are where transfer
+time is charged.
+
+## Components charge compute latency
+
+Transfer time alone is not the whole timeline — a component also spends time **computing**. Two
+ways to model that, both on [`SimObj`](../../../waveflow/simulation/simobj.py):
+
+**Wait explicitly with `self.timeout(delay)`** — `delay` in seconds, so convert cycles via the clock:
+
+```python
+def run_proc(self) -> ProcessGen[None]:
+    # ... read input ...
+    yield self.timeout(compute_cycles / self.clk.freq)   # model the compute latency
+    # ... write output ...
+```
+
+**Or wrap a window with `self.action(name, processing_delay)`** — it advances time by
+`processing_delay` *and* records the window for analysis (start/end), so overlaps can be detected:
+
+```python
+yield from self.action("decode", processing_delay=3 / self.clk.freq)
+```
+
+Each call appends an `ActionRecord(name, start, end)` to `self.action_history`; concurrent windows
+on the same object are collected in `self.action_overlaps` (count via
+`self.active_overlap_count()`). `self.now` is the current time at any point.
+
+### Pipelined transfers
+
+For a component that streams data through (rather than buffering a whole burst), the stream endpoints
+expose `get_pipelined` / `write_pipelined`, which carry the first-word arrival time and the
+component's initiation interval / latency (`proc_ii`, `proc_latency`, set to match HLS synthesis
+numbers). That mechanism is documented on the [stream interface](../interface/stream.md) page.
+
+## What this feeds
+
+These cycle costs are what make the simulated timeline meaningful — and what the
+[Timing Analysis Tools](../timing/) then measure (and what the [Logger](./logging.md) records as
+timestamped events for later analysis).
+
+## See also
+
+- [Logging](./logging.md) — capture `self.now`-stamped events to a CSV during the run.
+- [Timing Analysis Tools](../timing/) — analyzing the timeline this model produces.
+- [Interface Overview](../interface/overview.md) — the per-interface latency parameters.

--- a/docs/guide/synthesis/index.md
+++ b/docs/guide/synthesis/index.md
@@ -1,7 +1,7 @@
 ---
 title: Synthesis
 parent: Guide
-nav_order: 6
+nav_order: 7
 has_children: true
 ---
 

--- a/docs/guide/timing/index.md
+++ b/docs/guide/timing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Timing Analysis Tools
 parent: Guide
-nav_order: 9
+nav_order: 10
 has_children: true
 ---
 


### PR DESCRIPTION
Phase 5 of the docs reorg — **new Sim section (authoring)**. Per `plans/docs_reorg.md`, Sim is Arc 2's Python-simulation section; milestone: *simulate a whole system in Python*. A normal flat section (no `python/`//`hls/` subsections). **Net-new authoring — every API grounded in source, no invented signatures.**

## Pages authored (key APIs each cites)
- **index.md** — what a discrete-event sim is + PySim; the 3-phase lifecycle at a glance; the milestone. Cites `Simulation`, `Simulation.run_sim`, `SimObj` (`pre_sim`/`run_proc`/`post_sim`/`error_cleanup`), the SimPy `Environment`.
- **running.md** — the four-step run + a minimal complete producer/consumer + the worked poly assembly. Cites `Simulation()`, `SimObj(sim=)`, `Clock(freq=)`, `StreamIF`/`DirectMMIF`, **`iface.bind(role, ep)`**, `run_sim()`, `StreamIFMaster`/`StreamIFSlave`.
- **timing.md** — the forward timing model. Cites `Clock(freq)` / `Clock.period`, the interface latency formula `(latency_init + nwords)/clk.freq`, `SimObj.now`, `SimObj.timeout(delay)`, `SimObj.action(name, processing_delay)` (+ `action_history` / `action_overlaps`), and the stream `proc_ii`/`proc_latency` pipelined hooks.
- **logging.md** — the event logger. Cites `Logger(name, sim, file_path, fields)`, `Logger.log(**fields)`, `Logger.get_tv(field)`, `NullLogger`; the CSV format (leading `time` column from `env.now` + declared fields, flushed per row).

Grounded in `waveflow/simulation/{simulation,simobj,logger}.py`, `waveflow/hw/clock.py`, and the worked `examples/stream_inband/poly.py` + `poly_build.py` (`PySimStep`).

## No invented `connect()`
There is no framework `connect()`. running.md shows the **real** wiring — create `Interface` objects (`StreamIF`, `DirectMMIF`) and call `iface.bind("master"/"slave", endpoint)` — and notes that poly collects those binds into an *example-local* `connect(sim, tb, accel, clk)` helper (a convenience in that file, not an API).

## Cross-links vs duplication
- **components/lifecycle.md** — index/running link it for the *per-object* hook semantics; Sim covers the *system* view (how `run_sim` drives all objects). No re-explaining the hooks.
- **interface/** — running cites it for endpoint classes + transaction calls (`write`/`read`/`get`); Sim only covers *assembling/running*. The latency *parameters* are left on interface/overview/stream/aximm; timing.md states only *that* interfaces charge transfer time.
- **timing/** (Timing Analysis) — timing.md is the forward *model*; it repeatedly defers *analysis* of the timeline to that section.
- **build/python.md** — running/logging link it for running a sim inside a `BuildDag` (`PySimStep`); not duplicated.
- Forward-refs to **comp_codegen / Custom Hooks** are plain text (those sections don't exist → would break the gate).

## Nav renumbering
Sim inserted at **nav_order 6** (after Components); subsequent Guide sections bumped +1:

| section | before → after |
|---|---|
| Synthesis | 6 → 7 |
| Build System | 7 → 8 |
| Memory Modeling | 8 → 9 |
| Timing Analysis Tools | 9 → 10 |
| Developers | 10 → 11 |
| AI Tooling | 11 → 12 |

Guide-level order is now 1–12 with no gaps/collisions. Within Sim: index (6), running 1, timing 2, logging 3.

## Validation (docs-only)
No Ruby/Jekyll locally and no docs-build CI → **structural**:
- **Link gate (the exact task sweep over every relative `.md` / `.py` / directory target): `broken total: 0`.**
- `audience: python` on every Sim page; `parent: Simulation` on the leaves; no nav_order collisions within Sim or at the Guide level; `Simulation` is a unique page title.

Do not merge yet — reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
