### PR TITLE
docs: restructure components/ — add the conceptual on-ramp

### DIFF
--- a/docs/guide/comp_codegen/structure.md
+++ b/docs/guide/comp_codegen/structure.md
@@ -39,8 +39,10 @@ The top function `simp_fun` is the kernel; `simp_fun_impl::compute` is a hook it
 
 ## The execution model: free-running vs. regmap-launched
 
-A generated kernel runs in one of two modes, and the generator picks the mode — and the Python
-method it extracts as the kernel body — from the component's endpoints:
+The definition-side view — how you *choose* the mode when writing the component — is
+[Defining a component: Execution models](../components/overview.md#execution-models); this section is its
+C++ realization. A generated kernel runs in one of two modes, and the generator picks the mode — and the
+Python method it extracts as the kernel body — from the component's endpoints:
 
 | Mode | Kernel entry | Selected when | Control |
 |---|---|---|---|

--- a/docs/guide/components/endpoints.md
+++ b/docs/guide/components/endpoints.md
@@ -1,0 +1,80 @@
+---
+title: Endpoint methods
+parent: Hardware Components
+nav_order: 2
+audience: python
+applies_to: [HwComponent]
+api: [StreamIFSlave, StreamIFMaster, MMIFMaster, MMIFSlave, VitisRegMapMMIFSlave, ArrayTransferIFSlave, SchemaTransferIFSlave]
+summary: "The master/slave roles and the endpoint methods a component's behavior is built from: a master initiates transactions (write/push on a stream, read/write/read_array/write_array on an m_axi); a slave responds — a launch handler (on_start), a get/pop pulled in the body (stream/transfer slave), or a passive memory target. A table maps each endpoint type to the method you define or call and the interface page with its signature."
+---
+
+# Endpoint methods
+
+A component's behavior is the **methods on its [endpoints](./overview.md)**. Every endpoint is either
+a **master** or a **slave**, and the role decides whether the component *initiates* a transaction or
+*responds* to one. The two are not a clean "master = code, slave = callback" split — read the roles
+below as *who drives the transaction*.
+
+## Master — the component initiates
+
+A master endpoint drives the bus: the component **calls** the transaction method itself, from its
+[lifecycle](./lifecycle.md) body (`run_proc`, or `on_start` / a `@synthesizable` hook).
+
+- **Stream** — [`StreamIFMaster`](../../../waveflow/hw/interface.py): `write(data)`,
+  `write_pipelined(data, t_out_start)`, `push(value)`. `poly`'s `m_out` emits its response with
+  `m_out.write(resp_hdr)` and `m_out.write_pipelined(...)`.
+- **Memory-mapped** — [`MMIFMaster`](../../../waveflow/hw/memif.py): `read(nwords, addr)`,
+  `write(words, addr)`, and the typed `read_array(elem_type, count, addr)` /
+  `write_array(arr, elem_type, addr)`. A read is still *master-initiated* — the component issues it.
+  `mem_demo`'s driver does `yield from self.master.write_array(values, Uint32, addr)` then
+  `self.master.read_array(Uint32, count=n, addr=addr)`.
+
+## Slave — the component responds
+
+A slave endpoint is the target of a transaction. The component responds in one of three ways:
+
+- **A launch handler.** [`VitisRegMapMMIFSlave`](../../../waveflow/hw/regmap.py) is constructed with
+  `on_start=self.on_start`; the host writing `ap_start` over AXI-Lite invokes that handler. The
+  component's inputs/outputs are the register fields (`self.regmap.get(...)` / `set(...)`). This is
+  `simp_fun`'s only endpoint and `poly`'s control path.
+- **A `get` pulled in the body.** A stream or transfer *slave* delivers incoming data when the
+  component asks for it: [`StreamIFSlave`](../../../waveflow/hw/interface.py) —
+  `get(schema_type, count)`, `get_pipelined(schema_type, count)`, `pop(value)`. `poly`'s `on_start`
+  pulls its command with `cmd_hdr = yield from self.s_in.get(PolyCmdHdr)` and its samples with
+  `s_in.get_pipelined(Float32, count=...)`.
+- **A passive memory target.** [`MMIFSlave`](../../../waveflow/hw/memif.py) is a memory the peer
+  master reads and writes; the component declares it and the transactions are serviced by the model
+  (no handler method). `mem_demo`'s `MemComponent.s_mm` is one.
+
+## By endpoint type
+
+The method names are canonical; the **signatures and semantics live on the linked interface page**.
+
+| Endpoint type | Role | Method you define / call | Interface page |
+|---|---|---|---|
+| `StreamIFSlave` | slave (consume) | `get(schema_type, count)` / `get_pipelined(...)` / `pop(value)` | [Stream](../interface/stream.md) |
+| `StreamIFMaster` | master (initiate) | `write(data)` / `write_pipelined(data, t)` / `push(value)` | [Stream](../interface/stream.md) |
+| `MMIFMaster` | master (initiate) | `read(nwords, addr)` / `write(words, addr)` / `read_array(elem, count, addr)` / `write_array(arr, elem, addr)` | [MM Interfaces](../interface/aximm.md) |
+| `MMIFSlave` | slave (memory target) | passive — serviced by the model; no handler | [MM Interfaces](../interface/aximm.md) |
+| `VitisRegMapMMIFSlave` | slave (launch) | define the `on_start` handler; fields via `regmap.get` / `regmap.set` | [Register Maps](../interface/regmap.md) |
+| `SchemaTransferIFMaster` / `Slave` | master / slave | `write(obj)` / `get()` | [Schema Transfer](../interface/schema_transfer.md) |
+| `ArrayTransferIFMaster` / `Slave` | master / slave | `write(elements)` / `get(count)` | [Array Transfer](../interface/array_transfer.md) |
+
+> A master endpoint connects to a slave endpoint through an **interface** — e.g. an `MMIFMaster` and
+> an `MMIFSlave` are bound to a [`DirectMMIF`](../interface/aximm.md). Declaring endpoints is *what* a
+> component exposes; binding them to interfaces is how a system is *wired* — see
+> [Interfaces](../interface/).
+
+## Endpoints are *what*; lifecycle is *when*
+
+This page is the *what* — the methods available per endpoint. *When* they run — `run_proc` for a
+free-running component vs. `on_start` for a regmap-launched one — is the [Lifecycle](./lifecycle.md)
+page. The synthesizable C++ realization of each endpoint (an `hls::stream` / `m_axi` / `s_axilite`
+port) is [Component Code Generation: Endpoint interfaces](../comp_codegen/interface.md).
+
+## Quick reference
+
+- Master = the component **calls** the transaction (`write` / `push` on a stream; `read` / `write` / `read_array` / `write_array` on an m_axi).
+- Slave = the component **responds**: a launch handler (`on_start`), a `get` / `pop` pulled in the body, or a passive memory target.
+- A `get` on a stream/transfer slave consumes *incoming* data; a `read_array` on an m_axi master *initiates* a read — different roles, both pull data.
+- Method signatures live on the [interface](../interface/) pages; this table is the index.

--- a/docs/guide/components/hwconst.md
+++ b/docs/guide/components/hwconst.md
@@ -1,7 +1,7 @@
 ---
 title: HwConst
 parent: Hardware Components
-nav_order: 2
+nav_order: 5
 audience: python
 applies_to: [HwComponent, DataArray]
 api: [HwConst, discover_hw_const]

--- a/docs/guide/components/hwparam.md
+++ b/docs/guide/components/hwparam.md
@@ -1,7 +1,7 @@
 ---
 title: HwParam
 parent: Hardware Components
-nav_order: 1
+nav_order: 4
 audience: python
 applies_to: [HwComponent]
 api: [HwParam, HwParamValue]

--- a/docs/guide/components/hwtestbench.md
+++ b/docs/guide/components/hwtestbench.md
@@ -1,7 +1,7 @@
 ---
 title: HwTestbench
 parent: Hardware Components
-nav_order: 3
+nav_order: 6
 audience: python
 applies_to: [HwComponent]
 api: [HwTestbench]

--- a/docs/guide/components/index.md
+++ b/docs/guide/components/index.md
@@ -4,58 +4,44 @@ parent: Guide
 nav_order: 5
 has_children: true
 audience: python
-summary: "The Python HwComponent model — declaring typed ports/endpoints, HwParam/HwConst fields, and the pre_sim/run_proc/post_sim lifecycle in the SimPy simulation."
+api: [HwComponent, Component, add_endpoint]
+summary: "The Python HwComponent model: a synthesizable hardware module defined by its interface endpoints, wired to other components by binding endpoints to interfaces, with behavior expressed as the methods on those endpoints. Covers defining a component, the endpoint methods, the lifecycle, and HwParam / HwConst / HwTestbench."
 ---
 
 # Hardware Components
 
-This section is the **Python `HwComponent` model**: how you declare a hardware component in the SimPy simulation — its typed ports (endpoints), its `HwParam` / `HwConst` fields, and its lifecycle. It is Python-only by design; a component's **synthesizable C++ realization** — the generated kernel structure, parameterization, and hand-written hooks — is the codegen arc (see the forward-pointers below).
+A [`HwComponent`](../../../waveflow/hw/hw_component.py) is Waveflow's representation of a
+**synthesizable hardware module**. You write it once in Python, and that one class is the source for
+both the SimPy simulation and the [generated C++ kernel](../comp_codegen/).
 
-## Concept
+A component is defined by three things, and this chapter is organized around them:
 
-`Component` is the base simulation object with named endpoints and SimPy lifecycle hooks. `HwComponent` extends it with synthesis-aware semantics: extractor-compatible methods, hardware endpoint declarations, and codegen metadata.
+- **Its interface endpoints** — the typed ports it talks to the outside world through (a stream
+  input, a memory-mapped master, an AXI-Lite register map). You declare them on the class.
+- **How it is wired** — a component does not call other components directly; its endpoints are
+  **bound** to [interfaces](../interface/), which carry transactions to the endpoints of other
+  components.
+- **What it does** — its behavior is expressed as the **methods on those endpoints** (`get` an
+  incoming transaction, `write` an outgoing one), driven from its lifecycle methods.
 
-Within a component class, fields usually fall into three categories:
-
-- `HwConst[T]` class-level constants for compile-time-style values.
-- `HwParam[T]` instance parameters that participate in synthesis templating.
-- Plain Python fields for simulation-only state and runtime configuration.
-
-Endpoints are declared in `__post_init__` and attached with `add_endpoint(...)`, typically including stream interfaces (`StreamIFMaster` / `StreamIFSlave`) and AXI-Lite control through regmap-backed endpoints such as `VitisRegMapMMIFSlave`. AXI-MM style interfaces are documented in [Interfaces](../interface/aximm.md).
-
-## API
-
-- [`Component`](../../../waveflow/hw/component.py)
-- [`HwComponent`](../../../waveflow/hw/hw_component.py)
-- [`add_endpoint(endpoint)`](../../../waveflow/hw/component.py)
-- [`HwParam`](./hwparam.md)
-- [`HwConst`](./hwconst.md)
-- [`HwTestbench`](./hwtestbench.md)
-
-## Example
-
-From [`examples/stream_inband/poly.py`](../../../examples/stream_inband/poly.py), `PolyAccelComponent` declares stream + regmap endpoints in `__post_init__` and registers each endpoint through `add_endpoint(...)`.
-
-## Quick reference
-
-- Use `Component` for simulation-only behavior.
-- Use `HwComponent` for synthesizable designs.
-- Declare endpoints explicitly in `__post_init__`.
-- Keep synthesis knobs in `HwParam` fields.
-- Keep compile-time constants in `HwConst` fields.
+This section is **Python-only** by design — the model you simulate. The same component's
+**synthesizable C++ realization** (the generated kernel function, its ports, parameterization) is the
+[Component Code Generation](../comp_codegen/) chapter; each page below cross-links its codegen dual.
 
 ## In this section
 
-- [HwParam](./hwparam.md)
-- [HwConst](./hwconst.md)
-- [HwTestbench](./hwtestbench.md)
-- [Lifecycle](./lifecycle.md)
+- [Defining a component](./overview.md) — the `HwComponent` class and how you declare its endpoints (`__post_init__` + `add_endpoint`), walked through `simp_fun`.
+- [Endpoint methods](./endpoints.md) — the master/slave roles and the method you define or call per endpoint type (stream, m_axi, regmap, schema/array transfer).
+- [Lifecycle](./lifecycle.md) — `pre_sim` / `run_proc` / `post_sim` and `on_start`: *when* the endpoint methods run.
+- [HwParam](./hwparam.md) — per-instance synthesis-parameter fields.
+- [HwConst](./hwconst.md) — class-level compile-time structural constants.
+- [HwTestbench](./hwtestbench.md) — a component subclass whose `main()` is a Python test sequence.
 
 ## See also
 
 **Prerequisites** — a component is built from these:
 
-- [Interfaces](../interface/) — the typed ports (stream / MM / regmap endpoints) a component declares.
+- [Interfaces](../interface/) — the typed ports (stream / MM / regmap endpoints) a component declares, and their transaction-method signatures.
 - [Data Schemas](../schema/) — the payloads those ports carry.
 
 **The synthesizable side** (the C++ realization of a component):

--- a/docs/guide/components/lifecycle.md
+++ b/docs/guide/components/lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: Lifecycle
 parent: Hardware Components
-nav_order: 4
+nav_order: 3
 audience: python
 applies_to: [HwComponent]
 api: [pre_sim, run_proc, post_sim, on_start, sim_only]

--- a/docs/guide/components/overview.md
+++ b/docs/guide/components/overview.md
@@ -86,6 +86,25 @@ def compute(self, x: Int32, a: Int32, b: Int32) -> Int32:
     return Int32(relu_affine(int(x.val), int(a.val), int(b.val)))
 ```
 
+## Execution models
+
+How you structure that behavior puts the component in one of two modes — and the mode follows from its
+endpoints:
+
+- **Free-running (`run_proc`).** The default: a long-lived [lifecycle](./lifecycle.md) process that loops
+  over the component's stream / `m_axi` ports, the way a streaming datapath runs continuously. You
+  implement `run_proc`.
+- **Regmap-launched (`on_start`).** *Invocation-style.* A component that declares a
+  [`VitisRegMapMMIFSlave`](./endpoints.md) is launched by the host (which writes `ap_start`); its
+  `on_start` reads its inputs from the register fields, computes, writes the results, and returns once.
+  `simp_fun` above is this mode; `poly` uses it as a control path while streaming sample data through
+  `s_in` / `m_out`.
+
+The selection is automatic — you don't set it explicitly: a component carrying a `VitisRegMapMMIFSlave` is
+regmap-launched (you implement `on_start`); otherwise it is free-running (you implement `run_proc`). The C++
+realization of each — the `ap_start` / `ap_done` handshake vs. `ap_ctrl_hs`, and how the kernel entry is
+chosen — is [Component Code Generation: Component structure](../comp_codegen/structure.md).
+
 ## The same class generates C++
 
 This one class is also the source for the synthesizable kernel: the generator turns the component

--- a/docs/guide/components/overview.md
+++ b/docs/guide/components/overview.md
@@ -1,0 +1,103 @@
+---
+title: Defining a component
+parent: Hardware Components
+nav_order: 1
+audience: python
+applies_to: [HwComponent]
+api: [HwComponent, Component, add_endpoint, VitisRegMapMMIFSlave, synthesizable]
+summary: "How you define a HwComponent: subclass HwComponent, declare its typed interface endpoints in __post_init__ and register each with add_endpoint, and mark compute methods @synthesizable — walked through the regmap simp_fun example. The same class is the source for the generated C++ kernel."
+---
+
+# Defining a component
+
+## The class
+
+A hardware module is a subclass of [`HwComponent`](../../../waveflow/hw/hw_component.py), which
+extends [`Component`](../../../waveflow/hw/component.py) (the base simulation object with named
+endpoints and the SimPy lifecycle). Components are written as dataclasses; runtime configuration and
+simulation-only state are plain fields, while synthesis knobs use [`HwParam`](./hwparam.md) and
+[`HwConst`](./hwconst.md).
+
+A few class-level (`ClassVar`) settings steer the generated C++ but are inert in simulation:
+`cpp_kernel_name` (override the kernel function name), `cpp_namespace` (the hook namespace), and
+`param_supports` (emit variant kernels) — all covered in [Component Code Generation](../comp_codegen/).
+
+## Declaring endpoints
+
+A component's ports are **interface endpoints**, declared in `__post_init__` and registered with
+[`add_endpoint(...)`](../../../waveflow/hw/component.py) (which records the endpoint under its name
+and back-links it to the component). From
+[`examples/regmap/simp_fun.py`](../../../examples/regmap/simp_fun.py):
+
+```python
+@dataclass
+class SimpFunComponent(HwComponent):
+    cpp_kernel_name: ClassVar[str | None] = "simp_fun"
+    cpp_namespace: ClassVar[str | None] = "simp_fun_impl"
+    clk: Clock = field(default_factory=lambda: Clock(freq=100e6))
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.regmap = VitisRegMap({
+            "x": RegField(Int32, RegAccess.RW, description="Input operand"),
+            "a": RegField(Int32, RegAccess.RW, description="Multiply coefficient"),
+            "b": RegField(Int32, RegAccess.RW, description="Bias term"),
+            "y": RegField(Int32, RegAccess.R,  description="relu(a*x + b)"),
+        })
+        self.s_lite = VitisRegMapMMIFSlave(
+            name=f"{self.name}_s_lite", sim=self.sim, bitwidth=32,
+            regmap=self.regmap, on_start=self.on_start,
+        )
+        self.add_endpoint(self.s_lite)
+```
+
+`simp_fun` declares one endpoint — an AXI-Lite register map
+([`VitisRegMapMMIFSlave`](../../../waveflow/hw/regmap.py)). A component with a datapath declares more:
+[`examples/stream_inband/poly.py`](../../../examples/stream_inband/poly.py)'s `PolyAccelComponent`
+declares a stream input, a stream output, and a regmap, and registers all three:
+
+```python
+def __post_init__(self) -> None:
+    super().__post_init__()
+    self.s_in  = StreamIFSlave( name=f'{self.name}_s_in',  sim=self.sim, bitwidth=self.in_bw)
+    self.m_out = StreamIFMaster(name=f'{self.name}_m_out', sim=self.sim, bitwidth=self.out_bw)
+    self.s_lite = VitisRegMapMMIFSlave(name=f'{self.name}_s_lite', sim=self.sim, ...)
+    for ep in (self.s_in, self.m_out, self.s_lite):
+        self.add_endpoint(ep)
+```
+
+Which endpoint *types* exist, and the master/slave role of each, is [Endpoint methods](./endpoints.md);
+the endpoint classes and their construction live in [Interfaces](../interface/).
+
+## Behavior and compute
+
+A component's behavior is the **methods on its endpoints**, driven from a [lifecycle](./lifecycle.md)
+method — `on_start` for a regmap-launched component (like `simp_fun`) or `run_proc` for a free-running
+one. Compute that must synthesize to hardware is marked
+[`@synthesizable`](../../../waveflow/hw/synth.py):
+
+```python
+def on_start(self) -> ProcessGen[None]:
+    y = self.compute(self.regmap.get("x"), self.regmap.get("a"), self.regmap.get("b"))
+    self.regmap.set("y", y)
+
+@synthesizable
+def compute(self, x: Int32, a: Int32, b: Int32) -> Int32:
+    return Int32(relu_affine(int(x.val), int(a.val), int(b.val)))
+```
+
+## The same class generates C++
+
+This one class is also the source for the synthesizable kernel: the generator turns the component
+into a top-level Vitis HLS function whose **arguments are these same endpoints**, and lowers the
+`@synthesizable` methods into the kernel body. That dual view — same `simp_fun` component, as a
+generated `void simp_fun(ap_int<32>& x, …)` — is
+[Component Code Generation: Component structure](../comp_codegen/structure.md).
+
+## Quick reference
+
+- Subclass `HwComponent` (a dataclass); call `super().__post_init__()` first.
+- Declare each port in `__post_init__` and register it with `add_endpoint(...)`.
+- Keep synthesis knobs in [`HwParam`](./hwparam.md) / [`HwConst`](./hwconst.md); everything else is a plain field.
+- Drive behavior from `on_start` (regmap-launched) or `run_proc` (free-running) — see [Lifecycle](./lifecycle.md).
+- Mark hardware compute `@synthesizable`; the [endpoint methods](./endpoints.md) move the data.


### PR DESCRIPTION
Restructure **components/** to add the conceptual on-ramp it was missing. It had the detail pages (HwParam / HwConst / HwTestbench / Lifecycle) but no "what is a `HwComponent`, and how do I define one" entry point. Mirrors the just-merged **comp_codegen/** shape: concept index → on-ramp pages → detail pages. Python-only, flat, `audience: python`, no internal "Arc" vocabulary. Every API grounded in source / the worked examples.

## index.md rewrite
Now a concept + chapter map: a `HwComponent` is Waveflow's representation of a **synthesizable hardware module**, defined by its **interface endpoints**, **wired** to other components by *binding* endpoints to interfaces, with behavior = the **methods on those endpoints**. Followed by the new "in this section" list. No "Arc".

## NEW overview.md (nav 1) — "Defining a component"
How you actually write one: subclass `HwComponent` (a dataclass), declare each typed endpoint in `__post_init__` and register it with `add_endpoint(...)`, mark hardware compute `@synthesizable`. Walked through `examples/regmap/simp_fun.py` (regmap-only) with `poly`'s multi-endpoint `__post_init__` as the richer case. Closes with the codegen dual — the same class becomes `void simp_fun(ap_int<32>& x, …)` — cross-linking **comp_codegen/structure.md**.
**APIs cited:** `HwComponent` / `Component`, `add_endpoint` (`component.py`), `VitisRegMapMMIFSlave` (`regmap.py`), `@synthesizable` (`synth.py`); `cpp_kernel_name` / `cpp_namespace` / `param_supports` noted as codegen-only.

## NEW endpoints.md (nav 2) — "Endpoint methods"
The master/slave roles, grounded **accurately** (not a clean "slave = callback" dichotomy):
- **master** = the component *initiates* the transaction — stream `write` / `write_pipelined` / `push`; m_axi `read` / `write` / `read_array` / `write_array` (a `read_array` is master-initiated even though it pulls data).
- **slave** = the component *responds* — a **launch handler** (`on_start` via `VitisRegMapMMIFSlave` on `ap_start`), a **`get` / `pop` pulled in the body** (stream/transfer slave), or a **passive memory target** (`MMIFSlave`).

Then the endpoint-method table, keyed by type → the method you define/call → the interface page with the signature:

| Endpoint type | Role | Method you define / call | Interface page |
|---|---|---|---|
| `StreamIFSlave` | slave (consume) | `get(schema_type, count)` / `get_pipelined(...)` / `pop(value)` | Stream |
| `StreamIFMaster` | master (initiate) | `write(data)` / `write_pipelined(data, t)` / `push(value)` | Stream |
| `MMIFMaster` | master (initiate) | `read` / `write` / `read_array(elem, count, addr)` / `write_array(arr, elem, addr)` | MM Interfaces |
| `MMIFSlave` | slave (memory target) | passive — serviced by the model | MM Interfaces |
| `VitisRegMapMMIFSlave` | slave (launch) | define `on_start`; fields via `regmap.get` / `set` | Register Maps |
| `SchemaTransferIFMaster` / `Slave` | master / slave | `write(obj)` / `get()` | Schema Transfer |
| `ArrayTransferIFMaster` / `Slave` | master / slave | `write(elements)` / `get(count)` | Array Transfer |

Signatures deliberately live on the linked **interface/** pages (not duplicated); paired with **lifecycle** (endpoints = *what*, lifecycle = *when*). Grounded in `interface.py`, `memif.py`, `regmap.py`, `schema_transfer_interface.py`, and `poly.py` / `simp_fun.py` / `mem_demo.py`.

## Reorder
Detail pages renumbered: Lifecycle 3, HwParam 4, HwConst 5, HwTestbench 6 (`nav_order` + the index list). Final order: overview (1) → endpoints (2) → lifecycle (3) → hwparam (4) → hwconst (5) → hwtestbench (6).

## Validation (docs-only)
No Ruby/Jekyll locally → structural:
- **Link gate** (exact repo-wide sweep over every relative `.md` / `.py` / dir target, new pages included): **`broken total: 0`**.
- `grep -rn "\bArc\b" docs/ --include=*.md` → nothing.
- components children `nav_order` **1–6 unique**; frontmatter consistent (`audience: python`, `parent: Hardware Components`).

Do not merge yet — reviewed per section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
