### PR TITLE
fix regmap csim conformance: ap_int.h codegen include + validate_csim register-output config

### DIFF
--- a/examples/regmap/simp_fun_build.py
+++ b/examples/regmap/simp_fun_build.py
@@ -321,9 +321,9 @@ def build_simp_fun_dag() -> BuildDag:
         name="validate_csim",
         golden_dir_artifact="sim_dir",
         actual_dir_artifact="csim_data_dir",
-        schemas=[
-            {"filename": "y_data.bin", "golden_filename": "y.bin", "schema": Int32},
-        ],
+        # simp_fun's output `y` is an s_axilite register, not a memory/stream buffer, so
+        # the kernel writes no `y_data.bin` — it is verified through regmap_status.json
+        # below. (A `.bin` schema comparison here would expect a file that never exists.)
         jsons=[
             {"filename": "regmap_status.json", "compare_fields": ["y"]},
         ],

--- a/waveflow/build/hwgen.py
+++ b/waveflow/build/hwgen.py
@@ -1103,7 +1103,12 @@ def header_to_cpp(
 
     tree = extract_kernel(default_comp)
     schemas = _collect_schemas(tree, default_comp)
-    lines = ['#pragma once', '']
+    # Always provide ap_int / ap_fixed: a kernel signature can use these via s_axilite
+    # register fields even when the component has no streams / schemas / m_axi (which
+    # otherwise pull in streamutils_hls.h, the header that supplies them). A regmap-only
+    # scalar kernel (e.g. simp_fun) would otherwise emit a header that uses ap_int<W> with
+    # nothing defining it. Redundant-include-safe via header guards.
+    lines = ['#pragma once', '', '#include <ap_int.h>', '#include <ap_fixed.h>', '']
     if _discover_stream_endpoints(default_comp):
         lines.append('#include "include/streamutils_hls.h"')
     for s in schemas:


### PR DESCRIPTION
Makes the regmap example's Vitis csim conformance pass end-to-end. Two related, pre-existing bugs (the second was hidden behind the first):

**1. Codegen — kernel header missing the `ap_int` include.** A regmap-only scalar kernel (`simp_fun`) generated a `.hpp` using `ap_int<W>` for its s_axilite register fields, with **no include defining it** — `header_to_cpp` gated the `ap_int`-providing `streamutils_hls.h` on the component having *stream* endpoints, and a regmap-only kernel has none. Fix: emit `#include <ap_int.h>` + `<ap_fixed.h>` unconditionally in the generated kernel header (redundant-include-safe via guards). → csim now **compiles**. *(General fix — applies to any regmap-only scalar kernel.)*

**2. Verify config — `.bin` comparison for a register output.** With csim compiling, `validate_csim` then failed: it had a `schemas`/`y_data.bin` check, but `simp_fun`'s output `y` is an **s_axilite register** (the kernel writes no `.bin`) — it's verified via the `regmap_status.json` `y` field (the `jsons` entry). Dropped the spurious `.bin` comparison. → validate_csim now **passes**. *(Specific to `simp_fun`'s verify config.)*

**Verified empirically:** `CSim done with 0 errors`, `WAVEFLOW_SUCCESS: simp_fun C-sim and C-synth passed`, and `validate_csim: PASSED` (csim `y=11` == golden `y=11`). Non-vitis codegen tests unaffected (only the pre-existing `test_build×9` baseline fails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)