### PR TITLE
docs(interface): add runnable two-SimObj toys to each interface page (PR B)

### DIFF
--- a/docs/guide/interface/array_transfer.md
+++ b/docs/guide/interface/array_transfer.md
@@ -3,8 +3,8 @@ title: Array Transfer Interface
 parent: Interfaces
 nav_order: 6
 audience: python
-api: [ArrayTransferIF, ArrayTransferIFMaster, ArrayTransferIFSlave, StreamTransport]
-summary: "The logical interface that carries a variable-length typed array over a transport — write(elements) with a numpy fast path, push (rx_proc) vs pull (get(count)) receive, and TLAST length validation."
+api: [ArrayTransferIF, ArrayTransferIFMaster, ArrayTransferIFSlave, StreamTransport, SimObj, Simulation]
+summary: "The logical interface that carries a variable-length typed array over a transport — write(elements) with a numpy fast path, push (rx_proc) vs pull (get(count)) receive, and TLAST length validation, with a runnable two-SimObj toy."
 ---
 
 # Array Transfer Interface
@@ -34,6 +34,82 @@ Physical layer:    StreamIFMaster                    StreamIFSlave
 | `ArrayTransferIF` | Optional logical container; validates endpoint types, `element_type`, and `bitwidth` |
 
 `PhysicalTransport` and `StreamTransport` are shared with `SchemaTransferIF`; see the [Schema Transfer Interface](schema_transfer.md) page.
+
+---
+
+## A minimal simulation
+
+Two raw [`SimObj`](../sim/simobj.md)s sending one variable-length array master→slave. Each transfer
+endpoint owns an internal `stream_ep`; bind those over a `StreamIF` to wire the physical link. No
+`HwComponent`. (The `yield from` / `run_proc` mechanics are in
+[Process generators](../sim/procgen.md).)
+
+```python
+from dataclasses import dataclass
+
+import numpy as np
+
+from waveflow.hw.clock import Clock
+from waveflow.hw.dataschema import FloatField
+from waveflow.hw.interface import StreamIF
+from waveflow.hw.schema_transfer_interface import (
+    ArrayTransferIFMaster, ArrayTransferIFSlave,
+)
+from waveflow.simulation.simobj import ProcessGen, SimObj
+from waveflow.simulation.simulation import Simulation
+
+Float32 = FloatField.specialize(bitwidth=32)
+
+
+@dataclass
+class Producer(SimObj):
+    """Holds the array master; sends one variable-length burst of samples."""
+
+    master: ArrayTransferIFMaster | None = None
+
+    def run_proc(self) -> ProcessGen[None]:
+        samples = np.array([1.0, -2.5, 3.14], dtype=np.float32)
+        yield from self.master.write(samples)     # one packet, TLAST on the last element
+
+
+@dataclass
+class Consumer(SimObj):
+    """Holds the array slave; rx_proc fires once with the whole received array."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.received: np.ndarray | None = None
+        self.slave = ArrayTransferIFSlave(
+            sim=self.sim, element_type=Float32, bitwidth=32, rx_proc=self.on_samples,
+        )
+
+    def on_samples(self, elements: np.ndarray) -> ProcessGen[None]:
+        self.received = elements                  # np.ndarray[float32]
+        yield self.timeout(0)
+
+
+sim = Simulation()
+clk = Clock(freq=1e9)
+
+producer = Producer(
+    name="producer", sim=sim,
+    master=ArrayTransferIFMaster(sim=sim, element_type=Float32, bitwidth=32),
+)
+consumer = Consumer(name="consumer", sim=sim)
+
+# Each transfer endpoint owns an internal stream_ep; bind those to wire the physical link.
+stream_if = StreamIF(sim=sim, clk=clk)
+stream_if.bind("master", producer.master.stream_ep)
+stream_if.bind("slave", consumer.slave.stream_ep)
+
+sim.run_sim()
+print("consumer received:", consumer.received.tolist())
+```
+
+The producer `write`s the three-element array as one burst; the slave infers the element count from
+the burst length and delivers the whole `np.ndarray[float32]` to `rx_proc`, so `consumer.received`
+is `[1.0, -2.5, 3.14]`. See [SimObj](../sim/simobj.md) for the base object and lifecycle; push- vs
+pull-mode receive is detailed below.
 
 ---
 

