### PR TITLE
docs: restructure comp_codegen (conceptual on-ramp) + drop internal "Arc" naming

### DIFF
--- a/docs/guide/comp_codegen/codegen.md
+++ b/docs/guide/comp_codegen/codegen.md
@@ -1,7 +1,7 @@
 ---
 title: Codegen
 parent: Component Code Generation
-nav_order: 2
+nav_order: 4
 audience: hls
 api: [kernel_files_to_str, HlsCodegenStep]
 summary: "How resolved HwStmt IR is emitted to deterministic kernel files — <kernel>.hpp / .cpp plus sticky hook impl files — with C++ type lowering, top-level signatures, namespace-qualified hook calls, and variant naming."

--- a/docs/guide/comp_codegen/extractor.md
+++ b/docs/guide/comp_codegen/extractor.md
@@ -1,7 +1,7 @@
 ---
 title: Extractor
 parent: Component Code Generation
-nav_order: 1
+nav_order: 3
 audience: hls
 api: [HwStmtExtractor, extract_kernel, SynthesisError]
 summary: "How HwStmtExtractor parses the synthesizable subset of a component's Python (on_start / run_proc, or main for a testbench) into the HwStmt IR, failing fast with SynthesisError on unsupported patterns."

--- a/docs/guide/comp_codegen/index.md
+++ b/docs/guide/comp_codegen/index.md
@@ -4,39 +4,32 @@ parent: Guide
 nav_order: 7
 has_children: true
 audience: hls
-summary: "The auto-generated codegen path: how a Python HwComponent lowers to Vitis-ready C++ — the HwStmt extractor over the synthesizable subset, the emitted file structure, and HwParam parameterization (templating / param_supports). Hand-written kernel bodies are Custom Hooks."
+summary: "How a Python HwComponent is generated into Vitis-ready C++: the HLS realization of a component (top function, endpoint ports, execution model), the HwStmt extractor over the synthesizable subset, the emitted file structure, and HwParam parameterization. Hand-written kernel bodies are Custom Hooks."
 ---
 
 # Component Code Generation
 
-This section is the **auto-generated codegen path**: how a Python [`HwComponent`](../components/) is
-lowered into concrete, Vitis-ready C++. It is the first half of Arc 3 (hardware generation) — the
-**machine-generated** structure of a component. The **hand-written** synthesizable kernel bodies that
-plug into that structure (the `@synthesizable(impl_file=…)` hooks) are documented in
-[Custom Hooks](../custom_hooks/).
+WaveFlow generates **Vitis-ready C++ for every [`HwComponent`](../components/)**. You write the
+component once in Python — its ports, its parameters, its behavior — and the generator emits a
+top-level HLS kernel with the right AXI interfaces, the C++ type lowering, and the build-ready file
+set, all from that single source.
 
-The flow starts from a Python class and resolves it into a typed intermediate representation
-(`HwStmt`) that is emitted deterministically. Two things define a generated component:
+This chapter covers **what the generator produces automatically**: the structure of a generated
+component, how each endpoint becomes an HLS port, the execution model it lowers to, what the
+`HwStmt` extractor accepts, and how `HwParam` parameterizes the output.
 
-- **What is lowered** — the [extractor](./extractor.md) walks the *synthesizable subset* of the
-  component's Python (`on_start` / `run_proc`, or `main` for a testbench) into the `HwStmt` IR, and
-  the [emitter](./codegen.md) turns that IR into the `.hpp` / `.cpp` file set (plus sticky hook impl
-  files).
-- **How it is parameterized** — `HwParam` fields drive [templating](./templating.md) (template-aware
-  C++ / `.tpp` hook stubs) and [param_supports](./param_supports.md) (multiple concrete kernel
-  entry points from one class).
-
-## Auto-generated vs. hand-written
-
-This section covers only the **auto-generated** C++. The body of a compute kernel is *not* generated
-— it is hand-written in a `.tpp` and attached to the component with `@synthesizable(impl_file=…)`.
-Those hand-written hooks (how to author one, the contract they satisfy) are documented in
-[Custom Hooks](../custom_hooks/).
+A component's compute body is *not* always auto-generated. When a datapath needs hand-tuned HLS C++,
+you write the kernel body yourself and attach it with `@synthesizable(impl_file=…)`. That
+hand-written path — how to author a kernel body, the in-kernel port and loop patterns — is the next
+chapter, [Custom Hooks](../custom_hooks/). This chapter is the auto-generated structure those hooks
+plug into.
 
 ## In this section
 
