### PR TITLE
docs(interface): fix stale transport= API in schema/array transfer deep sections

### DIFF
--- a/docs/guide/interface/array_transfer.md
+++ b/docs/guide/interface/array_transfer.md
@@ -117,14 +117,14 @@ pull-mode receive is detailed below.
 
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
-| `transport` | `PhysicalTransport` | — | Physical layer to transmit through |
 | `element_type` | `type[DataSchema]` | — | Schema class for each element |
 | `bitwidth` | `int` | `32` | Word width for serialization |
+
+The master creates an internal `StreamIFMaster` exposed as `.stream_ep` — bind it over a `StreamIF`.
 
 ```python
 master = ArrayTransferIFMaster(
     sim=sim,
-    transport=transport,
     element_type=Float32,
     bitwidth=32,
 )
@@ -160,12 +160,12 @@ yield from self.arr_master.write([1.0, -2.5, 3.14])              # raw values �
 
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
-| `transport` | `PhysicalTransport` | — | Physical layer to receive from |
 | `element_type` | `type[DataSchema]` | — | Schema class for each element |
 | `bitwidth` | `int` | `32` | Word width for deserialization |
 | `rx_proc` | `Callable[[list], ProcessGen[None]] \| None` | `None` | Push-mode callback |
 | `pull_mode` | `bool` | `False` | When `True`, enables `get(count)` and disables the push callback |
 
+The slave creates an internal `StreamIFSlave` exposed as `.stream_ep` — bind it over a `StreamIF`.
 Two receive modes are available.
 
 ### Push mode (default)
@@ -182,12 +182,11 @@ def on_samples(self, elements: np.ndarray) -> ProcessGen[None]:
 
 slave = ArrayTransferIFSlave(
     sim=sim,
-    transport=transport,
     element_type=Float32,
     bitwidth=32,
     rx_proc=self.on_samples,
 )
-slave.pre_sim()   # installs the receive callback
+# bind slave.stream_ep over a StreamIF; run_sim() then calls pre_sim() to install the callback
 ```
 
 ### Pull mode
@@ -197,7 +196,6 @@ Set `pull_mode=True` (and do not set `rx_proc`).  The owning component drives se
 ```python
 slave = ArrayTransferIFSlave(
     sim=sim,
-    transport=transport,
     element_type=Float32,
     bitwidth=32,
     pull_mode=True,
@@ -244,6 +242,9 @@ Binding raises:
 - `TypeError` if the wrong endpoint class is used for a side
 - `ValueError` if master and slave have different `element_type` or `bitwidth`
 
+Like `SchemaTransferIF`, this container only validates the logical pair — it does **not** wire the
+physical link. You still bind each endpoint's `.stream_ep` over a `StreamIF` to connect them.
+
 ---
 
 ## Example: push mode
@@ -251,12 +252,14 @@ Binding raises:
 The master sends a burst; the slave infers element count from burst length.
 
 ```python
+from dataclasses import dataclass
+
 import numpy as np
 from waveflow.hw.clock import Clock
 from waveflow.hw.dataschema import FloatField
-from waveflow.hw.interface import StreamIF, StreamIFMaster, StreamIFSlave
+from waveflow.hw.interface import StreamIF
 from waveflow.hw.schema_transfer_interface import (
-    ArrayTransferIFMaster, ArrayTransferIFSlave, StreamTransport,
+    ArrayTransferIFMaster, ArrayTransferIFSlave,
 )
 from waveflow.simulation.simulation import Simulation
 from waveflow.simulation.simobj import ProcessGen, SimObj
@@ -266,70 +269,101 @@ Float32 = FloatField.specialize(bitwidth=32)
 sim = Simulation()
 clk = Clock(freq=1e9)
 
-stream_if     = StreamIF(sim=sim, clk=clk)
-stream_master = StreamIFMaster(sim=sim, bitwidth=32)
-stream_slave  = StreamIFSlave(sim=sim, bitwidth=32)
-stream_if.bind("master", stream_master)
-stream_if.bind("slave",  stream_slave)
-
-transport = StreamTransport(master_ep=stream_master, slave_ep=stream_slave)
-
 received: list[np.ndarray] = []
 
 def on_samples(elements: np.ndarray) -> ProcessGen[None]:
     received.append(elements)   # np.ndarray[float32]
     yield sim.env.timeout(0)
 
