### PR TITLE
docs(timing): add Timing Models guide section

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -12,6 +12,7 @@ Welcome to Waveflow.  This folder will have guides to use the Waveflow functiona
 - [Data Schemas](./schema)
 - [Vectorization](./vectorization/)
 - [Memory Modeling](./memory/)
+- [Timing Models](./timing_model/)
 - [Timing Analysis Tools](./timing)
 - [Hardware Interfaces](./interface/overview.md)
 - [Build System](./build/)

--- a/docs/guide/sim/timing.md
+++ b/docs/guide/sim/timing.md
@@ -85,6 +85,7 @@ timestamped events for later analysis).
 
 ## See also
 
+- [Timing Models](../timing_model/) — the deeper forward model: how a component's load/compute/store shape (block, streaming, double-buffered) sets its timeline, building on this page.
 - [Logging](./logging.md) — capture `self.now`-stamped events to a CSV during the run.
 - [Timing Analysis Tools](../timing/) — analyzing the timeline this model produces.
 - [Interface Overview](../interface/overview.md) — the per-interface latency parameters.

--- a/docs/guide/timing_model/block.md
+++ b/docs/guide/timing_model/block.md
@@ -1,0 +1,92 @@
+---
+title: Block processing
+parent: Timing Models
+nav_order: 2
+audience: python
+api: [MMIFMaster.read_array, MMIFMaster.write_array, SimObj.timeout, Clock.period]
+summary: "The block-processing timing model: load a whole array, compute, store. A single serial coroutine — no overlap — so it is the simplest to model. The compute wait is the closed form latency + II·(m − 1), with the (m − 1) convention spelled out."
+---
+
+# Block processing
+
+**Block processing** is the serial barrier: load the whole input array into a buffer, compute on
+it, then store the whole output array. Nothing overlaps — load, compute, and store happen strictly
+one after another. It is the simplest flow to model, and the right starting point.
+
+A block-processing component's `run_proc` looks like this (the timing fields `self.latency`,
+`self.proc_ii`, and `self.unroll_factor` are the component's own synthesis parameters — see
+[Fitting a timing model](./fit.md)):
+
+```python
+import math
+
+x = yield from mem.read_array(Float32, n, xaddr, word_bw=word_bw)
+y = compute(x)
+
+# Wait the time to process `x`
+m = math.ceil(n / self.unroll_factor)        # effective trip count
+cycles = self.latency + self.proc_ii * (m - 1)
+yield self.timeout(cycles * self.clk.period)
+
+yield from mem.write_array(y, Float32, yaddr, word_bw=word_bw)
+```
+
+> A timeline figure for this page (deferred) would show three non-overlapping bars in sequence —
+> **load**, then **compute**, then **store** — making the serial barrier visually obvious.
+
+## Why there is no explicit load/store time
+
+Notice the model charges time *only* for compute. The load and store time is already handled by
+the `yield from` on [`read_array`](../interface/aximm.md) / `write_array`: those calls block the
+coroutine for however long the transfer actually takes. We deliberately do **not** add a fixed
+time for loading, because the load time is not the processor's to decide — it varies with
+interconnect occupancy (other masters contending for the bus, see [polling
+overhead](../interface/poll.md)) or with a source outside the processor entirely. Letting the
+interface charge it keeps the load/store cost honest and composable; the component models only the
+part it owns, the compute.
+
+## `ii` and `latency`
+
+Two numbers describe a pipelined compute:
+
+- **`ii`** — the **initiation interval**: the number of cycles between successive iterations
+  entering the pipeline. An `II = 1` pipeline accepts a new iteration every cycle; `II = 2` every
+  other cycle. It sets the *throughput*.
+- **`latency`** — the **pipeline depth**: the number of cycles from an input entering the pipeline
+  to its corresponding output coming out. It sets the *delay* of any single result.
+
+`unroll_factor` is the third knob: unrolling the loop by *U* processes *U* elements per iteration,
+so the **effective trip count** — the number of iterations actually issued — is
+`m = ceil(n / U)`, not `n`.
+
+## The closed form `latency + II·(m − 1)`
+
+For a pipeline that issues `m` iterations, the total compute time is:
+
+```
+cycles = latency + II · (m − 1)
+```
+
+The `(m − 1)` is deliberate, and worth stating explicitly. Reason it out from the two endpoints:
+
+- The **first** output lands `latency` cycles after compute starts (it has to traverse the whole
+  pipeline).
+- After that first output, the pipeline emits **one more output every `II` cycles**. There are
+  `m − 1` *remaining* outputs after the first, so they take `II · (m − 1)` additional cycles.
+
+Add them: `latency + II · (m − 1)`. A common off-by-one is to write `latency + II · m`, which
+over-counts by one `II` — it charges an initiation interval for the first output, which has already
+been paid for inside `latency`. With `m = 1` (a single iteration), the formula correctly collapses
+to just `latency`.
+
+## Fitting the numbers
+
+`latency`, `ii`, and `unroll_factor` are properties of the synthesized hardware. You can set them
+by hand from an HLS report, or **fit** them from a few measured data points so the LT model tracks
+real cycle counts — that is covered in [Fitting a timing model](./fit.md).
+
+## See also
+
+- [Streaming processing](./streaming.md) — the next step on the continuum: let compute overlap the load instead of waiting for the whole array.
+- [MM Interfaces](../interface/aximm.md) — the `read_array` / `write_array` calls and their transfer-latency model.
+- [Simulation timing model](../sim/timing.md) — `self.timeout` and the `Clock` that converts cycles to seconds.