-- [Extractor](./extractor.md) — how `HwStmtExtractor` parses the synthesizable Python subset into IR.
-- [Codegen](./codegen.md) — how `kernel_files_to_str` emits kernel files and naming.
+- [Component structure](./structure.md) — how an `HwComponent` becomes a Vitis HLS top-level function: the kernel entry, the execution model (free-running vs. regmap-launched), and where hooks come from.
+- [Endpoint interfaces](./interface.md) — how each declared endpoint (stream / m_axi / regmap) is realized as a Vitis port (`hls::stream` / `m_axi` / `s_axilite`) and how a slave endpoint's handler binds.
+- [Extractor](./extractor.md) — how `HwStmtExtractor` parses the synthesizable Python subset into the `HwStmt` IR, failing fast on unsupported patterns.
+- [Codegen](./codegen.md) — how `kernel_files_to_str` emits the deterministic kernel file set and resolves naming.
 - [Templating](./templating.md) — how `HwParam` values map to template-aware code paths.
 - [Param supports](./param_supports.md) — how variant kernels are emitted from `param_supports`.
 - [Testbench](./testbench.md) — `HwTestbench` and `is_testbench=True` codegen mode.
@@ -44,5 +37,6 @@ Those hand-written hooks (how to author one, the contract they satisfy) are docu
 ## See also
 
 - [Hardware Components](../components/) — the Python `HwComponent` this section generates C++ for.
+- [Custom Hooks](../custom_hooks/) — the hand-written synthesizable kernel bodies that plug into a generated component.
 - [Cosim timing](../timing/cosim_timing.md) — extracting and validating cycle timing from the generated kernel's cosim (now under Timing Analysis, where the timeline analysis lives).
 - [Build System](../build/) — the `BuildDag` that drives these codegen steps end to end.