--- a/docs/guide/interface/aximm.md
+++ b/docs/guide/interface/aximm.md
@@ -3,8 +3,8 @@ title: MM Interfaces
 parent: Interfaces
 nav_order: 3
 audience: python
-api: [MMIFMaster, MMIFSlave, AXIMMCrossBarIF, DirectMMIF, AXIMMProtocol, assign_address_ranges]
-summary: "Memory-mapped interfaces in the SimPy model — MMIFMaster/MMIFSlave endpoints, the AXIMMCrossBarIF (FULL/LITE, address routing) and DirectMMIF, and read/write/read_schema/read_array."
+api: [MMIFMaster, MMIFSlave, AXIMMCrossBarIF, DirectMMIF, AXIMMProtocol, assign_address_ranges, SimObj, Simulation]
+summary: "Memory-mapped interfaces in the SimPy model — MMIFMaster/MMIFSlave endpoints, the AXIMMCrossBarIF (FULL/LITE, address routing) and DirectMMIF, and read/write/read_schema/read_array, with a runnable two-SimObj DirectMMIF toy."
 ---
 
 # Memory-Mapped (MM) Interfaces
@@ -91,6 +91,83 @@ arr = yield from master_ep.read_array(Float32, count=nsamp, addr=DATA_ADDR)
 ```
 
 ---
+
+## A minimal simulation
+
+Two raw [`SimObj`](../sim/simobj.md)s over a point-to-point [`DirectMMIF`](#directmmif): a `Cpu` holding
+the `MMIFMaster` writes a burst and reads it back, and a `MemBank` holding the `MMIFSlave` is a tiny
+word-addressed memory model. No `HwComponent`. (The `yield from` / `run_proc` / `ProcessGen` mechanics
+are explained in [Process generators](../sim/procgen.md).)
+
+```python
+from dataclasses import dataclass
+
+import numpy as np
+
+from waveflow.hw.aximm import DirectMMIF, MMIFMaster, MMIFSlave
+from waveflow.hw.clock import Clock
+from waveflow.hw.interface import Words
+from waveflow.simulation.simobj import ProcessGen, SimObj
+from waveflow.simulation.simulation import Simulation
+
+
+@dataclass
+class MemBank(SimObj):
+    """A tiny word-addressed memory behind a slave endpoint."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._mem: dict[int, int] = {}
+        self.slave = MMIFSlave(
+            sim=self.sim, bitwidth=32,
+            rx_write_proc=self.on_write, rx_read_proc=self.on_read,
+        )
+
+    def on_write(self, words: Words, local_addr: int) -> ProcessGen[None]:
+        for i, w in enumerate(words):
+            self._mem[local_addr + i] = int(w)
+        yield self.timeout(0)
+
+    def on_read(self, nwords: int, local_addr: int) -> ProcessGen[Words]:
+        yield self.timeout(0)   # model peripheral access latency here
+        return np.array([self._mem.get(local_addr + i, 0) for i in range(nwords)], dtype=np.uint32)
+
+
+@dataclass
+class Cpu(SimObj):
+    """Holds the master endpoint; writes a burst then reads it back."""
+
+    master: MMIFMaster | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.readback: np.ndarray | None = None
+
+    def run_proc(self) -> ProcessGen[None]:
+        data = np.array([0xA0, 0xA1, 0xA2, 0xA3], dtype=np.uint32)
+        yield from self.master.write(data, 0)
+        self.readback = yield from self.master.read(4, 0)
+        print(f"{self.name} read back {self.readback.tolist()}")
+
+
+sim = Simulation()
+clk = Clock(freq=100e6)
+
+mem = MemBank(name="mem", sim=sim)
+cpu = Cpu(name="cpu", sim=sim, master=MMIFMaster(sim=sim, bitwidth=32))
+
+link = DirectMMIF(sim=sim, clk=clk, byte_addressable=False)   # word addresses (BRAM convention)
+link.bind("master", cpu.master)
+link.bind("slave", mem.slave)
+
+sim.run_sim()
+```
+
+`cpu.readback` is `[0xA0, 0xA1, 0xA2, 0xA3]`: the master-initiated `write` then `read` round-trip
+through the slave's `rx_write_proc` / `rx_read_proc`. `DirectMMIF` is point-to-point, so no address
+ranges are needed; for the multi-slave **crossbar** you also call
+[`assign_address_ranges()`](#axiammcrossbarif) after `bind` (see the [full example](#full-example)
+below). See [SimObj](../sim/simobj.md) for the base object and lifecycle.
 
 ## AXIMMCrossBarIF
 

--- a/docs/guide/interface/overview.md
+++ b/docs/guide/interface/overview.md
@@ -3,8 +3,8 @@ title: Overview
 parent: Interfaces
 nav_order: 1
 audience: python
-api: [Interface, InterfaceEndpoint, StreamIF, MMIFMaster, MMIFSlave, Words]
-summary: "The transactional interface model — Interface vs master/slave endpoint, the Words type, the cycle-based latency model, and the SimPy write/read/bind lifecycle."
+api: [Interface, InterfaceEndpoint, StreamIF, StreamIFMaster, StreamIFSlave, MMIFMaster, MMIFSlave, Words, Simulation]
+summary: "The transactional interface model — Interface vs master/slave endpoint, the Words type, the cycle-based latency model, and the SimPy write/read/bind lifecycle, plus a runnable two-SimObj StreamIF toy."
 ---
 
 # Overview
@@ -89,6 +89,74 @@ proc = env.process(master_ep.read(nwords=4, global_addr=0x0000))
 yield proc
 data = proc.value   # numpy array of shape (4,)
 ```
+
+## A minimal simulation
+
+Two raw [`SimObj`](../sim/simobj.md)s connecting over a `StreamIF` — a `Producer` holding the master
+endpoint and a `Consumer` holding the slave endpoint, bound and run in one `Simulation`. No
+`HwComponent` involved. (The `yield` / `run_proc` / `ProcessGen` mechanics are explained in
+[Process generators](../sim/procgen.md).)
+
+```python
+from dataclasses import dataclass
+
+import numpy as np
+
+from waveflow.hw.clock import Clock
+from waveflow.hw.interface import StreamIF, StreamIFMaster, StreamIFSlave, Words
+from waveflow.simulation.simobj import ProcessGen, SimObj
+from waveflow.simulation.simulation import Simulation
+
+
+@dataclass
+class Producer(SimObj):
+    """Holds the master endpoint; writes each packet over the stream."""
+
+    master: StreamIFMaster | None = None
+    packets: list | None = None
+
+    def run_proc(self) -> ProcessGen[None]:
+        for packet in self.packets:
+            yield from self.master.write(packet)   # blocks for latency + burst cycles
+            print(f"{self.name} sent {packet.tolist()}")
+
+
+@dataclass
+class Consumer(SimObj):
+    """Holds the slave endpoint; rx_proc fires for each arriving burst."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.received: list[np.ndarray] = []
+        self.slave = StreamIFSlave(sim=self.sim, bitwidth=32, rx_proc=self.on_receive)
+
+    def on_receive(self, words: Words) -> ProcessGen[None]:
+        self.received.append(np.array(words, copy=True))
+        print(f"{self.name} received {words.tolist()}")
+        yield self.timeout(0)
+
+
+sim = Simulation()
+iface = StreamIF(sim=sim, clk=Clock(freq=100e6), bitwidth=32)
+
+producer = Producer(
+    name="producer", sim=sim,
+    master=StreamIFMaster(sim=sim, bitwidth=32),
+    packets=[np.array([1, 2, 3], dtype=np.uint32), np.array([4, 5], dtype=np.uint32)],
+)
+consumer = Consumer(name="consumer", sim=sim)
+
+iface.bind("master", producer.master)
+iface.bind("slave", consumer.slave)
+
+sim.run_sim()
+print("consumer received:", [p.tolist() for p in consumer.received])
+```
+
+Each burst the producer `write`s lands in `consumer.received` (`[[1, 2, 3], [4, 5]]`): the master
+drives, the slave's `rx_proc` fires per burst, and `run_sim()` returns once the producer's `run_proc`
+finishes and the slave's receive loop parks on its empty buffer. See [SimObj](../sim/simobj.md) for the
+base object and lifecycle.
 
 ## Available interface types
 

--- a/docs/guide/interface/regmap.md
+++ b/docs/guide/interface/regmap.md
@@ -3,8 +3,8 @@ title: Register Maps
 parent: Interfaces
 nav_order: 4
 audience: python
-api: [RegMap, RegField, RegAccess, RegMapMMIFSlave, VitisRegMap, VitisRegMapMMIFSlave, BoundRegMap]
-summary: "AXI-Lite register maps in the SimPy model — RegField/RegAccess, the RegMap slave dispatch, the VitisRegMap ap_ctrl_hs (ap_start/ap_done) launch lifecycle, and the BoundRegMap host surface."
+api: [RegMap, RegField, RegAccess, RegMapMMIFSlave, VitisRegMap, VitisRegMapMMIFSlave, BoundRegMap, SimObj, Simulation]
+summary: "AXI-Lite register maps in the SimPy model — RegField/RegAccess, the RegMap slave dispatch, the VitisRegMap ap_ctrl_hs (ap_start/ap_done) launch lifecycle, and the BoundRegMap host surface, with a runnable two-SimObj launch-then-poll toy."
 ---
 
 # Register Maps
@@ -23,6 +23,97 @@ Waveflow provides the register-map abstraction as a thin layer on top of the exi
 The register map matches the model that Vitis HLS generates from `s_axilite` scalars and arrays: each field becomes one or more 32-bit registers in a single auto-generated AXI-Lite slave. When Waveflow eventually generates the HLS pragmas for a kernel, the offsets in the Python `RegMap` are the offsets the host driver uses.
 
 ---
+
+## A minimal simulation
+
+Two raw [`SimObj`](../sim/simobj.md)s exercising the launch-then-poll lifecycle over a
+[`DirectMMIF`](./aximm.md#directmmif): a `Kernel` holding a `VitisRegMapMMIFSlave` runs its `on_start`
+when launched, and a `Host` holding an `MMIFMaster` writes the inputs, asserts `ap_start`, polls
+`ap_done`, and reads the result back. No `HwComponent`. (`on_start` is the regmap-launched entry — see
+the [SimObj lifecycle](../sim/simobj.md#its-lifecycle); the `yield from` mechanics are in
+[Process generators](../sim/procgen.md).)
+
+```python
+from dataclasses import dataclass
+
+from waveflow.hw.aximm import DirectMMIF, MMIFMaster
+from waveflow.hw.clock import Clock
+from waveflow.hw.dataschema import IntField
+from waveflow.hw.regmap import RegAccess, RegField, VitisRegMap, VitisRegMapMMIFSlave
+from waveflow.simulation.simobj import ProcessGen, SimObj
+from waveflow.simulation.simulation import Simulation
+
+Int32 = IntField.specialize(bitwidth=32, signed=True)
+
+
+@dataclass
+class Kernel(SimObj):
+    """A regmap-launched compute SimObj: y = a*x + b, run on host ap_start."""
+
+    clk: Clock | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.regmap = VitisRegMap({
+            "x": RegField(Int32, RegAccess.RW),
+            "a": RegField(Int32, RegAccess.RW),
+            "b": RegField(Int32, RegAccess.RW),
+            "y": RegField(Int32, RegAccess.R),
+        })
+        self.s_lite = VitisRegMapMMIFSlave(
+            name=f"{self.name}_s_lite", sim=self.sim, bitwidth=32,
+            regmap=self.regmap, on_start=self.on_start,
+        )
+
+    def on_start(self) -> ProcessGen[None]:
+        # The slave invokes this on ap_start; it auto-sets ap_done when on_start returns.
+        x = int(self.regmap.get("x").val)
+        a = int(self.regmap.get("a").val)
+        b = int(self.regmap.get("b").val)
+        yield self.timeout(4 * self.clk.period)          # model compute latency
+        self.regmap.set("y", a * x + b)
+
+
+@dataclass
+class Host(SimObj):
+    """Holds the master; configures inputs, launches, polls ap_done, reads y back."""
+
+    master: MMIFMaster | None = None
+    kernel: Kernel | None = None
+    clk: Clock | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.y: int | None = None
+
+    def run_proc(self) -> ProcessGen[None]:
+        rm = self.kernel.regmap.bind_master(self.master, base_addr=0)
+        yield from rm.set("x", 5)
+        yield from rm.set("a", 3)
+        yield from rm.set("b", -4)
+        yield from rm.start()                            # write ap_start
+        ap_done = yield from rm.poll_end(interval=4 * self.clk.period, max_polls=32)
+        self.y = yield from rm.get("y")
+        print(f"ap_done={ap_done}, y={self.y}")
+
+
+sim = Simulation()
+clk = Clock(freq=100e6)
+
+kernel = Kernel(name="kernel", sim=sim, clk=clk)
+host = Host(name="host", sim=sim, master=MMIFMaster(sim=sim, bitwidth=32), kernel=kernel, clk=clk)
+
+link = DirectMMIF(sim=sim, clk=clk, byte_addressable=True)   # byte addresses (AXI-Lite convention)
+link.bind("master", host.master)
+link.bind("slave", kernel.s_lite)
+
+sim.run_sim()
+```
+
+`host.y` is `11` (`3*5 - 4`): the host's `set` writes land in the register fields, `start()` writes
+`ap_start` which launches `on_start`, the slave sets `ap_done` when it returns, and `poll_end` reads
+that back before the host fetches `y`. `bind_master` / `start` / `poll_end` are the host-side
+[`BoundRegMap`](#host-side-boundregmap) surface. See [SimObj](../sim/simobj.md) for the lifecycle.
 
 ## Quick example
 

--- a/docs/guide/interface/schema_transfer.md
+++ b/docs/guide/interface/schema_transfer.md
@@ -3,8 +3,8 @@ title: Schema Transfer Interface
 parent: Interfaces
 nav_order: 5
 audience: python
-api: [SchemaTransferIF, SchemaTransferIFMaster, SchemaTransferIFSlave, PhysicalTransport, StreamTransport]
-summary: "The logical interface that carries serializable schema objects (DataList / DataUnion) over a transport — write(obj) / rx_proc, the layered transport model, and single- vs multi-type framing."
+api: [SchemaTransferIF, SchemaTransferIFMaster, SchemaTransferIFSlave, PhysicalTransport, StreamTransport, SimObj, Simulation]
+summary: "The logical interface that carries serializable schema objects (DataList / DataUnion) over a transport — write(obj) / rx_proc, the layered transport model, and single- vs multi-type framing, with a runnable two-SimObj toy."
 ---
 
 # Schema Transfer Interface
@@ -22,6 +22,82 @@ Transport layer:     PhysicalTransport  (StreamTransport | …)
                            │                            │
 Physical layer:    StreamIFMaster               StreamIFSlave
 ```
