### PR TITLE
docs: Custom Hooks section (Phase 7 finale) — hand-written codegen guide

### DIFF
--- a/docs/guide/ai_tooling/index.md
+++ b/docs/guide/ai_tooling/index.md
@@ -1,7 +1,7 @@
 ---
 title: AI Tooling
 parent: Guide
-nav_order: 12
+nav_order: 13
 has_children: true
 ---
 

--- a/docs/guide/build/index.md
+++ b/docs/guide/build/index.md
@@ -1,7 +1,7 @@
 ---
 title: Build System
 parent: Guide
-nav_order: 8
+nav_order: 9
 has_children: true
 ---
 

--- a/docs/guide/comp_codegen/index.md
+++ b/docs/guide/comp_codegen/index.md
@@ -12,7 +12,8 @@ summary: "The auto-generated codegen path: how a Python HwComponent lowers to Vi
 This section is the **auto-generated codegen path**: how a Python [`HwComponent`](../components/) is
 lowered into concrete, Vitis-ready C++. It is the first half of Arc 3 (hardware generation) — the
 **machine-generated** structure of a component. The **hand-written** synthesizable kernel bodies that
-plug into that structure (the `@synthesizable(impl_file=…)` hooks) are the **Custom Hooks** section.
+plug into that structure (the `@synthesizable(impl_file=…)` hooks) are documented in
+[Custom Hooks](../custom_hooks/).
 
 The flow starts from a Python class and resolves it into a typed intermediate representation
 (`HwStmt`) that is emitted deterministically. Two things define a generated component:
@@ -29,8 +30,8 @@ The flow starts from a Python class and resolves it into a typed intermediate re
 
 This section covers only the **auto-generated** C++. The body of a compute kernel is *not* generated
 — it is hand-written in a `.tpp` and attached to the component with `@synthesizable(impl_file=…)`.
-Those hand-written hooks (how to author one, the contract they satisfy) are documented in the
-**Custom Hooks** section *(forthcoming)*.
+Those hand-written hooks (how to author one, the contract they satisfy) are documented in
+[Custom Hooks](../custom_hooks/).
 
 ## In this section
 

--- a/docs/guide/components/index.md
+++ b/docs/guide/components/index.md
@@ -61,4 +61,4 @@ From [`examples/stream_inband/poly.py`](../../../examples/stream_inband/poly.py)
 **The synthesizable side** (the C++ realization of a component):
 
 - [Component Code Generation](../comp_codegen/) — what a full component generates: the kernel structure, how `HwParam` becomes C++ template parameters, and `main()`→testbench emission.
-- **Custom Hooks** *(forthcoming section)* — the hand-written synthesizable kernel bodies that plug into a generated component.
+- [Custom Hooks](../custom_hooks/) — the hand-written synthesizable kernel bodies that plug into a generated component.