--- a/docs/guide/comp_codegen/interface.md
+++ b/docs/guide/comp_codegen/interface.md
@@ -1,0 +1,116 @@
+---
+title: Endpoint interfaces
+parent: Component Code Generation
+nav_order: 2
+audience: hls
+applies_to: [HwComponent]
+api: [kernel_signature, StreamIF, MMIFMaster, VitisRegMapMMIFSlave]
+summary: "How each declared endpoint on an HwComponent is realized as a Vitis HLS port: stream endpoints become hls::stream<axi4s_word<bw>>& with #pragma HLS INTERFACE axis; m_axi masters become ap_uint<bw>* with m_axi offset=slave bundle=gmem; a VitisRegMapMMIFSlave becomes s_axilite register-field ports plus the ap_start/ap_done control protocol. Also how a slave endpoint's handler binds to the kernel body."
+---
+
+# Endpoint interfaces
+
+## Concept
+
+A generated kernel's argument list and its `#pragma HLS INTERFACE` block are derived directly from
+the component's declared endpoints by
+[`kernel_signature(comp)`](../../../waveflow/build/hwgen.py). Each endpoint type maps to a specific
+Vitis port realization, emitted in a canonical order — **streams, then regmap fields, then m_axi
+masters**.
+
+| Endpoint (Python) | Kernel argument | Interface pragma |
+|---|---|---|
+| `StreamIFMaster` / `StreamIFSlave` | `hls::stream<streamutils::axi4s_word<bw>>& <name>` | `#pragma HLS INTERFACE axis port=<name>` |
+| `VitisRegMapMMIFSlave` (per field) | `<cpp_type>& <field>` (or `<elem>[<count>]` for a raw array field) | `#pragma HLS INTERFACE s_axilite port=<field> bundle=control` |
+| m_axi master (e.g. `MMIFMaster` / `DirectMMIF` master) | `ap_uint<bw>* <name>` | `#pragma HLS INTERFACE m_axi port=<name> offset=slave bundle=gmem depth=<name>_depth` |
+
+## Stream endpoints → `axis`
+
+Every stream endpoint becomes an `hls::stream` reference of AXI4-Stream words, with an `axis`
+interface pragma. The word bitwidth is the endpoint's concrete `bitwidth` (or the variant's
+`HwParamValue`). From [`examples/stream_inband/gen/poly.hpp`](../../../examples/stream_inband/gen/poly.hpp):
+
+```cpp
+void poly(
+    hls::stream<streamutils::axi4s_word<32>>& s_in,
+    hls::stream<streamutils::axi4s_word<32>>& m_out,
+    ...
+```
+
+Master and slave streams both realize as `hls::stream<...>&` — the direction is a property of how the
+body reads or writes them, not of the port type.
+
+## Regmap slave → `s_axilite` + `ap_ctrl`
+
+A [`VitisRegMapMMIFSlave`](../../../waveflow/hw/regmap.py) does **not** become one port — it expands
+to **one `s_axilite` port per user-declared register field**, each on `bundle=control`. The
+generated `simp_fun` kernel turns the `x` / `a` / `b` / `y` register fields into four scalar
+references:
+
+```cpp
+void simp_fun(
+    ap_int<32>& x,
+    ap_int<32>& a,
+    ap_int<32>& b,
+    ap_int<32>& y
+);
+```
+
+The auto-prepended `ap_start` / `ap_done` registers are not emitted as data ports; they are the
+**control protocol**. When a regmap drives the component, the kernel's `return` port also binds
+`s_axilite ... bundle=control`, giving the host the `ap_start`/`ap_done` handshake that launches the
+[regmap-launched](./structure.md) `on_start` body.
+
+## m_axi master → `m_axi` pointer
+
+A memory-mapped master endpoint becomes an `ap_uint<bw>*` pointer with an `m_axi` pragma
+(`offset=slave bundle=gmem`), the burst region bounded by a generated `<name>_depth` header
+constant. From [`examples/shared_mem/gen/hist.hpp`](../../../examples/shared_mem/gen/hist.hpp):
+
+```cpp
+void hist(
+    hls::stream<streamutils::axi4s_word<32>>& s_in,
+    hls::stream<streamutils::axi4s_word<32>>& m_out,
+    ap_uint<32>* m_mem
+);
+```
+
+(Note the canonical order: the two streams precede the `m_mem` master.) Reading and writing through
+this pointer inside the body — the lane/slice transactions — is [Custom Hooks](../custom_hooks/)
+material.
+
+## The control protocol on `return`
+
+Which protocol binds the `return` port follows from the endpoint mix (in `kernel_signature`):
+
+- a regmap slave is present ⇒ `s_axilite ... bundle=control` (host-launched via `ap_start`/`ap_done`);
+- else m_axi masters are present ⇒ `ap_ctrl_hs`;
+- else (stream-only) ⇒ `s_axilite ... bundle=control`.
+
+## How a slave endpoint's handler binds
+
+A slave endpoint carries the Python handler that becomes (part of) the synthesized body:
+
+- A **`VitisRegMapMMIFSlave`** is constructed with `on_start=self.on_start` (see
+  [`examples/regmap/simp_fun.py`](../../../examples/regmap/simp_fun.py)). That handler is exactly the
+  method [`extract_kernel`](../../../waveflow/build/hwcodegen.py) lowers as the kernel body — the
+  regmap slave both adds the `s_axilite` ports *and* designates the `ap_start`-triggered entry point.
+- For **stream / m_axi** endpoints there is no separate handler method: the free-running `run_proc`
+  body reads and writes them directly, and those per-port read/write calls are lowered to
+  `hls::stream` / `m_axi` transactions. The transaction methods themselves (`read_stream_lane`,
+  `read_array_lane`, …) are documented in [Custom Hooks: Kernel patterns](../custom_hooks/patterns.md).
+
+## API
+
+- [`kernel_signature(comp, variant_suffix="")`](../../../waveflow/build/hwgen.py) — builds the concrete top-function signature + `#pragma HLS INTERFACE` lines from the endpoints.
+- [`StreamIFMaster` / `StreamIFSlave`](../../../waveflow/hw/interface.py) — stream endpoints → `axis` ports.
+- [`VitisRegMapMMIFSlave`](../../../waveflow/hw/regmap.py) — regmap slave → `s_axilite` field ports + control protocol; carries the `on_start` handler.
+- [`MMIFMaster` / `DirectMMIF`](../../../waveflow/hw/aximm.py) — memory-mapped master → `m_axi` pointer.
+
+## Quick reference
+
+- Argument order is canonical: streams → regmap fields → m_axi masters.
+- Stream endpoint ⇒ `hls::stream<axi4s_word<bw>>&` + `axis`.
+- Regmap slave ⇒ one `s_axilite` port *per field* + `ap_start`/`ap_done` control; its `on_start` is the kernel body.
+- m_axi master ⇒ `ap_uint<bw>*` + `m_axi offset=slave bundle=gmem depth=<name>_depth`.
+- `return` protocol: `s_axilite` when a regmap (or stream-only) drives control, `ap_ctrl_hs` for m_axi-only kernels.