--- a/docs/guide/timing_model/double_buffered.md
+++ b/docs/guide/timing_model/double_buffered.md
@@ -1,0 +1,115 @@
+---
+title: Double-buffered processing
+parent: Timing Models
+nav_order: 4
+audience: python
+api: [MMIFMaster.read_array, MMIFMaster.write_array, SimObj.timeout, SimObj.process, Clock.period]
+summary: "The double-buffered (ping-pong) timing model: load(n) ∥ process(n-1) ∥ store(n-2). Block-granularity overlap that cannot be expressed in one serial coroutine — it needs three concurrent SimPy processes handing off through depth-2 buffers, from which the steady-state max(load, compute, store) emerges."
+---
+
+# Double-buffered processing
+
+**Double-buffered** (or **ping-pong**) processing sits between [block](./block.md) and
+[streaming](./streaming.md) on the [overlap continuum](./index.md#three-flows-one-continuum). It
+overlaps at **block** granularity: while block *n* is loading, block *n-1* is being computed and
+block *n-2* is being stored.
+
+```
+load(n) ∥ process(n-1) ∥ store(n-2)
+```
+
+All three stages run at once on different blocks, so once the pipeline fills, the time per block
+is set by the *slowest* stage rather than the sum of all three — roughly
+`t_block ≈ max(load, process, store)`.
+
+## Why this flow needs a different shape
+
+You **cannot** model this overlap inside one sequential coroutine. In block and streaming, the
+whole timing model fits in a single `run_proc` because the stages really are sequential there. But
+in a double-buffered flow the stages must run *concurrently*, and the `yield from` on
+`read_array` / `write_array` genuinely advances the clock and **serializes** — the moment you
+`yield from` a load, that coroutine is blocked until the load finishes, so nothing else in it can
+overlap. A single coroutine cannot be in a load and a store at the same simulated instant.
+
+So this flow requires **actual concurrency**: three separate SimPy processes — a loader, a
+compute stage, and a storer — handing blocks off to each other through bounded buffers.
+
+## The pattern
+
+```python
+import math
+import simpy
+
+buf_in  = simpy.Store(env, capacity=2)   # ping-pong: capacity 2 == double buffer
+buf_out = simpy.Store(env, capacity=2)
+
+def loader():
+    for blk in blocks:
+        x = yield from mem.read_array(Float32, n, blk.xaddr, word_bw=word_bw)
+        yield buf_in.put(x)              # blocks if the loader gets 2 blocks ahead
+
+def compute_proc():
+    for blk in blocks:
+        x = yield buf_in.get()
+        y = compute(x)
+        m = math.ceil(n / self.unroll_factor)
+        yield self.timeout((self.latency + self.proc_ii * (m - 1)) * self.clk.period)
+        yield buf_out.put(y)
+
+def storer():
+    for blk in blocks:
+        y = yield buf_out.get()
+        yield from mem.write_array(y, Float32, blk.yaddr, word_bw=word_bw)
+```
+
+The three functions are started as concurrent processes (e.g. `self.process(loader())`,
+`self.process(compute_proc())`, `self.process(storer())`) so SimPy interleaves them.
+
+> A timeline figure for this page (deferred) would show three staggered rows — load, compute,
+> store — each one block behind the row above, with the steady-state block period set by the
+> tallest bar.
+
+## Key points
+
+- **The overlap is emergent, not computed.** You do not calculate `t_block ≈ max(load, process,
+  store)` anywhere — it *falls out* of SimPy scheduling. Each stage simply does its work and blocks
+  on the buffer hand-off; the discrete-event runtime resolves who waits for whom, and the
+  steady-state throughput is whatever the slowest stage allows. This is the payoff of modeling with
+  real processes instead of arithmetic.
+- **`capacity=2` is what makes it "double" buffered.** The depth-2 `Store` bounds how far ahead a
+  producer may run: the loader can be at most one block ahead of compute before `buf_in.put`
+  blocks. That one block of look-ahead is exactly the second buffer.
+- **The capacity is the knob across the whole continuum.** `capacity=1` removes the look-ahead and
+  collapses this back to [block](./block.md) processing (load and compute can no longer overlap).
+  `capacity=∞` is unbounded buffering (the loader races ahead with no back-pressure). `capacity=2`
+  is the canonical ping-pong middle ground.
+
+## Synthesis mapping (deferred)
+
+> **This page teaches an LT timing model, not a synthesizable structure.** The three internal
+> SimPy processes are a *sim-only* device: their only job is to produce the
+> `max(load, compute, store)` timeline. They use nothing new — three `self.process(...)`
+> coroutines and two `simpy.Store`s — so the model works **today**, with no added framework
+> capability.
+
+The model does have a synthesizable counterpart, worth naming so you know where it lands. In HLS
+the same overlap is the canonical `#pragma HLS DATAFLOW` decomposition: a **parent `HwComponent`**
+containing three **dataflow sub-components** — load, compute, store — with the AXI-MM interface
+exposed to the load and store sub-components, **shared input/output PIPO buffers** declared at the
+top level, and **`hls::stream` handshakes** between the stages signaling data-ready. That is the
+hardware realization of the loader/compute/storer processes and the depth-2 buffers above.
+
+Building it is gated on **hierarchical multi-`HwComponent` composition** — a parent component that
+owns sub-components and wires shared memory and streams between them — which the current
+single-component examples do not do yet. It therefore lands with that milestone (the
+accelerator-anatomy convergence work on hierarchical composition), **not in this docs pass**. Until
+then, this page ships the sim-only LT timing model and forward-references the synthesizable
+structure.
+
+## See also
+
+- [Block processing](./block.md) — `capacity=1` collapses double-buffering back to this.
+- [Streaming processing](./streaming.md) — finer-grained overlap (per element) when the source delivers a continuous stream rather than discrete blocks.
+- [Hardware Components](../components/) — declaring components and their ports; the home of the future hierarchical-composition milestone this flow's synthesizable structure depends on.
+- [Custom Hooks](../custom_hooks/) — the synthesizable side, where the `#pragma HLS DATAFLOW` body would be written.
+- [Process generators](../sim/procgen.md) — spawning concurrent SimPy processes, the mechanism this flow relies on.

--- a/docs/guide/timing_model/fit.md
+++ b/docs/guide/timing_model/fit.md
@@ -1,0 +1,68 @@
+---
+title: Fitting a timing model
+parent: Timing Models
+nav_order: 5
+audience: python
+api: [Clock.period]
+summary: "Recovering the timing-model parameters — latency, ii, unroll_factor — from a few measured (size, cycles) data points, by linear regression against the effective trip count. The cosim cycle-model work is building the infrastructure to do this against RTL ground truth."
+---
+
+# Fitting a timing model
+
+The [block](./block.md), [streaming](./streaming.md), and [double-buffered](./double_buffered.md)
+models are all driven by three numbers: **`latency`** (pipeline depth), **`ii`** (initiation
+interval), and **`unroll_factor`** (elements processed per iteration). Those numbers are properties
+of the *synthesized* hardware. You can read them off a Vitis HLS report by hand — but you can also
+**fit** them from a handful of measured data points, so the loosely-timed model tracks real cycle
+counts without you transcribing report numbers.
+
+## The model is linear in the trip count
+
+Recall the block compute latency:
+
+```
+cycles = latency + ii · (m − 1),      m = ceil(n / unroll_factor)
+```
+
+For a **fixed** `unroll_factor`, this is a straight line in `(m − 1)`: the slope is `ii` and the
+intercept is `latency`. So if you measure the cycle count at several input sizes `n`, compute
+`m − 1` for each, and fit a line `cycles = a + b·(m − 1)`, you recover:
+
+- **`ii = b`** — the slope (cycles added per extra iteration).
+- **`latency = a`** — the intercept (cost of the very first output).
+
+Two points suffice in principle; use more and a least-squares fit so measurement noise averages
+out, and check the residual / R² to confirm the model actually holds over the swept range.
+
+## Recovering `unroll_factor`
+
+`unroll_factor` enters through `m = ceil(n / unroll_factor)`, so it is not a free linear
+coefficient — it reshapes the x-axis. Two ways to pin it down:
+
+1. **Known from synthesis.** If you set the unroll pragma, you already know `U`; plug it in and fit
+   only `latency` and `ii`.
+2. **Swept.** If `U` is unknown, fit the line for each candidate `U` and pick the one with the best
+   agreement (lowest residual / highest R²). The throughput asymptote also reveals it: at large
+   `n`, `cycles / n → ii / unroll_factor`, so the steady-state cycles-per-element fixes the ratio.
+
+## Where the data points come from
+
+The measured `(n, cycles)` points are *ground truth* — and the most faithful source of ground
+truth for a Waveflow design is a **Vitis HLS cosim sweep**: synthesize the kernel, run cosim at a
+range of input sizes, and read the cycle count for each. That is a cycle-timed measurement (see
+[LT vs CT](./models.md)) used precisely to calibrate the loosely-timed model so the fast LT
+simulation predicts the slow RTL.
+
+## Infrastructure (in progress)
+
+Turning "run a sweep, fit `latency`/`ii`/`unroll_factor`, attach them to the component" into a
+reusable, committed flow is the **cosim cycle-model** work. The pattern already exists end-to-end
+in the AXI-MM command-queue example, which fits a `(depth, ii)` cycle model from a committed cosim
+sweep and feeds it back into the LT simulation; the general infrastructure for arbitrary components
+is being built out from there.
+
+## See also
+
+- [Block processing](./block.md) — the `latency + ii·(m − 1)` form this fit inverts.
+- [AXI-MM Command Queue example](../../examples/mmqueue/) — a worked cosim-sweep calibration (`depth`, `ii`) that this generalizes.
+- [Timing Analysis Tools — cosim timing](../timing/cosim_timing.md) — extracting cycle counts from a Vitis HLS cosim run, the measurement side of the fit.

--- a/docs/guide/timing_model/index.md
+++ b/docs/guide/timing_model/index.md
@@ -1,0 +1,59 @@
+---
+title: Timing Models
+parent: Guide
+nav_order: 11
+has_children: true
+audience: python
+api: [SimObj.timeout, Clock.period, MMIFMaster.read_array, MMIFMaster.write_array, StreamIFSlave.get_pipelined, StreamIFMaster.write_pipelined]
+summary: "How an HwComponent specifies its timing model — not just what it computes, but how long that takes and what event it pends on to complete. Teaches three processing flows as a continuum of load/compute/store overlap: block, double-buffered, and streaming."
+---
+
+# Timing Models
+
+Every `HwComponent` carries two models. The **functional model** says *what* it computes — the
+math from inputs to outputs. The **timing model** says *how long* that takes and *what event it
+pends on* to complete — when, in simulated time, the work finishes and the output becomes
+available. The functional model is documented with each component; this section is about the
+timing model.
+
+> The name **timing model** may not be final — it is the *forward* model that produces a
+> timeline (as opposed to the [Timing Analysis Tools](../timing/) that *measure* one). It builds
+> directly on the [Simulation timing model](../sim/timing.md) page (`Clock`, `self.timeout`,
+> charging compute latency) and goes deeper: how the **shape** of a component's load/compute/store
+> loop changes the timeline.
+
+## Three flows, one continuum
+
+Many of the accelerators in Waveflow follow a three-step process: read input data, perform some computation on it, and write the output data.  This **load / compute / store** sequence arises often in accelerators, and designers typically use one of three models to realize it.  All three models have the same *functional* behavior but differ in their *timing* behavior — specifically, in the extent to which the steps overlap.  That overlap in turn affects which computations can be supported, the resource usage, and the latency.
+
+ - **block**: load, compute, and store run sequentially with no overlap — a serial barrier: load the whole array, then compute, then store.  Simplest to implement, but has the highest latency.
+
+ - **double-buffered**: overlap at *block* granularity (load(n) ∥ process(n-1) ∥ store(n-2)).  Reduces latency, but requires additional memory for buffering.
+
+ - **streaming**: the limit as block size → 1 beat — per-element overlap.  Needs minimal buffering and achieves the lowest latency, but is only possible when the computation can be performed as data arrives.
+
+
+The pages below take them in order of modeling difficulty — block first (a single serial
+coroutine), then streaming (per-element timestamps in one coroutine), then double-buffered (which
+needs *actual* concurrency).
+
+## A note on naming
+
+This section prefers **double-buffered** (or "ping-pong") over a bare "buffered." Block processing
+also uses a buffer — it loads a whole array into one before computing — so "buffered" alone is
+ambiguous. "Double-buffered" names the thing that matters: *two* buffers, so the next block can
+load while the current one is still being processed.
+
+## In this section
+
+- [LT vs CT models](./models.md) — loosely-timed vs cycle-timed simulation, and why Waveflow is LT.
+- [Block processing](./block.md) — the serial barrier: load → compute → store. The simplest to model, and the closed-form compute latency `latency + II·(m − 1)`.
+- [Streaming processing](./streaming.md) — per-element overlap: the first output appears `latency` cycles after the *first* input, and the rest are gated by whichever is slower, input arrival or compute rate.
+- [Double-buffered processing](./double_buffered.md) — block-granularity overlap (`load(n) ∥ process(n-1) ∥ store(n-2)`), modeled with three concurrent SimPy processes through depth-2 buffers.
+- [Fitting a timing model](./fit.md) — recovering `latency`, `ii`, and `unroll_factor` from measured data points.
+
+## See also
+
+- [Simulation timing model](../sim/timing.md) — the `Clock`, `self.timeout`, and where transfer vs. compute latency is charged. This section assumes that page.
+- [Timing Analysis Tools](../timing/) — the *reverse* direction: measuring throughput / latency / overlap from a produced timeline (VCD, cosim, AXI parsing).
+- [Interfaces](../interface/) — `read_array` / `write_array` (memory-mapped) and `get_pipelined` / `write_pipelined` (streams), the transfer calls these flows are built from.

--- a/docs/guide/timing_model/models.md
+++ b/docs/guide/timing_model/models.md
@@ -1,0 +1,64 @@
+---
+title: LT vs CT models
+parent: Timing Models
+nav_order: 1
+audience: python
+api: [Clock, SimObj.timeout]
+summary: "Loosely-timed (LT) vs cycle-timed (CT) simulation. Waveflow models timing loosely — one timed event per transaction, not per clock edge — which is what makes a whole-system Python simulation fast, and is the same choice established computer-architecture simulators make."
+---
+
+# Loosely-timed vs cycle-timed
+
+A timing model can be written at two very different levels of detail.
+
+## Cycle-timed (CT)
+
+A **cycle-timed** (or cycle-accurate) model advances one clock edge at a time and resolves the
+state of every signal on every cycle. It is the most faithful — it can reproduce pipeline stalls,
+arbitration, and back-pressure to the exact cycle — but it is expensive: simulating a 1024-word
+burst means stepping the simulator 1024+ times, and a whole system of such blocks multiplies out.
+RTL simulation (and Vitis HLS **cosim**) is cycle-timed; it is where you go for ground truth, not
+for fast design-space exploration.
+
+## Loosely-timed (LT)
+
+A **loosely-timed** model does not step every cycle. It represents a unit of work as a single
+**timed transaction**: compute *how long* the work takes (in cycles, converted to seconds through
+the [`Clock`](../../../waveflow/hw/clock.py)), then advance simulated time by that amount in one
+jump with `yield self.timeout(...)`. The functional result is computed all at once; only the
+*timestamps* are modeled. A 1024-word burst is **one** event, not 1024.
+
+This is exactly the discrete-event style Waveflow's [simulation](../sim/) is built on: time only
+moves when something happens, so the cost of a simulation scales with the number of transactions,
+not the number of cycles.
+
+## Why Waveflow is LT
+
+Waveflow's milestone is to **simulate a whole system in Python** before any C++ is generated —
+wire components through interfaces, run them, and check that the data flows and the results are
+correct. That is a design-space-exploration job: you run it constantly, over many configurations,
+and you need it to be fast and to compose across dozens of blocks. An LT model delivers that. The
+trade is precision: an LT model predicts timing within a calibrated error band rather than to the
+exact cycle. When you need the exact cycle count, you fall back to cosim — and you can *calibrate*
+the LT model against it (see [Fitting a timing model](./fit.md)).
+
+The three flows in this section — [block](./block.md), [streaming](./streaming.md), and
+[double-buffered](./double_buffered.md) — are all LT models. They differ only in how much
+load/compute/store overlap their timeline exposes, not in whether they step every cycle (none of
+them do).
+
+## Not a new idea
+
+Loosely-timed, transaction-level modeling is the established approach for fast architectural
+simulation. SystemC TLM-2.0 defines an explicit *loosely-timed* coding style for exactly this
+purpose, and widely-used computer-architecture simulators (gem5 in its faster CPU modes, and
+event-driven SoC virtual platforms) make the same bet: model transactions and their latencies, not
+every clock edge, so a full system stays tractable. Waveflow's contribution is to express that
+model in the *same* Python that defines the functional behavior and that feeds synthesis, so one
+source of truth drives simulation, timing, and codegen.
+
+## See also
+
+- [Simulation](../sim/) — the SimPy discrete-event runtime an LT model runs on.
+- [Block processing](./block.md) — the first and simplest LT timing model.
+- [Timing Analysis Tools](../timing/) — including the cosim path that produces the cycle-accurate ground truth an LT model is calibrated against.

--- a/docs/guide/timing_model/streaming.md
+++ b/docs/guide/timing_model/streaming.md
@@ -1,0 +1,116 @@
+---
+title: Streaming processing
+parent: Timing Models
+nav_order: 3
+audience: python
+api: [StreamIFSlave.get_pipelined, StreamIFMaster.write_pipelined, SimObj.timeout, Clock.period]
+summary: "The streaming timing model: compute overlaps the load, so the first output appears `latency` cycles after the first input and later outputs are gated by whichever is slower — input arrival or compute rate. The per-element max() collapses to a first/last form; only first and last arrival times are known."
+---
+
+# Streaming processing
+
+**Streaming** is the opposite end of the continuum from [block](./block.md): instead of loading the
+whole array and *then* computing, the compute pipeline starts as soon as the **first** input
+element arrives and runs concurrently with the rest of the load. There is no load-then-compute
+barrier — load and compute overlap element by element.
+
+That overlap is exactly what makes streaming harder to model. In block processing the compute
+window is a single `timeout` after the load finishes. In streaming, each output's time depends on
+two competing pressures, and we have to take the later of them.
+
+## The per-element model
+
+Let `L` be the pipeline `latency`, `II` the initiation interval, and `T` the clock period
+(`self.clk.period`). For output element `k`:
+
+```
+t_out[k]    = max( t_in[k] + L*T ,  t_out[k-1] + II*T )
+
+t_out_first = t_in_first + L*T
+t_out_last  = max( t_in_last + L*T ,  t_out_first + (m-1)*II*T )
+                  └─ input-limited ─┘   └──── compute-limited ────┘
+```
+
+Read the per-element line as a race between two bounds:
+
+- **`t_in[k] + L*T` — input-limited.** Output `k` cannot exist until input `k` has arrived
+  (`t_in[k]`) and traversed the pipeline (`L*T`). If the source is slow, this dominates.
+- **`t_out[k-1] + II*T` — compute-limited.** The pipeline can emit at most one result every `II`
+  cycles, so output `k` is at least `II*T` after output `k-1`. If the source is fast, this
+  dominates.
+
+The output is paced by whichever is slower, hence the `max`. Collapsing the recurrence to just the
+**first** and **last** elements gives the form we actually compute: the first output is purely
+input-limited (`t_in_first + L*T`), and the last output is the later of the input-limited bound
+(`t_in_last + L*T`) and the compute-limited bound (`(m-1)` more iterations at `II` after the
+first). The `(m-1)` is the same effective-trip-count convention as in
+[block processing](./block.md) — `m = ceil(n / unroll_factor)`
+iterations means `m-1` outputs after the first.
+
+> A timeline figure for this page (deferred) would show the **load** bar and the **compute** bar
+> overlapping, with the first output offset `L*T` into the load and the gap between outputs set by
+> the slower of arrival and `II` — visually, the two bounds racing.
+
+## The pattern
+
+```python
+import math
+from waveflow.hw.arrayutils import array
+
+# Wait for the entire vector x to load, but also retrieve when the first
+# sample was loaded.  After this returns, env.now == t_in_last.
+x, t_in_first = yield from s_in.get_pipelined(Float32, count=n)
+
+y = compute(x)
+m = math.ceil(n / self.unroll_factor)
+T = self.clk.period
+
+# First output is ready `latency` cycles after the first input.
+t_out_first = t_in_first + self.latency * T
+
+# Last output: gated by the later of the input-limited and compute-limited bounds.
+# env.now == t_in_last, so the input-limited bound is (env.now + latency*T).
+t_out_last = max(self.env.now  + self.latency * T,
+                 t_out_first   + (m - 1) * self.proc_ii * T)
+
+# Stay busy until the last output is emitted.
+yield self.timeout(t_out_last - self.env.now)
+
+# Write the output, tagging the stream with when it could start.
+yield from m_out.write_pipelined(array(Float32, y), t_out_first)
+```
+
+[`get_pipelined`](../interface/stream.md) returns the data **and** the first-word arrival time:
+after it returns, `self.env.now` is `t_in_last` (the whole burst has arrived), and `t_in_first` is
+when the first word landed. [`write_pipelined`](../interface/stream.md) tags the outgoing stream
+with `t_out_first` so the *next* component downstream sees a correctly-timed first word and can
+overlap against it in turn — that is how streaming composes across a pipeline of components.
+
+Note the division of labor between the two delays here. The **compute rate** is set by
+`self.proc_ii` and is charged by the `yield self.timeout(...)` above — that is what holds the
+component busy until its last result exists. The **output transport rate** is a separate concern
+owned by `write_pipelined`, which models the burst as leaving at one word per clock from
+`t_out_first`. Do not read `proc_ii` as the rate at which words go out on the stream: it paces the
+datapath, not the wire. (In this pattern the `timeout` has already advanced past `t_out_first`, so
+`write_pipelined`'s remaining delay collapses and the compute `timeout` dominates the total —
+`write_pipelined` is only setting the downstream *start* tag, not adding fresh time.)
+
+## Two simplifications to be honest about
+
+This model is loosely timed, and it makes two deliberate approximations:
+
+1. **Only first and last arrival times are known.** `get_pipelined` gives us `t_in_first` and
+   `t_in_last`, not the full per-element arrival profile. The `max()` therefore assumes the inputs
+   arrive **densely and uniformly** between those two times. A bursty source that pauses mid-stream
+   would, in real hardware, stall the pipeline at points this model smooths over.
+2. **Functional compute happens "all at once."** `y = compute(x)` runs as a single numpy-level
+   operation on the whole vector — only the *timestamps* are pipelined, not the data. The model
+   reproduces *when* each output would be available, but it does not actually push elements through
+   a cycle-by-cycle datapath. (This is the LT bet from [LT vs CT](./models.md): model the
+   transaction's timing, not every cycle.)
+
+## See also
+
+- [Block processing](./block.md) — the no-overlap baseline this is the streaming limit of.
+- [Double-buffered processing](./double_buffered.md) — overlap at *block* granularity rather than per element, when the source delivers whole blocks.
+- [Stream Interfaces](../interface/stream.md) — `get_pipelined` / `write_pipelined` and the first-word-time mechanism.


### PR DESCRIPTION
Adds `docs/guide/timing_model/` — a new guide section teaching the loosely-timed (LT) timing model for the load/compute/store flow as a continuum of overlap: **block → double-buffered → streaming**.

## Pages
- **index** — functional vs timing model; the overlap continuum; double-buffered naming note
- **models** — loosely-timed vs cycle-timed, why Waveflow is LT
- **block** — serial barrier; closed-form compute latency `latency + II*(m-1)`
- **streaming** — per-element `max(input-limited, compute-limited)` collapsed to first/last; `get_pipelined`/`write_pipelined`; compute-rate (`proc_ii`) vs output-transport-rate distinction; the two LT simplifications
- **double_buffered** — three concurrent SimPy processes over depth-2 buffers; synthesis mapping (`HLS DATAFLOW`) forward-referenced, gated on hierarchical multi-`HwComponent` composition
- **fit** — recovering `latency`/`ii`/`unroll_factor` from measured points

## Nav
Linked from `docs/guide/index.md`; reciprocal see-also from `docs/guide/sim/timing.md`.

Docs-only. API snippets verified against real `read_array`/`write_array`/`get_pipelined`/`write_pipelined` signatures. Timing figures and the synthesizable double-buffered structure are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)