+
+---
+
+## A minimal simulation
+
+Two raw [`SimObj`](../sim/simobj.md)s sending a schema object master→slave. Each transfer endpoint
+owns an internal `StreamIFMaster` / `StreamIFSlave` (`stream_ep`); you complete the physical link by
+binding those two `stream_ep`s over a `StreamIF`. No `HwComponent`. (The `yield from` / `run_proc`
+mechanics are in [Process generators](../sim/procgen.md).)
+
+```python
+from dataclasses import dataclass
+
+from waveflow.hw.clock import Clock
+from waveflow.hw.dataschema import DataList, IntField
+from waveflow.hw.interface import StreamIF
+from waveflow.hw.schema_transfer_interface import (
+    SchemaTransferIFMaster, SchemaTransferIFSlave,
+)
+from waveflow.simulation.simobj import ProcessGen, SimObj
+from waveflow.simulation.simulation import Simulation
+
+U8 = IntField.specialize(bitwidth=8, signed=False)
+S16 = IntField.specialize(bitwidth=16, signed=True)
+
+
+class SensorPacket(DataList):
+    elements = {"temp": S16, "sensor_id": U8}
+
+
+@dataclass
+class Producer(SimObj):
+    """Holds the schema master; serializes and sends each packet."""
+
+    master: SchemaTransferIFMaster | None = None
+
+    def run_proc(self) -> ProcessGen[None]:
+        for temp, sid in [(-10, 1), (25, 2)]:
+            yield from self.master.write(SensorPacket(temp=temp, sensor_id=sid))
+
+
+@dataclass
+class Consumer(SimObj):
+    """Holds the schema slave; rx_proc fires with each deserialized packet."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.received: list[tuple[int, int]] = []
+        self.slave = SchemaTransferIFSlave(
+            sim=self.sim, schema_type=SensorPacket, bitwidth=32, rx_proc=self.on_packet,
+        )
+
+    def on_packet(self, pkt: SensorPacket) -> ProcessGen[None]:
+        self.received.append((int(pkt.temp), int(pkt.sensor_id)))
+        yield self.timeout(0)
+
+
+sim = Simulation()
+clk = Clock(freq=1e9)
+
+producer = Producer(name="producer", sim=sim, master=SchemaTransferIFMaster(sim=sim, bitwidth=32))
+consumer = Consumer(name="consumer", sim=sim)
+
+# Each transfer endpoint owns an internal stream_ep; bind those to wire the physical link.
+stream_if = StreamIF(sim=sim, clk=clk)
+stream_if.bind("master", producer.master.stream_ep)
+stream_if.bind("slave", consumer.slave.stream_ep)
+
+sim.run_sim()
+print("consumer received:", consumer.received)
+```
+
+Each `SensorPacket` the producer `write`s is serialized, carried over the stream, deserialized, and
+delivered to the consumer's `rx_proc` — `consumer.received` ends up `[(-10, 1), (25, 2)]`. See
+[SimObj](../sim/simobj.md) for the base object and lifecycle. The detailed single-type and
+multi-type (`DataUnion`) walkthroughs are below.
 
 ---
 