--- a/docs/guide/comp_codegen/param_supports.md
+++ b/docs/guide/comp_codegen/param_supports.md
@@ -1,7 +1,7 @@
 ---
 title: Param supports
 parent: Component Code Generation
-nav_order: 4
+nav_order: 6
 audience: hls
 applies_to: [HwParam]
 api: [param_supports]

--- a/docs/guide/comp_codegen/structure.md
+++ b/docs/guide/comp_codegen/structure.md
@@ -1,0 +1,106 @@
+---
+title: Component structure
+parent: Component Code Generation
+nav_order: 1
+audience: hls
+applies_to: [HwComponent]
+api: [kernel_files_to_str, cpp_kernel_name, extract_kernel, synthesizable]
+summary: "The Vitis HLS realization of an HwComponent: each component becomes one top-level kernel function whose arguments are its endpoints; the execution model is a free-running loop (run_proc) or a one-time regmap-launched call (on_start), selected by whether the component carries a VitisRegMapMMIFSlave; the kernel body comes from the @synthesizable methods (auto-extracted or, with impl_file=, hand-written)."
+---
+
+# Component structure
+
+## Concept
+
+Each [`HwComponent`](../components/) is generated into **one Vitis HLS top-level function** — the
+kernel. The function name defaults to the class name in `snake_case` with a trailing `_component`
+stripped (`PolyAccelComponent → poly_accel`), overridable per class with
+`cpp_kernel_name: ClassVar[str] = "..."`. Its arguments correspond one-to-one to the component's
+declared **endpoints**; how each endpoint type maps to a port (`hls::stream` / `m_axi` /
+`s_axilite`) is the next page, [Endpoint interfaces](./interface.md).
+
+For the simplest case, a regmap-only component generates a kernel whose arguments are just its
+register fields. From [`examples/regmap/gen/simp_fun.hpp`](../../../examples/regmap/gen/simp_fun.hpp):
+
+```cpp
+void simp_fun(
+    ap_int<32>& x,
+    ap_int<32>& a,
+    ap_int<32>& b,
+    ap_int<32>& y
+);
+
+namespace simp_fun_impl {
+    ap_int<32> compute(ap_int<32> x, ap_int<32> a, ap_int<32> b);
+}
+```
+
+The top function `simp_fun` is the kernel; `simp_fun_impl::compute` is a hook it calls.
+
+## The execution model: free-running vs. regmap-launched
+
+A generated kernel runs in one of two modes, and the generator picks the mode — and the Python
+method it extracts as the kernel body — from the component's endpoints:
+
+| Mode | Kernel entry | Selected when | Control |
+|---|---|---|---|
+| **Regmap-launched** (one-time call) | `on_start` | the component has a `VitisRegMapMMIFSlave` endpoint | host writes `ap_start`; kernel runs once, sets `ap_done` |
+| **Free-running** (endless loop) | `run_proc` | otherwise | `ap_ctrl_hs` / stream-driven |
+
+The selection lives in [`extract_kernel(comp)`](../../../waveflow/build/hwcodegen.py): it scans the
+component's endpoints and, if any is a `VitisRegMapMMIFSlave`, extracts `on_start`; otherwise it
+extracts `run_proc`. (For `HwTestbench` subclasses it routes to `main()` instead — see
+[Testbench](./testbench.md).)
+
+The regmap-launched body is *invocation-style*: it reads inputs from the register map, computes, and
+writes the result, returning once. From
+[`examples/regmap/simp_fun.py`](../../../examples/regmap/simp_fun.py):
+
+```python
+def on_start(self) -> ProcessGen[None]:
+    y = self.compute(
+        self.regmap.get("x"),
+        self.regmap.get("a"),
+        self.regmap.get("b"),
+    )
+    self.regmap.set("y", y)
+```
+
+`VitisRegMap` auto-manages `ap_done` (cleared on `ap_start`, set when `on_start` returns), so the
+body only writes its result. A free-running component instead implements `run_proc` as a long-lived
+process that loops over its stream/`m_axi` ports.
+
+> **Sim-only lifecycle hooks are not synthesized.** `pre_sim` and `post_sim` exist for the Python
+> [simulation lifecycle](../components/lifecycle.md) only — the generator never lowers them. Only the
+> selected kernel entry (`on_start` / `run_proc`, or `main` for a testbench) and the `@synthesizable`
+> methods it calls become C++.
+
+## Where the kernel body comes from
+
+The top function's body and its helper functions come from the component's
+[`@synthesizable`](../../../waveflow/hw/synth.py) methods. There are two kinds:
+
+- **Auto-extracted** — a plain `@synthesizable` method is lowered from the synthesizable subset of
+  its Python by the [extractor](./extractor.md) (`simp_fun_impl::compute`, above, is one).
+- **Hand-written** — `@synthesizable(impl_file="…tpp")` is a stub: the generator emits a *call* to a
+  C++ function you write in that `.tpp`, and the method's Python body remains the simulation golden.
+  This is the [Custom Hooks](../custom_hooks/) path.
+
+Either way the hook is emitted into a namespace derived from the kernel name (or
+`cpp_namespace`), so the call site is `<kernel>_impl::<hook>(...)` as in the `simp_fun_impl::compute`
+declaration above.
+
+## API
+
+- [`kernel_files_to_str(comp_class, output_dir=".", impl_dir=None)`](../../../waveflow/build/hwgen.py) — generate the kernel file contents for a component class.
+- [`cpp_kernel_name(comp_class)`](../../../waveflow/build/hwgen.py) — the default top-function name (`CamelCase → snake_case`, drop `_component`).
+- [`extract_kernel(comp)`](../../../waveflow/build/hwcodegen.py) — selects `on_start` (regmap-launched) vs. `run_proc` (free-running) and resolves the kernel `HwStmt`.
+- [`@synthesizable`](../../../waveflow/hw/synth.py) — marks the methods that become the kernel body / hooks; with `impl_file=` it becomes a hand-written stub.
+
+## Quick reference
+
+- One `HwComponent` → one top-level kernel function; its args are its endpoints.
+- A `VitisRegMapMMIFSlave` endpoint ⇒ regmap-launched (`on_start`, `ap_start`/`ap_done`); otherwise free-running (`run_proc`).
+- `pre_sim` / `post_sim` are simulation-only and are never synthesized.
+- Kernel body = the `@synthesizable` methods; `impl_file=` defers a body to a hand-written [Custom Hook](../custom_hooks/).
+- Override the kernel name with `cpp_kernel_name`; the hook namespace with `cpp_namespace`.