-arr_master = ArrayTransferIFMaster(sim=sim, transport=transport, element_type=Float32, bitwidth=32)
-arr_slave  = ArrayTransferIFSlave(
-    sim=sim, transport=transport, element_type=Float32,
-    bitwidth=32, rx_proc=on_samples,
-)
-arr_slave.pre_sim()
+arr_master = ArrayTransferIFMaster(sim=sim, element_type=Float32, bitwidth=32)
+arr_slave  = ArrayTransferIFSlave(sim=sim, element_type=Float32, bitwidth=32, rx_proc=on_samples)
 
-def tx():
-    yield from arr_master.write(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+# Each transfer endpoint owns an internal stream_ep; bind those over a StreamIF.
+stream_if = StreamIF(sim=sim, clk=clk)
+stream_if.bind("master", arr_master.stream_ep)
+stream_if.bind("slave",  arr_slave.stream_ep)
 
-sim.env.process(stream_slave.run_proc())
-sim.env.process(tx())
-sim.env.run(until=sim.env.timeout(10))
+
+@dataclass
+class Tx(SimObj):
+    def run_proc(self) -> ProcessGen[None]:
+        yield from arr_master.write(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+
+
+Tx(name="tx", sim=sim)
+sim.run_sim()   # calls arr_slave.pre_sim() to install the receive callback
 # received[0] == np.array([1.0, 2.0, 3.0], dtype=np.float32)
 ```
 
 ---
 
-## Example: pull mode (PolyAccel pattern)
+## Example: pull mode
 
-The motivating use case: a component receives a typed header first, then uses the header's `nsamp` field to pull the right number of samples from the same physical stream.
+In pull mode the consumer drives sequencing: it calls `get(count=n)` for an **exact** element count
+(TLAST-validated) instead of registering a callback.
 
 ```python
-class PolyAccelSim(SimObj):
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        self.stream_slave = StreamIFSlave(sim=self.sim, bitwidth=32)
+from dataclasses import dataclass
 
-        transport = StreamTransport(master_ep=..., slave_ep=self.stream_slave)
+import numpy as np
+from waveflow.hw.clock import Clock
+from waveflow.hw.dataschema import FloatField
+from waveflow.hw.interface import StreamIF
+from waveflow.hw.schema_transfer_interface import (
+    ArrayTransferIFMaster, ArrayTransferIFSlave,
+)
+from waveflow.simulation.simulation import Simulation
+from waveflow.simulation.simobj import ProcessGen, SimObj
 
-        self.cmd_slave = SchemaTransferIFSlave(
-            sim=self.sim, transport=transport,
-            schema_type=PolyCmdHdr, bitwidth=32,
-            pull_mode=True,
-        )
-        self.samp_slave = ArrayTransferIFSlave(
-            sim=self.sim, transport=transport,
-            element_type=Float32, bitwidth=32,
-            pull_mode=True,
-        )
+Float32 = FloatField.specialize(bitwidth=32)
+
+
+@dataclass
+class Producer(SimObj):
+    master: ArrayTransferIFMaster | None = None
 
     def run_proc(self) -> ProcessGen[None]:
-        while True:
-            cmd     = yield from self.cmd_slave.get()                        # PolyCmdHdr
-            samples = yield from self.samp_slave.get(count=cmd.nsamp)        # np.ndarray[float32]
-            _, out, _ = self.accel.evaluate(cmd, samples.astype(float))
-            yield from self.resp_master.write(...)
+        yield from self.master.write(np.array([1.0, 2.0, 3.0], dtype=np.float32))
+
+
+@dataclass
+class Consumer(SimObj):
+    slave: ArrayTransferIFSlave | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.samples: np.ndarray | None = None
+
+    def run_proc(self) -> ProcessGen[None]:
+        self.samples = yield from self.slave.get(count=3)   # exact count; TLAST-validated
+
+
+sim = Simulation()
+clk = Clock(freq=1e9)
+
+producer = Producer(
+    name="producer", sim=sim,
+    master=ArrayTransferIFMaster(sim=sim, element_type=Float32, bitwidth=32),
+)
+consumer = Consumer(
+    name="consumer", sim=sim,
+    slave=ArrayTransferIFSlave(sim=sim, element_type=Float32, bitwidth=32, pull_mode=True),
+)
+
+stream_if = StreamIF(sim=sim, clk=clk)
+stream_if.bind("master", producer.master.stream_ep)
+stream_if.bind("slave",  consumer.slave.stream_ep)
+
+sim.run_sim()
+# consumer.samples == np.array([1.0, 2.0, 3.0], dtype=np.float32)
 ```
 
-Both `cmd_slave` and `samp_slave` share the same `transport` (and therefore the same physical `StreamIFSlave`).  Because `run_proc` is a sequential coroutine, there is no contention — `cmd_slave.get()` consumes the first burst, then `samp_slave.get(count=nsamp)` consumes the second.
+> **Header + payload on one physical stream.** Each transfer endpoint owns its own `stream_ep`, so two
+> transfer slaves cannot share a single stream. For the "typed header first, then pull `nsamp`
+> samples from the *same* stream" pattern (the poly accelerator), use a single raw
+> [`StreamIFSlave`](./stream.md) and successive `get()` calls — `cmd = yield from s_in.get(PolyCmdHdr)`
+> then `samp = yield from s_in.get_pipelined(Float32, count=cmd.nsamp)` — as
+> [`examples/stream_inband/poly.py`](../../../examples/stream_inband/poly.py) does.
 
 ---
 
@@ -368,10 +402,10 @@ from waveflow.hw.schema_transfer_interface import (
 
 | Operation | Code |
 |---|---|
-| Create transport | `StreamTransport(master_ep=m, slave_ep=s)` |
-| Create master | `ArrayTransferIFMaster(sim=sim, transport=t, element_type=T, bitwidth=32)` |
-| Create slave (push) | `ArrayTransferIFSlave(sim=sim, transport=t, element_type=T, bitwidth=32, rx_proc=fn)` |
-| Create slave (pull) | `ArrayTransferIFSlave(sim=sim, transport=t, element_type=T, bitwidth=32, pull_mode=True)` |
+| Create master | `ArrayTransferIFMaster(sim=sim, element_type=T, bitwidth=32)` |
+| Create slave (push) | `ArrayTransferIFSlave(sim=sim, element_type=T, bitwidth=32, rx_proc=fn)` |
+| Create slave (pull) | `ArrayTransferIFSlave(sim=sim, element_type=T, bitwidth=32, pull_mode=True)` |
+| Wire the physical link | `stream_if.bind("master", master.stream_ep); stream_if.bind("slave", slave.stream_ep)` |
 | Transmit (numpy fast path) | `yield from master.write(np.array(..., dtype=np.float32))` |
 | Transmit (schema / raw values) | `yield from master.write([v1, v2, …])` |
 | Receive (push, manual setup) | `slave.pre_sim()` before `env.run()` |

--- a/docs/guide/interface/schema_transfer.md
+++ b/docs/guide/interface/schema_transfer.md
@@ -105,48 +105,26 @@ multi-type (`DataUnion`) walkthroughs are below.
 
 | Class | Role |
 |---|---|
-| `PhysicalTransport` | Abstract base: `write_words(words)` + `set_rx_callback(fn)` |
-| `StreamTransport` | Adapter over `StreamIFMaster` / `StreamIFSlave` |
-| `SchemaTransferIFMaster` | Serializes objects → forwards word bursts to transport |
+| `PhysicalTransport` | Abstract base: `write_words(words)` + `set_rx_callback(fn)` (internal) |
+| `StreamTransport` | Adapter over `StreamIFMaster` / `StreamIFSlave` (built internally by each endpoint) |
+| `SchemaTransferIFMaster` | Serializes objects → forwards word bursts over its stream port |
 | `SchemaTransferIFSlave` | Receives word bursts → deserializes → delivers to `rx_proc` / queue |
 | `SchemaTransferIF` | Optional logical container; validates endpoint types and bitwidth |
 
 ---
 
-## PhysicalTransport
+## The transport layer (internal)
 
-`PhysicalTransport` is an ABC with two methods:
+You do **not** construct or pass a transport. Each `SchemaTransferIF` endpoint creates its own
+internal `StreamTransport` in `__post_init__` and exposes the underlying stream endpoint as
+`.stream_ep`; you wire the physical link by binding those `.stream_ep`s over a shared `StreamIF`
+(exactly as the [minimal simulation](#a-minimal-simulation) above does).
 
-```python
-class PhysicalTransport(ABC):
-
-    @abstractmethod
-    def write_words(self, words: Words) -> ProcessGen:
-        """Transmit a word burst through the physical endpoint."""
-
-    @abstractmethod
-    def set_rx_callback(self, callback: Callable[[Words], ProcessGen]) -> None:
-        """Register the callback invoked when a word burst arrives."""
-```
-
-The only concrete implementation shipped today is `StreamTransport`.
-
----
-
-## StreamTransport
-
-`StreamTransport` wraps a `StreamIFMaster` / `StreamIFSlave` pair:
-
-```python
-from waveflow.hw.schema_transfer_interface import StreamTransport
-
-transport = StreamTransport(
-    master_ep=stream_master,   # StreamIFMaster
-    slave_ep=stream_slave,     # StreamIFSlave
-)
-```
-
-`write_words` delegates to `stream_master.write(words)`.  `set_rx_callback` sets `stream_slave.rx_proc = callback`.
+`PhysicalTransport` is the ABC the layer is built on (`write_words(words)` +
+`set_rx_callback(fn)`), and `StreamTransport` is its only implementation — an adapter whose
+`write_words` delegates to the master `stream_ep.write(words)` and whose `set_rx_callback` sets the
+slave `stream_ep.rx_proc`. Both are plumbing; the sections below cover the endpoints you actually
+construct.
 
 ---
 
@@ -154,11 +132,12 @@ transport = StreamTransport(
 
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
-| `transport` | `PhysicalTransport` | — | Physical layer to transmit through |
 | `bitwidth` | `int` | `32` | Word width for serialization |
 
+The master creates an internal `StreamIFMaster` exposed as `.stream_ep` — bind it over a `StreamIF`.
+
 ```python
-master = SchemaTransferIFMaster(sim=sim, transport=transport, bitwidth=32)
+master = SchemaTransferIFMaster(sim=sim, bitwidth=32)
 ```
 
 **Usage** — from inside a `run_proc`:
@@ -176,15 +155,16 @@ def run_proc(self) -> ProcessGen:
 
 | Parameter | Type | Default | Meaning |
 |---|---|---|---|
-| `transport` | `PhysicalTransport` | — | Physical layer to receive from |
 | `schema_type` | `type` | — | Class to call `.deserialize(words, word_bw)` on |
 | `bitwidth` | `int` | `32` | Word width for deserialization |
 | `rx_proc` | `Callable[[Any], ProcessGen] \| None` | `None` | Callback invoked with each deserialized object |
+| `pull_mode` | `bool` | `False` | When `True`, disables the push callback and enables `yield from slave.get()` |
+
+The slave creates an internal `StreamIFSlave` exposed as `.stream_ep` — bind it over a `StreamIF`.
 
 ```python
 slave = SchemaTransferIFSlave(
     sim=sim,
-    transport=transport,
     schema_type=SensorDU,   # DataUnion or DataList subclass
     bitwidth=32,
     rx_proc=self._on_object,
@@ -226,7 +206,7 @@ iface.bind("slave",  slave_ep)
 
 Binding raises `TypeError` if the wrong endpoint class is used for a side, and `ValueError` if the master and slave have different bitwidths.
 
-`SchemaTransferIF` is not required for the transport to function — the transport operates through the master/slave endpoint pair directly.
+`SchemaTransferIF` is optional and only validates the logical pair — it does **not** wire the physical link. You still bind each endpoint's `.stream_ep` over a `StreamIF` to connect them (see the [minimal simulation](#a-minimal-simulation)).
 
 ---
 
@@ -235,11 +215,13 @@ Binding raises `TypeError` if the wrong endpoint class is used for a side, and `
 Every transfer carries one known schema; no header is needed.
 
 ```python
+from dataclasses import dataclass
+
 from waveflow.hw.clock import Clock
 from waveflow.hw.dataschema import DataList, IntField
-from waveflow.hw.interface import StreamIF, StreamIFMaster, StreamIFSlave
+from waveflow.hw.interface import StreamIF
 from waveflow.hw.schema_transfer_interface import (
-    SchemaTransferIFMaster, SchemaTransferIFSlave, StreamTransport,
+    SchemaTransferIFMaster, SchemaTransferIFSlave,
 )
 from waveflow.simulation.simulation import Simulation
 from waveflow.simulation.simobj import ProcessGen, SimObj
@@ -257,8 +239,7 @@ class SensorPacket(DataList):
 class TxComponent(SimObj):
     def __post_init__(self) -> None:
         super().__post_init__()
-        self.stream_ep = StreamIFMaster(sim=self.sim, bitwidth=32)
-        self.schema_ep: SchemaTransferIFMaster | None = None
+        self.schema_ep = SchemaTransferIFMaster(sim=self.sim, bitwidth=32)
 
     def run_proc(self) -> ProcessGen:
         for temp_raw, sid in [(-10, 1), (25, 2), (75, 3)]:
@@ -269,8 +250,9 @@ class TxComponent(SimObj):
 class RxComponent(SimObj):
     def __post_init__(self) -> None:
         super().__post_init__()
-        self.stream_ep = StreamIFSlave(sim=self.sim, bitwidth=32)
-        self.schema_ep: SchemaTransferIFSlave | None = None
+        self.schema_ep = SchemaTransferIFSlave(
+            sim=self.sim, schema_type=SensorPacket, bitwidth=32, rx_proc=self.on_packet,
+        )
 
     def on_packet(self, pkt: SensorPacket) -> ProcessGen:
         print(f"temp_raw={int(pkt.temp_raw)}  sensor_id={int(pkt.sensor_id)}")
@@ -283,19 +265,10 @@ clk = Clock(freq=1e9)
 tx = TxComponent(sim=sim)
 rx = RxComponent(sim=sim)
 
-# Physical layer
+# Each transfer endpoint owns an internal stream_ep; bind those over a StreamIF.
 stream_if = StreamIF(sim=sim, clk=clk)
-stream_if.bind("master", tx.stream_ep)
-stream_if.bind("slave",  rx.stream_ep)
-
-# Logical layer
-transport = StreamTransport(master_ep=tx.stream_ep, slave_ep=rx.stream_ep)
-tx.schema_ep = SchemaTransferIFMaster(sim=sim, transport=transport, bitwidth=32)
-rx.schema_ep = SchemaTransferIFSlave(
-    sim=sim, transport=transport,
-    schema_type=SensorPacket, bitwidth=32,
-    rx_proc=rx.on_packet,
-)
+stream_if.bind("master", tx.schema_ep.stream_ep)
+stream_if.bind("slave",  rx.schema_ep.stream_ep)
 
 sim.run_sim()
 ```
@@ -347,9 +320,10 @@ def on_receive(self, du: SensorDU) -> ProcessGen:
     if handler is not None:
         yield from handler(self, du.payload)
 
-# Slave configuration
+# Slave configuration — only schema_type changes vs. the single-type example;
+# bind rx.schema_ep.stream_ep over the StreamIF exactly as before.
 rx.schema_ep = SchemaTransferIFSlave(
-    sim=sim, transport=transport,
+    sim=sim,
     schema_type=SensorDU,   # ← DataUnion, not DataList
     bitwidth=32,
     rx_proc=rx.on_receive,
@@ -413,9 +387,9 @@ from waveflow.hw.schema_transfer_interface import (
 
 | Operation | Code |
 |---|---|
-| Create transport | `StreamTransport(master_ep=m, slave_ep=s)` |
-| Create master | `SchemaTransferIFMaster(sim=sim, transport=t, bitwidth=32)` |
-| Create slave | `SchemaTransferIFSlave(sim=sim, transport=t, schema_type=T, bitwidth=32, rx_proc=fn)` |
+| Create master | `SchemaTransferIFMaster(sim=sim, bitwidth=32)` |
+| Create slave | `SchemaTransferIFSlave(sim=sim, schema_type=T, bitwidth=32, rx_proc=fn)` |
+| Wire the physical link | `stream_if.bind("master", master.stream_ep); stream_if.bind("slave", slave.stream_ep)` |
 | Transmit (from run_proc) | `yield from master.write(obj)` |
 | Register callback (manual) | `slave.pre_sim()` before `env.run()` |
 | Poll queue | `event = slave.queue.get(); yield event; obj = event.value` |


### PR DESCRIPTION
Fixes the stale-API tech debt flagged in PR #95. Docs-only — no changes under `waveflow/` or `examples/`. The newer "## A minimal simulation" toys (added in PR #95) are correct and are **left untouched**; this migrates the **older, deeper sections** of `schema_transfer.md` and `array_transfer.md`, which still used a constructor API the current engine rejects.

## The drift (verified against `waveflow/hw/schema_transfer_interface.py`)
The transfer endpoints (`SchemaTransferIFMaster/Slave`, `ArrayTransferIFMaster/Slave`) each **own** an internal `StreamIFMaster/Slave` exposed as `.stream_ep` (a `field(init=False)`) and build their `_transport = StreamTransport(...)` **internally** in `__post_init__`. You wire the physical link by binding each endpoint's `.stream_ep` over a shared `StreamIF`. The deeper sections still hand-built `StreamTransport(master_ep=…, slave_ep=…)` and passed `transport=…` to the endpoints — the `transport=` kwarg no longer exists, so that code raises on construction.

## What changed (both pages)
- **Parameter tables** — dropped the `transport` row from each master/slave table; noted the endpoint creates its own `.stream_ep` to bind.
- **`PhysicalTransport` / `StreamTransport` docs** — reframed as the **internal** transport layer each endpoint builds automatically (not something you construct or pass); the user-facing wiring is the `.stream_ep` bind.
- **Logical-container sections** (`SchemaTransferIF` / `ArrayTransferIF`) — clarified they only validate the logical pair; you still bind the `.stream_ep`s over a `StreamIF` to connect them.
- **Worked examples** — migrated to the current API: schema single-type and multi-type (DataUnion); array push-mode (now uses `run_sim()` instead of manual `env.run`) and pull-mode.
- **Quick-reference tables** — removed the "Create transport" / `transport=t` rows; added a "Wire the physical link" row showing the `stream_ep` bind.

### One semantic correction (array pull-mode)
The old pull-mode example shared **one** transport across two slaves (`cmd_slave` + `samp_slave`) — which the current API cannot express, since each transfer endpoint owns its own stream. It is now a correct **single-slave** pull-mode example, with a note that the "typed header then pull `nsamp` samples from the *same* physical stream" pattern (the poly accelerator) uses a single raw `StreamIFSlave` with successive `get()` calls — as `examples/stream_inband/poly.py` does.

## Verification
- **Toys preserved.** The PR #95 "## A minimal simulation" sections are byte-unchanged.
- **Examples run.** Every complete (`run_sim`) code block on both pages was extracted **verbatim** and executed under `../pysilicon-venv/Scripts/python.exe` — **5/5 PASS** (2 on schema: the toy + migrated single-type; 3 on array: the toy + push + pull). The multi-type and container snippets remain illustrative fragments. No tests added.
- **No residual stale API:** `grep "transport="` and hand-built `StreamTransport(...)`-passed-to-endpoint → none.
- **Full link gate = 0** (per-file realpath sweep over every relative `.md` / `.py` / dir target).
- **Docs-only** — the diff is exactly the two interface pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