--- a/docs/guide/interface/stream.md
+++ b/docs/guide/interface/stream.md
@@ -3,8 +3,8 @@ title: Stream Interfaces
 parent: Interfaces
 nav_order: 2
 audience: python
-api: [StreamIF, StreamIFMaster, StreamIFSlave, CrossBarIF, CrossBarIFInput, CrossBarIFOutput]
-summary: "Unidirectional stream interfaces in the SimPy model — point-to-point StreamIF (write/rx_proc), the CrossBarIF switching fabric, and pipelined get/write timing."
+api: [StreamIF, StreamIFMaster, StreamIFSlave, CrossBarIF, CrossBarIFInput, CrossBarIFOutput, SimObj, Simulation]
+summary: "Unidirectional stream interfaces in the SimPy model — point-to-point StreamIF (write/rx_proc), the CrossBarIF switching fabric, and pipelined get/write timing, with a runnable two-SimObj producer→consumer toy."
 ---
 
 # Stream Interfaces
@@ -141,6 +141,8 @@ sim.run_sim()
 ```
 
 The `Consumer.run_proc()` must delegate to `ep.run_proc()` so the slave's receive loop is active during simulation. `Simulation.run_sim()` calls each `SimObj.run_proc()` automatically, so this pattern wires together correctly.
+
+This is a complete, runnable two-[`SimObj`](../sim/simobj.md) simulation — a `Producer` (master) and a `Consumer` (slave) bound over one `StreamIF`, no `HwComponent` — and it is the same shape as the toys on the other interface pages. The `yield` / `run_proc` / `ProcessGen` mechanics it relies on are explained in [Process generators](../sim/procgen.md). A `CrossBarIF` variant is the same idea with port-indexed endpoints (`in_0` / `out_0`) — see below.
 
 ---
 


### PR DESCRIPTION
**PR B** of the sim restructure (`plans/docs-interface-toys.md`). Docs-only and additive — add a runnable raw-`SimObj` toy to each interface page so each interface is concrete on its own page, *before* the reader meets `HwComponent`. No restructure; no changes under `waveflow/` or `examples/`. Builds on PR A's `sim/simobj.md` / `sim/procgen.md` (the toys *use* `yield` / `ProcessGen` / `run_proc` and cross-link there rather than re-teaching SimPy).

Each toy is two plain `SimObj` subclasses — a `Producer` holding the master endpoint and a `Consumer` holding the slave endpoint — bound over that interface, registered in one `Simulation`, run via `run_sim()`. Every toy uses the **real** endpoint API (no invented `connect()`), grounded in `tests/hw/test_interface.py`, `test_aximm_interface.py`/`test_aximm_queue.py`, and `examples/regmap/simp_fun.py`.

## Per-page additions (each under "## A minimal simulation")
- **overview.md** — a complete `StreamIF` producer→consumer toy (promotes the page's prior fragments into one runnable block).
- **stream.md** — already had a complete point-to-point two-`SimObj` example; enhanced with the `../sim/procgen.md` / `../sim/simobj.md` cross-links + a `CrossBarIF`-variant note (no duplicate code).
- **aximm.md** — a `DirectMMIF` toy: a `Cpu` (`MMIFMaster`) writes a burst and reads it back through a `MemBank` (`MMIFSlave` memory model); notes `assign_address_ranges()` placement for the crossbar variant.
- **regmap.md** — the launch-then-poll toy: a `Kernel` (`VitisRegMapMMIFSlave` whose `on_start` computes `y=a*x+b`) and a `Host` (`MMIFMaster`) that `set`s inputs, writes `ap_start` via `BoundRegMap.start()`, `poll_end`s `ap_done`, and reads `y` back — over `DirectMMIF`. Cross-links the `on_start` lifecycle.
- **schema_transfer.md** — a `SchemaTransferIF` toy: a `DataList` packet sent master→slave, wired by binding each transfer endpoint's internal `stream_ep` over a `StreamIF`.
- **array_transfer.md** — an `ArrayTransferIF` toy: one variable-length `Float32` array sent master→slave (numpy fast path), same `stream_ep` wiring.

Each edited page also extends `api:`/`summary:` to mention the toy.

## Verification
1. **Link gate = 0.** The full per-file `realpath` sweep over every relative `]( … )` target — `.md`, `.py`, and directories — across `docs/` prints **zero** `BROKEN:` lines (run on the committed tree).
2. **Toys run.** Every toy was extracted **verbatim from the shipped `.md`** to a scratch script and run to completion under `../pysilicon-venv/Scripts/python.exe`: overview (stream), aximm (MM), regmap, schema_transfer, array_transfer — **all 5 PASS** (exceeds the required stream/MM/regmap spot-check). They remain doc snippets; no tests added.
3. **No stale refs introduced; frontmatter valid.**
4. **Docs-only** — the entire branch diff is the six `docs/guide/interface/*.md` pages, so the non-vitis test baseline is unaffected.

### Note for a follow-up (not fixed here, out of additive scope)
While grounding the serialization toys I found the **pre-existing** deep examples in `schema_transfer.md` and `array_transfer.md` use an outdated constructor form (`SchemaTransferIFMaster(transport=…)`, `StreamTransport(master_ep=…, slave_ep=…)`); the current endpoints own their own `stream_ep` and are wired by binding those over a `StreamIF`. The new toys use the correct current API; the older example blocks below them are stale and worth a separate docs fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