--- a/docs/guide/comp_codegen/templating.md
+++ b/docs/guide/comp_codegen/templating.md
@@ -1,7 +1,7 @@
 ---
 title: Templating
 parent: Component Code Generation
-nav_order: 3
+nav_order: 5
 audience: hls
 applies_to: [HwParam]
 api: [HwParam, HwParamValue]

--- a/docs/guide/comp_codegen/testbench.md
+++ b/docs/guide/comp_codegen/testbench.md
@@ -1,7 +1,7 @@
 ---
 title: Testbench
 parent: Component Code Generation
-nav_order: 5
+nav_order: 7
 audience: hls
 applies_to: [HwTestbench]
 api: [HwTestbench, HlsCodegenStep]

--- a/docs/guide/custom_hooks/index.md
+++ b/docs/guide/custom_hooks/index.md
@@ -19,7 +19,7 @@ code.
 
 ## Auto-generated vs. hand-written
 
-This is the **hand-written** half of Arc 3 (hardware generation); the **auto-generated** half is
+This is the **hand-written** side of hardware generation; the **auto-generated** side is
 [Component Code Generation](../comp_codegen/). The boundary is one decorator:
 
 | | Auto-generated | Hand-written (here) |

--- a/docs/guide/sim/index.md
+++ b/docs/guide/sim/index.md
@@ -13,7 +13,7 @@ summary: "Run a whole system in Python: a SimPy discrete-event simulation that w
 A Waveflow design is, first, a **Python program you can run**. Before any C++ is generated, you
 assemble your components, wire them together with [interfaces](../interface/), and **simulate the
 whole system** — checking that the data flows, the protocol handshakes, and the results are correct.