--- a/docs/guide/custom_hooks/index.md
+++ b/docs/guide/custom_hooks/index.md
@@ -1,0 +1,69 @@
+---
+title: Custom Hooks
+parent: Guide
+nav_order: 8
+has_children: true
+audience: hls
+api: [synthesizable, FunctionStmt]
+summary: "The hand-written codegen path: when the HwStmt extractor can't lower a datapath, you attach a hand-written Vitis C++ kernel to a component method with @synthesizable(impl_file=…). Covers the boundary with auto-generated codegen, the .tpp contract, and the in-kernel port/loop patterns."
+---
+
+# Custom Hooks
+
+Most of a component lowers to C++ automatically — [Component Code Generation](../comp_codegen/)
+walks the synthesizable subset of your Python and emits the kernel structure. But some datapaths are
+beyond what the extractor can lower: a tight complex MAC, a custom pipeline, anything where you want
+hand-tuned HLS pragmas and exact `ap_fixed` intermediates. For those you write the kernel body
+yourself — a **custom hook** — and Waveflow drops it into the generated kernel in place of extracted
+code.
+
+## Auto-generated vs. hand-written
+
+This is the **hand-written** half of Arc 3 (hardware generation); the **auto-generated** half is
+[Component Code Generation](../comp_codegen/). The boundary is one decorator:
+
+| | Auto-generated | Hand-written (here) |
+|---|---|---|
+| Source | the method's Python body | a `.tpp` you write |
+| Lowered by | the `HwStmt` [extractor](../comp_codegen/extractor.md) | nothing — codegen emits a *call* to your C++ |
+| Use when | the body is in the synthesizable subset | the datapath needs hand-tuned HLS C++ |
+
+## The mechanism: `@synthesizable(impl_file=…)`
+
+A method decorated [`@synthesizable(impl_file="…")`](../../../waveflow/hw/synth.py) with no
+`synth_fn` is a **stub**: the extractor does not lower its Python body — codegen instead emits a call
+to a user-written C++ function living in `impl_file`. The method's Python body is still the
+**simulation** model (it runs in [PySim](../sim/)); only its *C++* is hand-written. So the same
+method is bit-exact-checked in Python and synthesized from your `.tpp`.
+
+```python
+from waveflow.hw.synth import synthesizable
+
+class VmacAccel(HwComponent):
+    @synthesizable(impl_file="vmac_compute_impl.tpp")
+    def vmac_compute(self, cmd: VmacCmd, mem: np.ndarray) -> ProcessGen[DataArray]:
+        return self.execute(cmd, mem)   # Python body == the golden; C++ is hand-written
+        yield                            # unreachable — makes this a generator (ProcessGen)
+```
+
+(From [`examples/vmac/vmac.py`](../../../examples/vmac/vmac.py). `execute` is the bit-exact Python
+golden; the C++ contract it must match is the hand-written
+[`vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp).)
+
+## VMAC — the running example
+
+The [VMAC accelerator](../../../examples/vmac/) is the worked hook throughout this section: a complex
+vector engine whose `vmac_compute` hook reads operand rows from an `m_axi` memory image, runs a
+complex datapath (`complex_utils` arithmetic, an `ap_fixed` accumulator, a single requantize), and
+writes results back — all hand-written, bit-exact with the Python golden by construction.
+
+## In this section
+
+- [Writing a hook](./writing.md) — the templated `.tpp` signature, how it plugs into the generated kernel, and the csynth gotchas (scalar `*_core` args, `#pragma HLS INLINE`), walked through VMAC.
+- [Kernel patterns](./patterns.md) — moving data over an `m_axi` / stream port inside a hook (`read_array_lane` / `read_array_slice` / `read_stream_lane`, `TLAST`) and the common loop shapes.
+
+## See also
+
+- [Component Code Generation](../comp_codegen/) — the auto-generated structure your hook plugs into.
+- [Hardware Components](../components/) — declaring the component (ports, `HwParam`) the hook belongs to.
+- [Serialization](../schema/hls/serialization.md) / [raw arrays](../vectorization/hls/raw.md) — the generated packing methods a hook calls.

--- a/docs/guide/custom_hooks/patterns.md
+++ b/docs/guide/custom_hooks/patterns.md
@@ -1,0 +1,100 @@
+---
+title: Kernel patterns
+parent: Custom Hooks
+nav_order: 2
+audience: hls
+api: [read_array_lane, write_array_lane, read_array_slice, write_array_slice, read_stream_lane, write_stream_lane, read_axi4_stream_lane, write_axi4_stream_lane]
+summary: "Moving data over a real port inside a hook: read/write an m_axi memory port (read_array_slice for a resident range, the read_array_lane lane loop for throughput) and a stream port (read_stream_lane / read_axi4_stream_lane with TLAST), plus the common loop shapes (load-to-array, pipelined lane loop)."
+---
+
+# Kernel patterns
+
+A hook spends most of its lines moving typed data between a **port** and **lane buffers**, then
+running the datapath. This page is the in-kernel interface/transaction reference: the calls for an
+`m_axi` memory port and a stream port, and the loop shapes that combine them. The element-keyed
+methods come from the generated `<element>_array_utils::` namespace (here aliased `au`); the geometry
+(`pf`, `lane_capacity`, `get_nwords`) and the lane loop in depth are in
+[raw arrays](../vectorization/hls/raw.md), and the single-schema model is in
+[Serialization](../schema/hls/serialization.md).
+
+## Over a memory (`m_axi`) port
+
+The port is an `ap_uint<WORD_BW>*`. Two access shapes:
+
+**A resident range — `read_array_slice` / `write_array_slice`.** Move an arbitrary element range
+`[i0, i1)` in element coordinates (the kernel never computes `i0/PF`):
+
+```cpp
+au::read_array_slice<WORD_BW>(mem, x);             // whole array → x[0..N)  (static-size overload)
+au::read_array_slice<WORD_BW>(mem, i0, i1, x);     // elements [i0, i1) → x[0 .. i1-i0)
+au::write_array_slice<WORD_BW>(x, mem, i0, i1);    // x → words [i0, i1)  (unaligned ends RMW)
+```
+
+**The lane loop — `read_array_lane` / `write_array_lane`.** For throughput: each call moves the next
+`LW = lane_capacity<WORD_BW>()` elements at a running word pointer (you advance it by
+`get_nwords<WORD_BW>(LW)` words):
+
+```cpp
+au::read_array_lane<WORD_BW>(src, lane, n);        // LW elements in, n valid
+au::write_array_lane<WORD_BW>(lane, dst, n);       // LW elements out
+```
+
+VMAC's hook uses exactly these — `read_array_lane` for operand rows and `read_array_slice` for the
+single per-row scalar (one element at an arbitrary index) — see
+[`vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp).
+
+## Over a stream port
+
+For an AXI-Stream the shape is identical, but you **drop the running pointers** (`xp`/`yp`/`WPU` — the
+stream sequences itself) and use the stream lane variants, which also carry `TLAST`:
+
+```cpp
+streamutils::tlast_status tl;
+au::read_axi4_stream_lane<WORD_BW>(s_in,  lane, n, tl);             // LW elements off the stream
+au::write_axi4_stream_lane<WORD_BW>(s_out, lane, /*tlast=*/last, n);
+```
+
+A plain FIFO (no `TLAST`) uses `read_stream_lane<WORD_BW>(s, dst, n)` /
+`write_stream_lane<WORD_BW>(src, s, n)`. [`examples/vmac/vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp)
+is the worked `m_axi` example; [`examples/stream_inband/poly_evaluate_impl.tpp`](../../../examples/stream_inband/poly_evaluate_impl.tpp)
+is the worked stream example.
+
+## The common loop shapes
+
+- **Load-to-array** — pull a whole operand resident, then compute at leisure:
+  `read_array_slice<WORD_BW>(mem, x)` into a local array. Use when you need random access (a
+  coefficient table, a strided row) and don't need cycle-level scheduling.
+- **Lane loop (throughput)** — step by `LW`, read a lane buffer, `UNROLL` the compute across lanes,
+  write back; advance the word pointer by `WPU`. One shape covers both regimes (vectorized and
+  wide-element `pf = 0`). The full annotated loop with its three pragmas
+  (`ARRAY_PARTITION complete` / `UNROLL` / `PIPELINE II=1`) is in
+  [raw arrays — the lane loop](../vectorization/hls/raw.md#the-lane-loop).
+- **Pipelined stream loop** — the same lane loop over a stream port (drop the pointers, use the
+  stream lane variants above); the stream self-sequences, so it streams in at one beat per `LW`.
+
+## Mapping the Python transfer interfaces to the kernel
+
+A hook is the C++ realization of a Python transfer interface. The
+[`ArrayTransferIF`](../interface/array_transfer.md) calls map to the generated array-utils methods:
+
+| Python (transactional model) | C++ (in the hook) |
+|---|---|
+| `ArrayTransferIFMaster(element_type=Float32).write(elements)` | `float32_array_utils::write_axi4_stream_lane<W>(src, s, tlast, n)` (looped over the burst) |
+| `ArrayTransferIFSlave(element_type=Float32).get(count=n)` | `float32_array_utils::read_axi4_stream_lane<W>(s, dst, n, tl)` (looped) |
+| an array resident in memory | `float32_array_utils::read_array_slice<W>(mem, out)` |
+
+`ArrayUtilsStep` generates these for any `DataSchema` element type, so a transfer parameterized on a
+composite `DataList` gets analogous helpers.
+
+> **API note (for [[project-serialization-phase2b-remaining]]):** earlier drafts mapped these to the
+> bulk `write_array(stream, …)` / `read_array(stream, …)` names. Those are the *memory* bulk methods
+> (`read_array<W>(words, dst, len)`) and were misapplied to streams; the current per-port API is the
+> lane/slice family above. The generator still ships the old bulk `read_array` / `write_array`
+> alongside the lane methods — retiring them is tracked in the serialization phase-2b follow-up.
+
+## See also
+
+- [Raw arrays](../vectorization/hls/raw.md) — the lane loop in depth (pragmas, `pf = 0`) and `read_array_slice`.
+- [Serialization](../schema/hls/serialization.md) — the single-schema methods and the `word_bw` model.
+- [Interfaces](../interface/) — the Python transactional model these kernel calls realize.
+- [Writing a hook](./writing.md) — the `.tpp` signature these calls live inside.

--- a/docs/guide/custom_hooks/writing.md
+++ b/docs/guide/custom_hooks/writing.md
@@ -1,0 +1,115 @@
+---
+title: Writing a hook
+parent: Custom Hooks
+nav_order: 1
+audience: hls
+api: [synthesizable]
+summary: "How to write a custom-hook .tpp: the templated function signature codegen calls, how it plugs into the generated kernel (m_axi/stream ports + the generated packing it calls), and the two VMAC csynth gotchas — pass scalars to a *_core function (a by-value struct DCEs the kernel) and #pragma HLS INLINE so m_axi binds to the top."
+---
+
+# Writing a hook
+
+A hook is a C++ function in the `impl_file` you named in `@synthesizable(impl_file="…")`. Codegen
+emits a *call* to it from the generated kernel; you write the body. This page is the contract that
+function must satisfy, walked through VMAC's
+[`vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp).
+
+## The templated signature
+
+The generated kernel is parameterized on the component's `HwParam` widths (see
+[templating](../comp_codegen/templating.md)), so the hook is a **function template** over those same
+widths, living in the component's `cpp_namespace`. VMAC's hook takes the command struct and the
+`m_axi` memory pointer:
+
+```cpp
+namespace vmac_impl {   // == VmacAccel.cpp_namespace
+
+template <int MEM_BW, int MEM_AWIDTH, int DATA_BW, int INT_BITS, int ACC_BW, int OUT_BW,
+          bool Q_RND, bool O_SAT, int MAX_COLS>
+void vmac_compute(VmacCmd cmd, ap_uint<MEM_BW>* mem) {
+    // ... read operands, compute, write back ...
+}
+
+}  // namespace vmac_impl
+```
+
+The file is a `.tpp` (not `.cpp`) because it is templated: the definition must be visible at the
+include site so the template instantiates for each width set. (The generated header includes it; see
+[templating](../comp_codegen/templating.md) for why parameterized hook stubs become `.tpp`.)
+
+## How it plugs in
+
+The hook is handed the component's **ports** and works through the **generated packing helpers** — it
+does not hand-roll bit twiddling:
+
+- The `ap_uint<MEM_BW>* mem` argument is the component's `m_axi` port. The hook reads/writes it with
+  the generated array-utils methods (`read_array_lane` / `read_array_slice` / `write_array_lane`) —
+  the [kernel patterns](./patterns.md) page covers these.
+- The command (`VmacCmd cmd`) is the deserialized control struct; its fields drive the addressing.
+- Arithmetic comes from the generated/shipped headers the component pulls in (VMAC uses
+  `complex_utils.hpp`), not from inline formulas.
+
+So a hook is *glue + datapath*: it calls generated serialization to move typed data over the port,
+and you write only the math in between.
+
+## The csynth gotchas (from VMAC)
+
+Two non-obvious rules, both learned from VMAC's `.tpp` and both about how the hook meets the
+synthesizable top:
+
+### 1. Pass scalars to a `*_core` function — not a struct by value
+
+Passing the nested `VmacCmd` **struct by value** into the synthesizable path mis-decomposes through
+HLS's array/struct optimization at csynth: loop bounds fold to 0 and the kernel is dead-code
+eliminated. The fix is a `*_core` function that takes the command as **flat scalar arguments**
+(each keeping its precise type), with the struct-taking wrapper kept only for the csim testbench:
+
+```cpp
+// Scalar-arg core — the synthesizable top calls THIS directly.
+template <int MEM_BW, int MEM_AWIDTH, /* … widths … */>
+void vmac_compute_core(
+    ap_uint<MEM_BW>* mem,
+    int op, bool reduce, ap_uint<16> n_rows, ap_uint<16> n_cols,
+    ap_uint<MEM_AWIDTH> a_addr, ap_int<MEM_AWIDTH> a_rs, /* … */) {
+#pragma HLS INLINE
+    // ... datapath ...
+}
+
+// Thin struct-taking wrapper — fine for the csim harness; unwraps cmd into the core's scalars.
+template <int MEM_BW, int MEM_AWIDTH, /* … */>
+void vmac_compute(VmacCmd cmd, ap_uint<MEM_BW>* mem) {
+    vmac_compute_core<MEM_BW, MEM_AWIDTH, /* … */>(
+        mem, (int)cmd.op, (bool)cmd.reduce, cmd.n_rows, cmd.n_cols,
+        cmd.a.addr, cmd.a.row_stride, /* … */);
+}
+```
+
+Keeping the precise field types (`ap_uint<MEM_AWIDTH>` addresses, signed strides, `ap_uint<16>`
+shape) also keeps the address arithmetic sized by `MEM_AWIDTH` rather than a stray 32-bit `int`.
+
+### 2. `#pragma HLS INLINE` so `m_axi` binds to the top
+
+The `*_core` function carries `#pragma HLS INLINE` so it is inlined **into the synthesizable top**.
+That way the `m_axi` reads/writes belong to the top's `gmem` port. Left as a separate module, the
+function would have "no outputs" and the `gmem` port would dangle. Any small helper that touches the
+memory pointer (VMAC's `elem_to_word`) is `INLINE` for the same reason.
+
+## Walkthrough: VMAC
+
+Putting it together, `vmac_compute_core` is the whole VMAC datapath:
+
+1. **Compute row addresses** from the command's element-coordinate addr/stride fields.
+2. **Read operand rows** off `mem` with the generated lane methods (`vmac_in_au::read_array_lane`),
+   and the per-row scalar with `read_array_slice` — see [kernel patterns](./patterns.md).
+3. **Run the complex datapath** — `complex_utils` `cmult`/`cadd`/`conj`, an `ap_fixed` accumulator,
+   one `cx_requantize` to the output format (full precision until the single requantize).
+4. **Write results back** with `vmac_out_au::write_array_lane`.
+
+Because the hook's Python sibling (`VmacAccel.execute`) is the bit-exact golden, the `.tpp` is
+validated against it in csim — the hook can never silently drift from the model.
+
+## See also
+
+- [Kernel patterns](./patterns.md) — the port read/write calls and loop shapes a hook uses.
+- [Component Code Generation: Templating](../comp_codegen/templating.md) — why the hook is a `.tpp` and how `HwParam` reaches it.
+- [`@synthesizable`](../../../waveflow/hw/synth.py) — the decorator and its `impl_file` / `synth_fn` options.

--- a/docs/guide/developer/index.md
+++ b/docs/guide/developer/index.md
@@ -1,7 +1,7 @@
 ---
 title: Developers
 parent: Guide
-nav_order: 11
+nav_order: 12
 has_children: true
 ---
 

--- a/docs/guide/interface/array_transfer.md
+++ b/docs/guide/interface/array_transfer.md
@@ -259,18 +259,10 @@ Both `cmd_slave` and `samp_slave` share the same `transport` (and therefore the 
 
 ## Synthesis mapping
 
-> The synthesizable side — using this interface inside a kernel body (the `m_axi` / stream port and
-> the `read_array` / `write_array` calls on it) — is covered in the forthcoming **Custom Hooks**
-> section. This mapping table is a pointer to that C++; it is documented in full there.
-
-When generating Vitis HLS code, `ArrayTransferIF` maps to the utilities produced by `ArrayUtilsStep`:
-
-| Python | C++ |
-|---|---|
-| `ArrayTransferIFMaster(element_type=Float32).write(elements)` | `float32_array_utils::write_array(stream, data, n)` |
-| `ArrayTransferIFSlave(element_type=Float32).get(count=n)` | `float32_array_utils::read_array(stream, n)` |
-
-`ArrayUtilsStep` works for any `DataSchema` subclass, so an `ArrayTransferIF` parameterized on a composite `DataList` generates analogous struct-array utilities.
+The **synthesizable side** — the generated `<element>_array_utils` calls a kernel uses to move this
+transfer over an `m_axi` / stream port (`write_axi4_stream_lane` / `read_axi4_stream_lane`, or
+`read_array_slice` for a resident array) — is documented, with the Python→C++ mapping table, in
+[Custom Hooks: kernel patterns](../custom_hooks/patterns.md#mapping-the-python-transfer-interfaces-to-the-kernel).
 
 ---
 

--- a/docs/guide/interface/index.md
+++ b/docs/guide/interface/index.md
@@ -25,5 +25,5 @@ This section is the **Python transactional model**: the interface classes, their
 ## See also
 
 - [Hardware Components](../components/) — declaring the ports (these endpoints) on a component.
-- **Custom Hooks** *(forthcoming section)* — the synthesizable side: using an interface inside a kernel body (the `#pragma HLS INTERFACE` ports and the `read_stream` / `m_axi` calls). It does not exist yet; the kernel-facing C++ for these interfaces lands there.
+- [Custom Hooks](../custom_hooks/) — the synthesizable side: using an interface inside a kernel body (the `#pragma HLS INTERFACE` ports and the `read_stream` / `m_axi` calls on it).
 

--- a/docs/guide/memory/index.md
+++ b/docs/guide/memory/index.md
@@ -1,7 +1,7 @@
 ---
 title: Memory Modeling
 parent: Guide
-nav_order: 9
+nav_order: 10
 has_children: true
 ---
 

--- a/docs/guide/sim/index.md
+++ b/docs/guide/sim/index.md
@@ -56,5 +56,5 @@ kernels — is on the [component Lifecycle](../components/lifecycle.md) page; th
 - [Build System](../build/python.md) — running a simulation as a step in a `BuildDag`.
 
 > The simulation models a design in Python. Turning that design into synthesizable C++ — the
-> generated kernel structure and the hand-written kernel bodies — is the codegen arc: the
-> forthcoming **component codegen** and **Custom Hooks** sections.
+> generated kernel structure and the hand-written kernel bodies — is the codegen arc:
+> [Component Code Generation](../comp_codegen/) and [Custom Hooks](../custom_hooks/).

--- a/docs/guide/timing/index.md
+++ b/docs/guide/timing/index.md
@@ -1,7 +1,7 @@
 ---
 title: Timing Analysis Tools
 parent: Guide
-nav_order: 10
+nav_order: 11
 has_children: true
 ---
 

--- a/docs/guide/vectorization/hls/raw.md
+++ b/docs/guide/vectorization/hls/raw.md
@@ -204,20 +204,11 @@ bus-width → throughput relationship made concrete (and what the VMAC `mem_dwid
 
 ### Streams instead of memory
 
-> Transfer over a real stream/port — the stream/`TLAST` variants and the `m_axi`-port loop patterns — is
-> detailed in [Interfaces](../../interface/); this section is the local-buffer sketch.
-
-For an AXI-Stream port the shape is identical, but you **drop the running pointers** (`xp`/`yp`/`WPU` — the
-stream sequences itself) and use the stream lane variants, which also carry `TLAST`:
-
-```cpp
-streamutils::tlast_status tl;
-au::read_axi4_stream_lane<WORD_BW>(s_in,  lane, n, tl);             // LW elements off the stream
-au::write_axi4_stream_lane<WORD_BW>(s_out, lane, /*tlast=*/last, n);
-```
-
-`examples/vmac/vmac_compute_impl.tpp` is the worked `m_axi` example (the lane loop above);
-`examples/stream_inband/poly_evaluate_impl.tpp` is the worked stream example.
+The same lane loop runs over a stream port — you drop the running pointers (the stream
+self-sequences) and use the stream lane variants (`read_stream_lane` / `read_axi4_stream_lane`, the
+latter carrying `TLAST`). Moving data over a real stream or `m_axi` port inside a kernel — the stream
+lane calls and the worked `.tpp` examples — is covered in
+[Custom Hooks: kernel patterns](../../custom_hooks/patterns.md).
 
 ## See also
 


### PR DESCRIPTION
Phase 7 of the docs reorg — **the finale: new Custom Hooks section**. The second half of Arc 3 (hardware generation): the **hand-written** codegen path — the hook-authoring guide. Net-new authoring + migration of two parked sections; every signature grounded in source / VMAC.

## Pages authored (key APIs each cites)
All `audience: hls`, `parent: Custom Hooks`.
- **index.md** — what a custom hook is + when you need one (a datapath the `HwStmt` extractor can't lower); the auto-generated (comp_codegen) vs hand-written boundary; the **`@synthesizable(impl_file=…)`** stub mechanism (`waveflow/hw/synth.py`); VMAC as the running example (the `vmac_compute` hook from `examples/vmac/vmac.py`).
- **writing.md** — the templated `.tpp` signature codegen calls; how it plugs into the generated kernel (the `m_axi`/stream ports + the generated packing it calls); the **two VMAC csynth gotchas** — pass scalars to a `*_core` fn (a by-value `VmacCmd` DCEs the kernel at csynth) and **`#pragma HLS INLINE`** so `m_axi` binds to the top — walked through `vmac_compute_impl.tpp`.
- **patterns.md** — in-kernel port transactions + loop shapes: `read_array_slice` / `read_array_lane` / `write_array_lane` (m_axi), `read_stream_lane` / `read_axi4_stream_lane` (stream, `TLAST`); the load-to-array and pipelined lane-loop shapes.

Grounded in `waveflow/hw/synth.py`, `examples/vmac/vmac.py` + `vmac_compute_impl.tpp` (the scalar-args `*_core`, `INLINE`, the gotchas), and the port methods from `schema/hls/serialization.md` + `vectorization/hls/raw.md`.

## Parked-content migration (moved, not copied)
- **`vectorization/hls/raw.md` "Streams instead of memory"** → `custom_hooks/patterns.md`; raw.md replaced with a one-line cross-link.
- **`interface/array_transfer.md` "Synthesis mapping" table** → `custom_hooks/patterns.md`; array_transfer.md replaced with a cross-link.
  - **API reconciliation:** the old table used bulk `write_array(stream, …)` / `read_array(stream, n)` — those are the *memory* bulk methods, misapplied to a stream. The migrated table uses the current per-port lane family: `write_axi4_stream_lane` / `read_axi4_stream_lane` (and `read_array_slice` for a resident array). The lingering old bulk `read_array` / `write_array` (still shipped by the generator) is flagged in-page for the **serialization phase-2b** follow-up.

## Forward-refs converted to real links
The plain-text "Custom Hooks (forthcoming)" left by Phases 3–6 are now real links: `components/index.md`, `comp_codegen/index.md` (×2), `interface/array_transfer.md` (folded into the migration), `interface/index.md`, `sim/index.md` (which also links the now-real Component Code Generation). **No "forthcoming" Custom Hooks reference remains.**

## Nav renumbering
custom_hooks at **8**; bumped +1: Build 8→9, Memory 9→10, Timing 10→11, Developers 11→12, AI Tooling 12→13. Guide order is now **1–13**, unique. The Arc-3 sections are adjacent: Component Code Generation (7) → Custom Hooks (8).

## Validation (docs-only)
No Ruby/Jekyll locally and no docs-build CI → **structural**:
- **Link gate (exact sweep over every relative `.md` / `.py` / directory target): `broken total: 0`.**
- No `forthcoming` Custom Hooks refs remain; the parked sections are gone from `raw.md` / `array_transfer.md` (replaced by cross-links).
- `audience: hls` + `parent: Custom Hooks` on the leaves; `Custom Hooks` is a unique title; Guide nav **1–13 unique** (custom_hooks at 8).

This completes the guide reorg (Phases 1–7). Do not merge yet — reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