-That is the Arc-2 milestone: *simulate a whole system in Python.*
+That is the milestone: *simulate a whole system in Python.*
 
 ## Discrete-event simulation (PySim)
 


### PR DESCRIPTION
Docs cleanup of the **Component Code Generation** chapter: (A) remove internal "Arc 1/2/3" vocabulary from user-facing docs, and (B) give the chapter a conceptual on-ramp it was missing. Every new signature grounded in source / generated examples.

## Part A — "Arc" rewordings
The reorg plan organizes work into internal "Arc 1/2/3"; that's a planning construct, not reader-facing. Three spots reworded (real cross-refs kept as links):
- `custom_hooks/index.md` — "hand-written half of **Arc 3** … auto-generated half is comp_codegen" → "hand-written **side** … auto-generated **side** is …" (comp_codegen link kept).
- `sim/index.md` — "the **Arc-2** milestone" → "the milestone".
- `comp_codegen/index.md` — folded into the rewrite below.

`grep -rn "\bArc\b" docs/ --include=*.md` now returns nothing.

## Part B — comp_codegen restructure
The chapter had the auto-gen mechanics (extractor/codegen/templating/…) but no "what does a generated component actually look like" on-ramp. Added two front pages and a contextual index.

**index.md rewrite** — short + contextual: WaveFlow generates Vitis-ready C++ for each `HwComponent`; what the chapter covers; this chapter is the auto-generated methods — hand-written kernel bodies are the next chapter, Custom Hooks. New "in this section" order. No "Arc".

**NEW `structure.md` (nav 1)** — the Vitis HLS realization of an `HwComponent`:
- each component → one top-level kernel function whose args correspond to its endpoints;
- the **execution model** — free-running endless loop (`run_proc`) vs. one-time call (`on_start`, `ap_start`-triggered), selected when the component carries a `VitisRegMapMMIFSlave`;
- which class method is the kernel entry per model; `pre_sim`/`post_sim` are sim-only and **not** synthesized (links `components/lifecycle.md`);
- where hooks come from (`@synthesizable` extracted vs. `@synthesizable(impl_file=…)` → Custom Hooks).
- **Cites:** `cpp_kernel_name` / `kernel_files_to_str` (`waveflow/build/hwgen.py`), `extract_kernel` (`waveflow/build/hwcodegen.py`), `@synthesizable` (`waveflow/hw/synth.py`); worked from `examples/regmap/gen/simp_fun.hpp` + `examples/regmap/simp_fun.py`.

**NEW `interface.md` (nav 2)** — endpoint → HLS port realization:
- `StreamIF` → `hls::stream<streamutils::axi4s_word<bw>>&` + `#pragma HLS INTERFACE axis`;
- `VitisRegMapMMIFSlave` → one `s_axilite` port **per register field** + the `ap_start`/`ap_done` control protocol;
- m_axi master → `ap_uint<bw>*` + `m_axi offset=slave bundle=gmem depth=<name>_depth`;
- the `return`-port control-protocol rule (regmap/stream → `s_axilite`; m_axi-only → `ap_ctrl_hs`);
- how a slave endpoint's handler binds (the regmap slave's `on_start` *is* the kernel body; stream/m_axi read-write calls are lowered in the body → cross-link to Custom Hooks for the transaction methods).
- **Cites:** `kernel_signature` + the `_discover_*` helpers (`waveflow/build/hwgen.py`); worked from the generated `poly.hpp` / `hist.hpp` / `simp_fun.hpp`.

**Renumber:** structure 1, interface 2, extractor 3, codegen 4, templating 5, param_supports 6, testbench 7 (each `nav_order` + the index list updated).

New pages: `audience: hls`, `parent: Component Code Generation`, with `applies_to`/`api`/`summary`; self-contained, canonical signatures grounded in source (not invented), poly/VMAC/simp_fun examples, cross-linking `components/` + `custom_hooks/`.

## Validation (docs-only)
No Ruby/Jekyll locally → structural:
- **Link gate** (exact sweep over every relative `.md` / `.py` / directory target): `broken total: 0`.
- `grep -rn "\bArc\b" docs/ --include=*.md` → nothing.
- comp_codegen children `nav_order` **1–7 unique**; frontmatter consistent (`audience: hls`, `parent: Component Code Generation`).

Do not merge yet — reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
