### PR TITLE
docs(vmac/mmqueue): full VMAC example walkthrough + mm-queue guide pages

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -73,7 +73,7 @@ base case.
 | 2 | `pure_stream`                    | moving-average filter | streaming dataflow — no packet boundary, no TLAST, no control | planned                   | reserved (not built yet)               |
 | 3 | [`stream_inband`](./stream_inband/) | polynomial            | packetization (TLAST) + in-band control on the stream          | stages 1–5               | available                              |
 | 4 | [`shared_mem`](./shared_mem/)       | histogram             | data in memory (AXI-MM), control over a dedicated stream       | stages 1–5               | available; codegen upgrade in progress |
-| 5 | `mem_queue`                      | vector unit           | control*also* in memory, via a descriptor queue              | stages 1–2 (codegen TBD) | reserved (not built yet)               |
+| 5 | [`mmqueue`](./mmqueue/)             | complex vector MAC (VMAC) | control *also* in memory, via a descriptor queue            | stages 1–5               | available                              |
 
 The shared-memory (`shared_mem`) example is the reference for AXI-MM (`m_axi`)
 codegen — multiple buffers and element types read/written over one bundle, with

--- a/docs/examples/mmqueue/arithmetic.md
+++ b/docs/examples/mmqueue/arithmetic.md
@@ -1,0 +1,82 @@
+---
+title: Fixed-point arithmetic
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 3
+has_children: false
+---
+
+# Fixed-point arithmetic
+
+The [data types](./datatypes.md) page showed that VMAC's formats are *derived* from
+the command by `VmacFormats`. This page is what those formats **mean numerically**:
+the operand / accumulator / output number formats, how precision grows through the
+datapath, and the single requantize that lands the result back in the output format.
+It is VMAC's *use* of the fixed-point machinery — the machinery itself is
+[FixedField](../../guide/schema/python/fixpoint.md) and
+[ComplexField](../../guide/schema/python/complex.md), not re-taught here.
+
+## Three formats along the datapath
+
+A value passes through three component formats, each a fixed-point `(W, I, F)`
+(width, integer bits, fractional bits):
+
+| stage | format | from `VmacFormats` |
+| --- | --- | --- |
+| **operand** | `(data_bw, int_bits, F_in)` with `F_in = data_bw − int_bits` | `in_format()` / `operand_elem()` |
+| **accumulator** | wide, op-dependent (below) | `accumulator_format(cmd)` |
+| **output** | `(out_bw, *, F_out)` with `F_out = F_in` | `output_format(cmd)` |
+
+The operands `A`/`B` are read in the operand format; the datapath accumulates in the
+**wide** accumulator format with no loss; the result is requantized **once** to the
+output format on writeback. Everything between read and requantize is full precision.
+
+## How precision grows
+
+The accumulator format depends on the op — a product widens the fraction, a sum does
+not — and on `reduce`, which widens the integer part:
+
+- **`scalar_mult` (`α·A`) and `inner_prod` (`A·conj(B)`)** — both are complex
+  *products*, so the fractional bits double: `F_acc = 2·F_in`. (The C++ accumulator
+  is `std::complex<ap_fixed<ACC_BW, ACC_BW − 2·F_in>>`, i.e. exactly `2·F_in`
+  fractional bits within the `acc_bw` budget.)
+- **`sum` (`A + B`)** — an add keeps the scale: `F_acc = F_in`.
+- **`reduce`** — summing `n_rows` results can grow the magnitude, so the reduce adds
+  `⌈log₂ n_rows⌉` integer bits to the accumulator. The width budget `acc_bw` must
+  hold the result; `VmacFormats` checks this and **fails loud** if it does not.
+
+So the datapath is `cmult` / `cadd` into a wide complex `ap_fixed` accumulator,
+optionally `cadd`-reduced down the rows, all carried at full precision.
+
+## The single requantize
+
+The result is brought back to the output format **once**, at writeback, by
+`derived_shift(cmd)` — a right-shift of `SHIFT = F_acc − F_out` fractional bits,
+then round and saturate per the command's modes:
+
+- product ops (`scalar_mult`, `inner_prod`): `SHIFT = F_in` (the fraction doubled,
+  the output keeps `F_in`, so shed `F_in` bits);
+- `sum`: `SHIFT = 0` (same scale in and out).
+
+Rounding (`q_rnd`: truncate vs. round) and overflow (`o_sat`: wrap vs. saturate) are
+the standard fixed-point modes; both are carried in `output_format` as the
+`FixedField`'s quantization/overflow modes. There is exactly one requantize per
+result element — the accumulator is never rounded mid-datapath — which is what keeps
+the model and the kernel bit-identical.
+
+## Why bit-exactness matters here
+
+Because every format is derived and there is a single, precisely-sized requantize,
+the Python golden and the synthesized C++ kernel compute the **same bits**. That is
+not a nicety — it is the conformance contract the [C and RTL simulation](./rtlsim.md)
+page checks **byte-for-byte**: Vitis csim/cosim output is compared against the one
+`execute` golden's image, and any drift in a shift, a rounding mode, or an
+accumulator width shows up as a mismatch. The format algebra in `VmacFormats` is what
+makes that contract hold by construction rather than by luck.
+
+## See also
+
+- [FixedField](../../guide/schema/python/fixpoint.md) — the `(W, I, F)` model,
+  `QMode`/`OMode`, and the conformance harness behind the rounding/overflow modes.
+- [ComplexField](../../guide/schema/python/complex.md) — the complex component type
+  the operand/accumulator/output formats wrap.
+- [Data types](./datatypes.md) — where these formats come from (`VmacFormats`).

--- a/docs/examples/mmqueue/codegen.md
+++ b/docs/examples/mmqueue/codegen.md
@@ -1,0 +1,86 @@
+---
+title: Code generation
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 6
+has_children: false
+---
+
+# Code generation — the synthesizable top
+
+VMAC's synthesizable top is **auto-extracted** from the same `run_proc` the
+[Python simulation](./pysim.md) runs. There is no hand-written top in the build path:
+the framework lowers the extracted `run_proc` IR to a free-running C++ kernel, and a
+Vitis cosim checks it bit-exact against the one golden.
+
+## The generated path is the real one
+
+[`vmac_topgen.py`](../../../examples/vmac/vmac_topgen.py) generates the top from the
+extracted `run_proc` IR through the framework `kernel_to_cpp` path
+(`kernel_signature` + `kernel_body_to_cpp`). The result is a **free-running,
+`m_axi`-only** kernel that:
+
+1. dequeues a `VmacCmd` from the in-memory ring — the synthesizable
+   [`AXIMMQueue.get`](../../guide/interface/mmqueue.md) lowered to the
+   [`queue_get` ring-dequeue hook](../../guide/custom_hooks/queue.md);
+2. stops if the command is `OpCode.end`;
+3. otherwise runs `vmac_compute` (the [hand-written datapath hook](./hook.md)) and
+   loops.
+
+It is wired into the build as the `topgen_cosim` step, which builds a ring image in
+memory (head/tail/capacity + one command slot + an `END` slot via the producer-side
+`VmacCmd.serialize`), lays the `A`/`B` operands after the ring, invokes the generated
+top, and checks the `Y` region **bit-exact** against
+[`vmac_golden_mem.apply_golden`](../../../examples/vmac/vmac_golden_mem.py) (which
+runs the one `execute` golden — no second golden):
+
+```bash
+cd examples/vmac
+python vmac_build.py --through topgen_cosim   # the auto-extracted top, bit-exact cosim (Vitis)
+```
+
+So the generated top and the synthesizable queue dequeue are **done and validated**,
+not aspirational.
+
+## Why the top has only `m_axi` + `ap_ctrl`
+
+The generated top exposes exactly two interfaces: the `m_axi` `gmem` master and the
+`ap_ctrl` block-control handshake. There is **no `s_axilite`** command port. The
+command never crosses a register boundary — it is read from the ring in memory by the
+dequeue hook and deserialized inside the kernel.
+
+This is deliberate (decision D6) and it **sidesteps a csynth pitfall**. Passing the
+nested `VmacCmd` struct in over `s_axilite` (or by value into the synthesizable path)
+mis-decomposes through HLS's struct/array optimization at C-synthesis — loop bounds
+can fold to zero and the kernel gets dead-code-eliminated. That is exactly the
+gotcha the [hook-writing guide](../../guide/custom_hooks/writing.md#pass-scalars-to-a-core-function--not-a-struct-by-value)
+documents, and it is why the **old hand-rolled top had to unpack the command into
+scalar registers** by hand. Reading the command from memory removes the boundary
+entirely: the deserialized fields are already plain scalars by the time they reach
+`vmac_compute_core`.
+
+## How the pieces fit
+
+The generated top is the *glue*; the datapath is hand-written:
+
+- The **structure** (the kernel signature, the `m_axi` port, the dequeue/compute
+  loop) is auto-generated — the general mechanism is
+  [Component Code Generation](../../guide/comp_codegen/).
+- The **dequeue** is the [`queue_get` hook](../../guide/custom_hooks/queue.md), called
+  where `run_proc` had `cmd_queue.get`.
+- The **compute** is the [`vmac_compute_impl.tpp` hook](./hook.md), called where
+  `run_proc` had `vmac_compute`.
+
+The generated top calls into both hooks; codegen emits the calls, you wrote the
+bodies.
+
+## Transitional note
+
+The build still contains hand-rolled `render_top` / `render_cosim_tb` f-strings (the
+ones that unpack the command into `s_axilite` scalars). They are **not** the current
+top — they remain only because the **calibration pipeline**
+([`vmac_cosim_sweep.py`](../../../examples/vmac/vmac_cosim_sweep.py) /
+[`vmac_cosim_stage3.py`](../../../examples/vmac/vmac_cosim_stage3.py) →
+`calibration/vmac_calibration.json`, the queue-sim baseline behind the
+[timing study](./timing.md)) still shares them. Migrating the calibration sweep onto
+the generated top and re-running the Vitis sweep is a follow-up; the generated path
+above is what produces the kernel.

--- a/docs/examples/mmqueue/datatypes.md
+++ b/docs/examples/mmqueue/datatypes.md
@@ -1,0 +1,105 @@
+---
+title: Data types — command and formats
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 2
+has_children: false
+---
+
+# Data types — the command and its formats
+
+VMAC's data layer has two halves, both in
+[`examples/vmac/vmac_datatypes.py`](../../../examples/vmac/vmac_datatypes.py): the
+**command** the host enqueues (`VmacCmd`) and the **dependent types**
+(`VmacFormats`) that a command implies for the datapath. This page is about those
+*types*; the numeric behaviour they describe — how precision grows and is requantized
+— is the [arithmetic](./arithmetic.md) page.
+
+## The command — `VmacCmd`
+
+A `VmacCmd` is the instruction the accelerator dequeues. It is a
+[`ParamSchema`](../../guide/schema/python/) specialized on the accelerator's address
+and component widths (`VmacCmd.specialize(mem_awidth=…, data_bw=…)`), so its fields
+are sized to the design. Its fields:
+
+| field | type | role |
+| --- | --- | --- |
+| `op` | `EnumField(OpCode)` | which element-wise op — `scalar_mult` / `inner_prod` / `sum` / `end` |
+| `reduce` | `BooleanField` | sum each result down its rows to one output row |
+| `n_rows`, `n_cols` | `UInt16` | the operand matrix shape |
+| `a`, `b`, `y` | `Region` | operand A, operand B, destination Y descriptors |
+| `alpha` | `Alpha` | the scaling operand for `scalar_mult` |
+
+### Region descriptors
+
+The operands are not inlined in the command — they are **pointers into shared
+memory**, described by a `Region`:
+
+| field | type | meaning |
+| --- | --- | --- |
+| `addr` | `IntField` (width `mem_awidth`) | base **element** offset of the region |
+| `row_stride` | `IntField`, signed | outer pitch in **elements** between rows |
+
+A region addresses a row-major matrix as `M[i, j] = mem[addr + i·row_stride + j]`.
+Addresses and strides are in **element** units, not bytes or words — the
+width-agnostic coordinate system the kernel and the SimPy
+[`Region`](./pymodel.md#region--element-coordinates) both use. `a` is always read;
+`b` is read for `inner_prod` / `sum`; `y` is the destination (collapsed to a single
+row when `reduce` is set).
+
+### The scalar — `Alpha`
+
+`scalar_mult` needs a per-row complex scalar, and it can come two ways, captured by
+the `Alpha` schema's `direct` flag:
+
+- **direct (immediate)** — `direct == True`: the scalar travels in the command itself
+  (`imm`, a complex value built from the operand's integer component type).
+- **indirect (per-row)** — `direct == False`: `addr` / `stride` point at a column of
+  scalars in memory, one per row, read like any other operand.
+
+This is the small but real bit of ISA design in VMAC: an immediate for the common
+case, an indirect for a per-row vector, selected by one boolean.
+
+## The dependent types — `VmacFormats`
+
+VMAC's fixed-point formats are **not stored per element**. Nowhere does a matrix
+carry a scale or a width with each value. Instead the formats are a pure function of
+the design's structural widths and the command, computed by `VmacFormats` — a frozen
+dataclass over `data_bw`, `int_bits`, `acc_bw`, `out_bw`, and the rounding/overflow
+modes `q_rnd` / `o_sat`. This is the page's signature idea: the **types are
+derived, not declared**.
+
+`VmacFormats` answers, for a given command:
+
+- **`operand_elem()`** — the shared-memory element type: a
+  [`ComplexField`](../../guide/schema/python/complex.md) whose real and imaginary
+  parts are a `FixedField(data_bw, int_bits)`. This is the type `A`, `B`, and the
+  indirect `α` are stored in.
+- **`accumulator_format(cmd)`** — the wide intermediate format the op accumulates in,
+  which *depends on the op* (a product op widens differently from a sum) and on
+  `reduce` (a row sum adds `⌈log₂ n_rows⌉` integer bits).
+- **`output_format(cmd)`** — the `FixedField` the result `Y` is written back in,
+  at width `out_bw` with the command's rounding/overflow modes.
+- **`derived_shift(cmd)`** — the single requantize shift from accumulator to output.
+- **`lane_capacity(word_bw)`** — how many complex columns pack into one memory word,
+  which sets the kernel's packing factor.
+
+Because these are derived, the golden model and the synthesizable kernel cannot
+disagree about a format: both read it off the same `VmacFormats`. The *arithmetic*
+those formats encode — what "widens differently" means, how the single requantize is
+sized — is the [next page](./arithmetic.md).
+
+## The complex element
+
+`A`, `B`, and `Y` are matrices of **complex fixed-point** values, modeled with the
+framework's [`ComplexField`](../../guide/schema/python/complex.md) over a
+[`FixedField`](../../guide/schema/python/fixpoint.md) component. VMAC does not
+re-teach complex or fixed-point typing — it *uses* them: `operand_elem()` above is
+just `ComplexField.specialize(FixedField(...))`. See those schema pages for how a
+complex field serializes (real low, imaginary high) and how a fixed-point field's
+`(W, I, F)` works.
+
+## Next
+
+- [Fixed-point arithmetic](./arithmetic.md) — what the derived formats *mean*
+  numerically: the operand / accumulator / output formats, how precision grows
+  through `cmult` → reduce → requantize, and the single requantize.

--- a/docs/examples/mmqueue/hook.md
+++ b/docs/examples/mmqueue/hook.md
@@ -1,0 +1,112 @@
+---
+title: Writing the kernel hook
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 7
+has_children: false
+---
+
+# Writing the kernel hook — `vmac_compute_impl.tpp`
+
+`vmac_compute` is the one method whose C++ is hand-written, in
+[`examples/vmac/vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp).
+This page walks **this specific datapath**. The *general* hook contract — the
+templated signature, how a hook plugs into the generated kernel, the csynth gotchas
+(scalar `*_core` args, `#pragma HLS INLINE`), and the `read_array_lane` /
+`read_array_slice` calls — is the guide's job:
+[Writing a hook](../../guide/custom_hooks/writing.md) and
+[Kernel patterns](../../guide/custom_hooks/patterns.md) already use VMAC for exactly
+that. Read those for the rules; this page is the VMAC-specific datapath they leave
+out.
+
+> Documented **as it currently is** — if the complex-typed cleanups tracked in the
+> repo's VMAC plan land later, the `.tpp` will move, but the shape below is what is in
+> the tree today.
+
+## Shape: a scalar-arg core + a thin wrapper
+
+Per the [csynth gotcha](../../guide/custom_hooks/writing.md#pass-scalars-to-a-core-function--not-a-struct-by-value),
+the real work is in a `vmac_compute_core` taking **flat scalar arguments**, with a
+struct-taking `vmac_compute(VmacCmd cmd, mem)` wrapper kept only for the csim
+testbench. The core is templated on the structural widths and takes the command as
+scalars — `op`, `reduce`, `n_rows`/`n_cols`, the three regions' `addr`/`row_stride`
+pairs, and the alpha fields:
+
+```cpp
+template <int MEM_BW, int MEM_AWIDTH, int DATA_BW, int INT_BITS, int ACC_BW, int OUT_BW,
+          bool Q_RND, bool O_SAT, int MAX_COLS>
+void vmac_compute_core(ap_uint<MEM_BW>* mem,
+                       int op, bool reduce, ap_uint<16> n_rows, ap_uint<16> n_cols,
+                       ap_uint<MEM_AWIDTH> a_addr, ap_int<MEM_AWIDTH> a_rs,
+                       ap_uint<MEM_AWIDTH> b_addr, ap_int<MEM_AWIDTH> b_rs,
+                       ap_uint<MEM_AWIDTH> y_addr, ap_int<MEM_AWIDTH> y_rs,
+                       bool al_direct, /*alpha imm*/ ..., ap_uint<MEM_AWIDTH> al_addr,
+                       ap_int<MEM_AWIDTH> al_stride);
+```
+
+## The complex types
+
+The datapath carries the [three formats](./arithmetic.md) as concrete C++ types,
+picked off the generated array-utils value types and the structural widths:
+
+- **operand** `CX = vmac_in_au::value_type` — `std::complex<ap_fixed<DATA_BW,
+  INT_BITS, …>>`;
+- **output** `CXO = vmac_out_au::value_type` — the `OUT_BW` complex type;
+- **accumulator** `ACC_CX = std::complex<ap_fixed<ACC_BW, ACC_BW − 2·F_in>>` — wide,
+  with `2·F_in` fractional bits (the product scale);
+- **requantize target** `REQ_FX = ap_fixed<OUT_BW, OUT_INT, QMODE, OMODE>` — carrying
+  the command's rounding/overflow modes.
+
+Full precision is held in the `ACC_CX` value until a **single** `cx_requantize` lands
+it in `CXO`.
+
+## The fused read-compute-write loop
+
+Operand rows are read with the `read_array_lane` lane loop (see
+[kernel patterns](../../guide/custom_hooks/patterns.md)): each iteration pulls the
+next `PF` complex columns for `A` (and `B`) at running word pointers and runs the
+complex datapath across the lane, `#pragma HLS UNROLL`-ed over the `PF` lanes:
+
+```cpp
+for (int k = 0; k < PF; ++k) {
+#pragma HLS UNROLL
+    CX r = /* cmult(alpha, a) | cmult(a, conj(b)) | cadd(a, b) */ ;   // complex_utils
+    if (reduce) acc[j] = cwiden<ACC_CX>(cadd(acc[j], r));             // accumulate wide
+    else        y_lane[k] = cx_requantize<CXO, REQ_FX>(r);            // non-reduce: requantize now
+}
+```
+
+The arithmetic (`cmult` / `cadd` / `conj` / `cwiden` / `cx_requantize`) comes from
+the shipped `complex_utils` header, not inline formulas. When `reduce` is set the
+column accumulators `acc[j]` carry the running sum at full precision; a second pass
+over the columns then `cx_requantize`s each accumulator and writes the single output
+row back with `write_array_lane`.
+
+## `ab_eq` — suppressing B's read
+
+The signature study of the [timing](./timing.md) page lives in one runtime flag:
+
+```cpp
+const bool ab_eq = need_b && (a_addr == b_addr) && (a_rs == b_rs);
+```
+
+When `B` aliases `A` element-for-element (same base **and** stride), the kernel fills
+`b_lane` from `a_lane` instead of issuing a second `m_axi` burst. `ab_eq` is a
+*runtime* predicate, so HLS fixes **one static II** at the worst case (B-read
+present) and only gates whether the B transaction *fires* — it does not reschedule
+shorter. That is the whole "same latency, freed bus" result, made concrete in the
+kernel.
+
+## Running pointers
+
+Addresses arrive in **element** coordinates (matching the Python
+[`Region`](./pymodel.md#region--element-coordinates)); the kernel converts to word
+pointers with `elem_to_word<PF>` (which checks PF-alignment) and advances them per
+beat (`a_w += 1` per lane iteration) and per row (`a_row += a_rsw`). Any helper that
+touches `mem` is `INLINE` so the `m_axi` reads bind to the top — again, the
+[guide's gotcha 2](../../guide/custom_hooks/writing.md#pragma-hls-inline-so-maxi-binds-to-the-top).
+
+## Validated against the golden
+
+Because `vmac_compute`'s Python sibling is the bit-exact [`execute` golden](./pymodel.md),
+the `.tpp` is checked against it in [csim/cosim](./rtlsim.md) for every config — the
+hook can never silently drift from the model.

--- a/docs/examples/mmqueue/index.md
+++ b/docs/examples/mmqueue/index.md
@@ -1,24 +1,21 @@
 ---
-title: AXI-MM Command Queue (VMAC timing)
+title: AXI-MM Command Queue (VMAC)
 parent: Examples
 nav_order: 6
-has_children: false
+has_children: true
 ---
 
-# AXI-MM Command Queue (VMAC timing)
+# AXI-MM Command Queue (VMAC)
 
-The previous examples taught one *interface concept* at a time. This one is a
-**timing study**: it takes a vector MAC accelerator (VMAC) fed commands over an
-AXI-MM command queue and asks a harder question than "does it compute the right
-numbers" — *does Waveflow's loosely-timed simulation predict the right **timing**,
-where exactly does it stop being faithful, and can a cosim **calibration** close the
-gap?*
-
-The answer is a named result — **bus utilization ≠ latency** — framed in the standard
-comp-arch vocabulary for what the simulator is (a **loosely-timed (LT) transaction-level
-model**), and then *corrected*: a Vitis RTL cosim **sweep** calibrates the LT model so
-its latency tracks real hardware. The headline figure is *committed* and regenerates
-with **no Vitis**.
+**VMAC** is a complex vector-MAC accelerator: it computes element-wise on complex
+fixed-point matrices and optionally reduces over rows. It supports **three
+element-wise operations plus a reduce** — `scalar_mult` (`α·A`), `inner_prod`
+(`A·conj(B)`), and `sum` (`A + B`), each with an optional per-column row sum. A host
+drives it not over a control stream but through a **command queue in shared memory**:
+the host appends `VmacCmd`s to a ring buffer, and a free-running accelerator dequeues
+and executes them over a single `m_axi` master. This is the
+[command-queue interface](../../guide/interface/mmqueue.md) — control moved off the
+stream and into memory — made concrete.
 
 ## The system
 
@@ -26,218 +23,46 @@ One host, one accelerator, one shared memory, over a single `m_axi` master:
 
 ```
    host ──AXI-MM command queue──▶ VMAC ──m_axi (gmem)──▶ shared memory
- (vmac_host.py)                 (vmac_queue_sim.py)        A | B | Y regions
+ (vmac_host.py)                  (vmac.py)                A | B | Y regions
 ```
 
-The host enqueues commands; VMAC dequeues them, reads its operand matrices `A`
-(and `B`) from memory over `m_axi`, computes, and writes the result `Y` back to
-the same bundle. Modeled in
-[`examples/vmac/vmac_queue_sim.py`](../../../examples/vmac/vmac_queue_sim.py) and
-[`examples/vmac/vmac_host.py`](../../../examples/vmac/vmac_host.py); the
-synthesizable kernel is
-[`examples/vmac/vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp).
+The host enqueues commands into the ring; VMAC dequeues them, reads its operand
+matrices `A` (and `B`) from memory over `m_axi`, computes, and writes the result `Y`
+back to the same bundle. The ring's `head`/`tail` pointers live in that memory too,
+so command flow and data flow share one interconnect.
 
-### Two commands, same opcode
+## Why this is the capstone example
 
-Both scenarios run the **same** `inner_prod` opcode (`R = A·conj(B)`) at PF=1 on
-4×4 operands, 100 MHz — they differ only in *where* `B` points:
+It is the last and most complete example in the
+[examples progression](../), and it is distinctive on two counts:
 
-- **`anorm`** — `b_addr == a_addr`. `B` aliases `A` (an auto-correlation / norm).
-  The kernel derives a loop-invariant **`ab_eq`** flag from `a_addr == b_addr` and
-  fills `b_lane` from `a_lane` **instead of issuing a second read burst**.
-- **`abcorr`** — `b_addr != a_addr`. The ordinary case: both `A` and `B` are read.
+- It is the only example that is **also a timing study** — it does not just ask
+  "are the numbers right" but "does the loosely-timed simulation predict the right
+  *timing*, and can a Vitis cosim calibrate it." That study is the [timing](./timing.md)
+  page.
+- It is the canonical **one-golden accelerator anatomy** — a single author-written
+  golden (`execute`) that both the SimPy model and the synthesizable kernel are
+  checked against. The [Python model](./pymodel.md) page is the reference other tiles
+  copy.
 
-`ab_eq` is a *runtime* flag, so HLS fixes **one static II** for the loop at the
-worst case (b-read present). It does not reschedule shorter when `ab_eq` holds — it
-only **predicates whether the AXI transaction fires**. That is the whole study:
-*same cycle count, B's bus beat suppressed.*
+## Walkthrough
 
-## The starting point: a transaction-gated LT sim
-
-The SimPy run logs a **source-agnostic** timeline — per-command memory
-transactions (`rw`/`name`/`addr`/`nwords`/`tstart`/`tend`), latency, read-word
-counts, and the command-queue occupancy. The Stage-1 LT model issues **one
-whole-matrix block per operand** (16 words in a single bus transaction) and made a
-command's latency the **sum of its transfer blocks** — *transaction-gated*. Its
-prediction:
-
-| scenario | read words | latency (naive LT) |
-| --- | --- | --- |
-| `anorm` (ab_eq) | 16 | 630 ns |
-| `abcorr`        | 32 | 940 ns |
-
-Half the reads **and** lower latency for `anorm` — the intuitive "fewer reads →
-faster" reading. **Both halves of that turn out to be wrong about latency**, and the
-RTL cosim is what exposes it.
-
-## What the RTL actually does
-
-Vitis RTL cosim measures the truth. At 4×4 the kernel takes **347 cycles** for
-*both* scenarios — `anorm` and `abcorr` are **identical in latency**, and `anorm`
-genuinely issues **half** the read-bus words:
-
-| scenario | read words (RTL) | latency (RTL) |
-| --- | --- | --- |
-| `anorm` (ab_eq) | **16** | **3470 ns** |
-| `abcorr`        | **32** | **3470 ns** |
-
-Two distinct errors in the naive sim fall out:
-
-1. **Ordering.** The sim said `anorm` is faster; the fixed-II RTL says **equal
-   latency, freed bus** — eliding B's read frees bandwidth, it does not shorten the
-   pipeline. *(bus utilization ≠ latency)*
-2. **Absolute scale.** The sim's 630–940 ns sit **~5× below** the RTL's 3470 ns: the
-   block model counts *transfer time*, not the kernel's *pipeline depth*.
-
-Both are the same root cause — a transaction-gated model can't see a pipeline whose
-latency decouples from the transaction count.
-
-## The fix: cosim-calibrated II-decoupling
-
-The repair is **II-decoupling** (TLM's LT→AT escalation — add just enough timing
-structure for the question at hand): make a command's latency the kernel **pipeline
-schedule** instead of the transfer sum,
-
-```
-latency_cycles ≈ depth + II · trips,   trips = n_rows · ⌈n_cols / PF⌉
-```
-
-while still *issuing* the bus transactions for occupancy. Latency becomes
-**II-driven** (depends only on `trips`, so `anorm` latency == `abcorr` latency — the
-fixed-II behaviour) and occupancy stays **transaction-driven** (`anorm` still issues
-half the reads). It lives entirely in the sim timing model
-([`VmacAccel.run_proc`](../../../examples/vmac/vmac.py)); the byte-exact golden
-`execute()` is untouched.
-
-### Calibration is a *sweep*, validated on a held-out point
-
-Fitting `(depth, II)` to the single 4×4 point would be tautological — one free
-parameter against one measurement always matches. So
-[`vmac_cosim_sweep.py`](../../../examples/vmac/vmac_cosim_sweep.py) cosims **four**
-sizes spanning distinct trip counts and commits the swept RTL cycles to
-[`calibration/vmac_calibration.json`](../../../examples/vmac/calibration/vmac_calibration.json):
-
-| size | trips | RTL cycles | RTL latency |
-| --- | --- | --- | --- |
-| 4×4 | 16 | 347 | 3470 ns |
-| 6×6 | 36 | 725 | 7250 ns |
-| 8×8 | 64 | 1258 | 12580 ns |
-| 8×16 | 128 | 2435 | 24350 ns |
-
-[`vmac_calibrate.py`](../../../examples/vmac/vmac_calibrate.py) fits the model on
-**three** of them and validates the prediction on the **held-out** fourth:
-
-- Fit on {4×4, 6×6, 8×8}: **depth = 42.7 cycles, II = 19.0 cycles/trip** (R² = 1.0000).
-  The data is cleanly linear in `trips`; `II ≈ 19` is the memory-gated inner-loop
-  interval, `depth ≈ 43` the fill/drain + reduce-loop overhead.
-- **Held-out 8×16** (trips 128): predicted 2472 cycles vs **actual 2435** —
-  **1.54 % error**. Leave-one-out over all four sizes stays ≤ 3.6 %.
-
-The same `(depth, II)` predict an un-fit configuration — that is what makes this a
-*calibration*, not a curve-trace. (It also seeds the DSE vision: the calibrated LT
-model now predicts un-cosim'd configs fast.)
-
-## The corrected result
-
-![VMAC loosely-timed sim, cosim-calibrated by II-decoupling, PF=1, 100 MHz. Panel (a): command latency vs trips across the 4×4/6×6/8×8/8×16 sweep — the naive transaction-gated LT curve sits ~5× below truth, while the calibrated LT curve (depth + II·trips, fit on three sizes) lands on the RTL cosim curve, including the circled held-out 8×16 point at 1.5% prediction error. Panel (b): m_axi read-bus words, anorm vs abcorr, per size — anorm is half across the sweep, so occupancy stays transaction-driven. Panel (c): calibrated latency anorm vs abcorr per size — equal bars (fixed-II), the "same latency, freed bus" result.](images/sim_vs_cosim.svg)
-
-The calibrated sim now reproduces both facts the naive model missed, while keeping
-the one it got right:
-
-| | naive LT | calibrated LT | RTL |
-| --- | --- | --- | --- |
-| `anorm` latency (4×4) | 630 ns | **3464 ns** | 3470 ns |
-| `abcorr` latency (4×4) | 940 ns | **3464 ns** | 3470 ns |
-| `anorm` vs `abcorr` latency | anorm faster ✗ | **equal ✓** | equal |
-| `anorm` read words | 16 (half ✓) | 16 (half ✓) | 16 (half) |
-
-- Panel **(a)** — *off → calibrated → tracks RTL*: the naive curve underestimates ~5×;
-  the calibrated curve sits on the RTL line across the whole sweep, **including the
-  held-out 8×16 point** it was never fit to.
-- Panel **(b)** — **bus still halved**: `anorm` reads half of `abcorr` at every size.
-  Occupancy stayed transaction-driven; the II-decoupling only touched latency.
-- Panel **(c)** — **fixed-II**: calibrated `anorm` latency == `abcorr` latency at every
-  size — the *"same latency, freed bus"* result, now correctly modeled.
-
-The named teaching result stands and is now *quantified*: **`ab_eq` frees the
-read-bus but does not shorten the pipeline** — and on a shared interconnect that freed
-bandwidth is exactly what another master (a CG matmul tile) would consume. The full
-numeric writeup is the committed
-[`calibration/vmac_calibration.json`](../../../examples/vmac/calibration/vmac_calibration.json)
-and [`timeline/sim_sweep.json`](../../../examples/vmac/timeline/sim_sweep.json).
-
-## What this says about the model (loosely-timed TLM)
-
-Waveflow's simulator is a **loosely-timed (LT) transaction-level model** in the
-SystemC TLM-2.0 sense: each transfer is a single timed *block* that holds a
-capacity-1 bus resource for its whole duration, and concurrent masters serialize
-on it (an implicit arbiter). This is accepted, standard practice — LT is how
-industry virtual platforms run fast — **not** a Waveflow shortcut. Framing the
-result, *and its repair*, in that vocabulary is the point of the example.
-
-**What LT captures faithfully here:**
-
-- Total interconnect **occupancy** (Σ of held block durations).
-- Multi-master **contention / arbitration** (serialization on the capacity-1 bus).
-- **First-order, burst-granular** memory-access timing — including the `ab_eq`
-  read-word halving, which the sim gets *right* in every mode.
-
-**What LT abstracts away (the boundary):**
-
-- **Sub-transaction interleaving / exact beat ordering** — a block is contiguous,
-  never "every other cycle."
-- Consequently **latency is mispredicted wherever it decouples from transaction
-  count** — the pipeline-depth and `ab_eq` cases above.
-
-**Fidelity per validation target, and how the calibration moves it:**
-
-| Target | Fidelity under the LT block model |
-| --- | --- |
-| Queue occupancy | **Robust** — command-level granularity; the block model is plenty fine |
-| Per-burst / total memory occupancy | **Robust** — the bus resource sums it correctly |
-| `ab_eq` latency & absolute latency | **Recoverable** — closed by the `(depth, II)` cosim calibration |
-| Sub-transaction ordering / fine contention | **Irreducible gap** — the block can't say who's on the bus *which* cycle |
-
-Escalating from *transaction-gated* to *II-parameterized* latency is Waveflow's analog
-of TLM's **LT→AT escalation**: the calibrated `(depth, II)` add just enough timing
-structure to answer the latency question, no more — sub-cycle ordering remains
-deliberately out of scope.
-
-> **Scope note.** Queue occupancy is a **sim-only** quantity here: the cosim kernel
-> has an `m_axi` but no command ring, so the calibration validates per-burst memory
-> timing and the `ab_eq` read-word result against RTL; occupancy is reported by the
-> sim alone and not fabricated for cosim.
-
-## The committed figure (regenerates without Vitis)
-
-The figure is rendered by
-[`examples/vmac/vmac_figures.py`](../../../examples/vmac/vmac_figures.py) from the
-**committed sweep timeline alone** —
-[`timeline/sim_sweep.json`](../../../examples/vmac/timeline/sim_sweep.json), which
-carries the naive, calibrated, and RTL latencies per size — no Vitis, no cosim
-re-run, no VCD read. That is the "committed figure" property: the docs build never
-needs the toolchain.
-
-```bash
-cd examples/vmac
-python vmac_calibrate.py         # print the fit + held-out validation (reads the calibration JSON)
-python vmac_queue_sim.py         # re-emit timeline/sim_timeline.json + timeline/sim_sweep.json
-python vmac_figures.py           # re-render docs/examples/mmqueue/images/sim_vs_cosim.svg
-python vmac_figures.py --check   # render to a temp file, byte-compare vs the committed SVG
-```
-
-The SVG is deterministic (a fixed `svg.hashsalt`, no embedded timestamp, mirroring
-[`shared_mem_figures.py`](../../../examples/shared_mem/shared_mem_figures.py)), so a
-re-render is **byte-identical** when nothing changed. `images/sync_status.json` records
-the source-JSON hash and the SVG hash, a cheap staleness signal a docs lint can check
-without re-running anything. The RTL truth was captured once by the Vitis-only
-[`vmac_cosim_sweep.py`](../../../examples/vmac/vmac_cosim_sweep.py) (and the 4×4
-headline by [`vmac_cosim_stage3.py`](../../../examples/vmac/vmac_cosim_stage3.py)) and
-committed.
-
-## Next
-
-- The [Shared Memory (histogram)](../shared_mem/) example — the previous step,
-  where the `m_axi` shared-memory pattern is introduced, with its own
-  [RTL cosim](../shared_mem/rtlsim.md) and [committed timing figures](../shared_mem/timing.md).
-- The [examples index](../) — the pattern progression this capstone sits in.
+1. [What we're building](./vmac.md) — the host-driven complex correlation the example
+   computes, the three-op + reduce model, and the system at a glance.
+2. [Data types — the command and formats](./datatypes.md) — `VmacCmd`, the operand
+   region descriptors, and `VmacFormats`, the dependent types derived from a command.
+3. [Fixed-point arithmetic](./arithmetic.md) — the operand / accumulator / output
+   number formats, how precision grows through the datapath, and the single
+   requantize.
+4. [The Python model](./pymodel.md) — the one author-written golden `execute`, the
+   synthesizable `vmac_compute` shell, and element-indexed `Region` access.
+5. [Python simulation](./pysim.md) — the SimPy queue sim: host + VMAC over a shared
+   memory, the free-running consumer loop, and parity against the golden.
+6. [Code generation](./codegen.md) — the auto-extracted, `m_axi`-only synthesizable
+   top that dequeues from the ring and runs `vmac_compute`.
+7. [Writing the kernel hook](./hook.md) — the hand-written `vmac_compute_impl.tpp`
+   complex datapath.
+8. [C and RTL simulation](./rtlsim.md) — Vitis csim/cosim against the one golden, the
+   conformance matrix, and throughput vs packing factor.
+9. [Timing — the LT model + cosim calibration](./timing.md) — the capstone timing
+   study (`ab_eq` bus-vs-latency, naive → calibrated → RTL, the committed figure).

--- a/docs/examples/mmqueue/pymodel.md
+++ b/docs/examples/mmqueue/pymodel.md
@@ -1,0 +1,104 @@
+---
+title: The Python model
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 4
+has_children: false
+---
+
+# The Python model — one-golden anatomy
+
+This is the reference page of the example. VMAC's `VmacAccel`
+([`examples/vmac/vmac.py`](../../../examples/vmac/vmac.py)) is the canonical
+**one-golden accelerator anatomy**: a single author-written numerical golden that
+*both* the SimPy simulation and the synthesized kernel are checked against, wrapped
+in a synthesizable shell that owns memory and timing. The next tile copies this
+shape.
+
+## One author-written golden
+
+The numerical truth is one method:
+
+```python
+def execute(self, cmd: VmacCmd, a, b=None, alpha=None) -> DataArray:
+    ...
+```
+
+`execute` is **pure math** — arrays in, result array out. It takes the operands
+already resident as numpy/`DataArray` structures (`a`, optional `b`, optional
+per-row `alpha`), applies the element-wise op, optionally reduces down the rows, and
+requantizes once to the output format (the [arithmetic](./arithmetic.md) page). It
+knows nothing about memory, addressing, the queue, or timing. Because it is the
+single source of numerical truth, the C++ kernel is bit-exact with it *by
+construction*, and the SimPy run is checked against it directly.
+
+> **Why one golden, not two.** An earlier design carried *two* goldens — `execute`
+> (pure math) and an `execute_mem` that operated on a flat memory image. They were
+> redundant and could drift. The example collapsed to a single `execute` plus a
+> generic memory-image harness ([`vmac_golden_mem.py`](../../../examples/vmac/vmac_golden_mem.py)'s
+> `apply_golden`, which deserializes operands out of a memory image, calls `execute`,
+> and serializes the result back). That is the same parity discipline the
+> [shared-memory histogram](../shared_mem/) example uses — one golden, a generic
+> deserialize/serialize wrapper for the memory view — and it is what the
+> [RTL conformance](./rtlsim.md) now compares against.
+
+## The synthesizable shell
+
+Around the golden sits the synthesizable method:
+
+```python
+@synthesizable(impl_file="vmac_compute_impl.tpp")
+def vmac_compute(self, cmd: VmacCmd, mem) -> ProcessGen[DataArray]:
+    ...                       # timed reads → self.execute(...) → timed writeback
+```
+
+`vmac_compute` **owns memory access and timing**: it reads the operand regions over
+`mem`, calls `self.execute(...)` for the math, and writes `Y` back — recording each
+transaction for the timing model. The `mem` argument is the same in both worlds: an
+[`MMIFMaster`](../../guide/interface/aximm.md) in the SimPy simulation, an `m_axi`
+pointer in the C++ kernel. Its Python body is the **simulation** model only — the
+extractor does *not* lower it; codegen emits a call to the hand-written
+[`vmac_compute_impl.tpp`](./hook.md) instead. So the one method is bit-exact-checked
+in Python and synthesized from the `.tpp`.
+
+## Region — element coordinates
+
+The shell reads and writes through a **`Region`** view over the master:
+`mem.region(...)` gives a `Region` whose `read_slice` / `write_slice` take **element
+indices**, not byte or word offsets. This is the SimPy twin of the C++
+`read_array_slice` / `read_array_lane` calls (see
+[kernel patterns](../../guide/custom_hooks/patterns.md)): the model and the kernel
+address operands the same width-agnostic way — `M[i, j]` at element `addr +
+i·row_stride + j` — so a `data_bw` or `mem_dwidth` change never rewrites the
+addressing. Element coordinates are also synth-natural: the kernel divides by the
+packing factor internally, the author never does. The `Region` slice calls keep
+timing **off the data path** — they return the values and record the transfer
+separately — which is what lets the timing model be calibrated independently (see
+[timing](./timing.md)).
+
+## Sim vs. hardware: what is extracted
+
+`VmacAccel` cleanly separates what becomes hardware from what is simulation
+bookkeeping. The free-running consumer is `run_proc`:
+
+```python
+while True:
+    cmd = yield from self.cmd_queue.get(self.Cmd)  # → AXIMMQueueGetStmt (synthesizable)
+    self._record_dequeue(cmd)                      # @sim_only — dropped by the extractor
+    if cmd.op == OpCode.end:                        # sentinel → ends the loop
+        return
+    yield from self.vmac_compute(cmd, self.m_mem)  # → the kernel hook
+    self._record_command(cmd)                       # @sim_only — latency bookkeeping
+```
+
+- The **extractable control flow** — the dequeue (`cmd_queue.get`, which lowers to
+  the [ring-dequeue hook](../../guide/custom_hooks/queue.md)), the `end` test, and the
+  `vmac_compute` call — is what the [generated top](./codegen.md) is built from.
+- The **`@sim_only`** helpers (`_record_dequeue`, `_record_command`) are timing/latency
+  bookkeeping; the extractor silently drops them, so they never reach hardware.
+- **`pre_sim`** does one-time Python setup (caching element geometry, setting the
+  ring's `poll_interval`); it is not synthesized.
+
+That split — synthesizable control flow with `@sim_only` instrumentation woven
+through it, and a `@synthesizable` datapath delegating to a pure golden — is the
+anatomy. The [Python simulation](./pysim.md) page runs it; the
+[code generation](./codegen.md) page extracts it.

--- a/docs/examples/mmqueue/pysim.md
+++ b/docs/examples/mmqueue/pysim.md
@@ -1,0 +1,83 @@
+---
+title: Python simulation
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 5
+has_children: false
+---
+
+# Python simulation
+
+The SimPy simulation wires the host and the accelerator to one shared memory and
+runs the whole command-queue protocol as a discrete-event simulation. It is the
+runnable Stage-2 model in
+[`examples/vmac/vmac_queue_sim.py`](../../../examples/vmac/vmac_queue_sim.py), and it
+is where numerical parity against the golden is established before any C++ exists.
+
+## Wiring
+
+Two masters, one memory, one interconnect:
+
+```
+   VmacHost ─┐                          ┌─ ring (head/tail + command slots)
+ (SimObj)    ├─ AXIMMCrossBarIF ─ MemComponent ─ A region
+   VmacAccel ┘                          └─ B | Y regions
+```
+
+The [`VmacHost`](../../../examples/vmac/vmac_host.py) and the `VmacAccel` are both
+masters on an `AXIMMCrossBarIF`; a single `MemComponent` is the slave holding the
+command **ring** (its `head`/`tail` pointers and slots) alongside the `A`, `B`, and
+`Y` data regions. Both sides reach the ring through an
+[`AXIMMQueue`](../../guide/interface/mmqueue.md) bound to that memory — the host as
+producer (`write`), the accelerator as consumer (`get`). This mirrors the minimal
+[`examples/interface/aximm_queue_demo.py`](../../../examples/interface/aximm_queue_demo.py)
+demo, scaled up to a real datapath.
+
+## The free-running consumer
+
+The accelerator does not wait to be told to start. Its `run_proc` loops forever,
+dequeuing and executing until the host enqueues the `end` sentinel:
+
+```python
+while True:
+    cmd = yield from self.cmd_queue.get(self.Cmd)   # block until a command is in the ring
+    if cmd.op == OpCode.end:
+        return                                       # sentinel — drain and stop
+    yield from self.vmac_compute(cmd, self.m_mem)    # timed reads → execute → timed writeback
+```
+
+Each `get` reads the ring pointers and one slot; when the ring is empty it
+[polls](../../guide/interface/poll.md) until the host advances `tail`. The host, for
+its part, writes `A` and `B`, enqueues `anorm` and `abcorr` (both `inner_prod +
+reduce`) then `end`, barriers on the ring draining, reads both `Y` regions back, and
+computes `rho = abcorr / anorm` itself (the [host/host-side division](./vmac.md#the-motivating-computation)).
+
+## The timing model at a glance
+
+The run logs a **source-agnostic** timeline — per-command memory transactions
+(`rw` / `addr` / `nwords` / `tstart` / `tend`), latencies, and ring occupancy — to
+`timeline/sim_timeline.json`. The Stage-2 loosely-timed (LT) model treats each
+operand transfer as a single timed **block** holding a capacity-1 bus resource for
+its whole duration. That is enough to get **occupancy** and the **`ab_eq` read-word
+halving** right, but not absolute latency — closing that gap with a Vitis cosim
+calibration is the whole subject of the [timing](./timing.md) page, which is why the
+timeline is emitted in the same schema as the cosim timeline.
+
+## Parity — the self-check
+
+The simulation's headline assertion is **bit-exact numerical parity**: the values
+VMAC writes to `Y` equal the one [`execute` golden](./pymodel.md), byte-for-byte, and
+the host's reconstructed `rho` matches the numpy reference. Alongside that, the run
+confirms the structural invariant the LT model *does* capture: the `anorm` command
+(where `B` aliases `A`, so `ab_eq` holds) issues **half** the read words of `abcorr`
+— 16 vs. 32 at 4×4. (The complementary "equal *latency* despite the freed bus"
+invariant is the calibrated-model result; see [timing](./timing.md).)
+
+Run it:
+
+```bash
+cd examples/vmac
+python vmac_queue_sim.py         # run the sim, re-emit timeline/sim_timeline.json + sim_sweep.json
+```
+
+With parity established in pure Python, the [next step](./codegen.md) extracts the
+same `run_proc` into a synthesizable top.

--- a/docs/examples/mmqueue/rtlsim.md
+++ b/docs/examples/mmqueue/rtlsim.md
@@ -1,0 +1,89 @@
+---
+title: C and RTL simulation
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 8
+has_children: false
+---
+
+# C and RTL simulation
+
+The Vitis stages turn the [Python model](./pymodel.md) into real hardware and check
+it. Every check has the same spec: the **one `execute` golden**. If Vitis ever
+disagrees, the rule is to fix the kernel, never loosen the compare. Vitis HLS is
+installed in this environment, so the numbers below are measured, not estimated.
+
+## Bit-exact against one golden
+
+C-simulation and RTL co-simulation both compare against the single golden, through
+the generic memory-image harness
+[`vmac_golden_mem.apply_golden`](../../../examples/vmac/vmac_golden_mem.py) (it
+deserializes operands from a memory image, runs `execute`, serializes the result
+back). The conformance reference moved from an earlier `execute_mem`'s image to this
+`execute` + generic deserialize path, so the kernel image and the golden image are
+**byte-identical** by construction (see the [one-golden anatomy](./pymodel.md)).
+
+## The conformance matrix
+
+[`vmac_build.py`](../../../examples/vmac/vmac_build.py) is the conformance BuildDag.
+It checks the datapath bit-for-bit across:
+
+- **all three ops** — `scalar_mult`, `inner_prod`, `sum`;
+- **× reduce** — each op with and without the row reduction;
+- **× alpha mode** — direct (immediate) and indirect (per-row) `α` for `scalar_mult`;
+- **× packing factor** — `mem_dwidth ∈ {16, 32, 64}` → **PF = 1, 2, 4** (cases use
+  `n_cols` a multiple of 4 so every row is word-aligned at each PF);
+- **× rounding/overflow** — the four `q_rnd` / `o_sat` modes at PF=1.
+
+Run the Vitis conformance (bit-exact C-simulation per structural config):
+
+```bash
+cd examples/vmac
+python vmac_build.py --through py_sim   # golden-vs-oracle parity, no Vitis
+python vmac_build.py --through csim     # the bit-exact Vitis C-sim conformance
+```
+
+The auto-extracted top (the [generated, `m_axi`-only kernel](./codegen.md)) gets its
+own RTL co-simulation, also bit-exact against `apply_golden`:
+
+```bash
+python vmac_build.py --through topgen_cosim   # the generated top, RTL cosim
+```
+
+## Throughput vs. packing factor
+
+The packing factor sets how many complex columns move per memory word, so the
+element-wise ops are expected to scale roughly **1× / 2× / 4×** with PF = 1 / 2 / 4.
+The throughput sweep re-checks the golden as it sweeps PF and extracts cosim cycle
+counts:
+
+```bash
+python vmac_build.py --through extract_cosim_timing   # throughput sweep (Vitis)
+```
+
+> The committed cycle artifacts are the **PF = 1** calibration sweep below; the
+> per-PF throughput numbers are produced by the command above rather than cited here,
+> to avoid quoting values that are not committed.
+
+## Committed RTL cycle counts
+
+The committed measurements that feed the [timing calibration](./timing.md) are the
+PF = 1, `inner_prod + reduce` cosim cycles in
+[`calibration/vmac_calibration.json`](../../../examples/vmac/calibration/vmac_calibration.json):
+
+| size | trips | RTL cycles | read words |
+| --- | --- | --- | --- |
+| 4×4  | 16  | 347  | 32 |
+| 6×6  | 36  | 725  | 72 |
+| 8×8  | 64  | 1258 | 128 |
+| 8×16 | 128 | 2435 | 256 |
+
+(`trips = n_rows · ⌈n_cols / PF⌉`; tool: *Vitis HLS 2025.1 cosim (xsim),
+xc7z020clg484-1, 10 ns clock*, per the committed JSON.) These are the RTL truth the
+[timing](./timing.md) page calibrates the loosely-timed model against — and where the
+`ab_eq` read-word halving (16 vs. 32 at 4×4) and the equal-latency result are
+established against hardware.
+
+## Next
+
+- [Timing — the LT model + cosim calibration](./timing.md) — the capstone: how these
+  cosim cycles calibrate the loosely-timed simulation.

--- a/docs/examples/mmqueue/timing.md
+++ b/docs/examples/mmqueue/timing.md
@@ -1,0 +1,249 @@
+---
+title: Timing — LT model + cosim calibration
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 9
+has_children: false
+---
+
+# Timing — the loosely-timed model and its cosim calibration
+
+This is the **capstone** page of the [VMAC example](./): the other pages build the
+accelerator and prove it computes the right numbers; this one is a
+**timing study**. It takes the VMAC accelerator fed commands over an
+AXI-MM command queue and asks a harder question than "does it compute the right
+numbers" — *does Waveflow's loosely-timed simulation predict the right **timing**,
+where exactly does it stop being faithful, and can a cosim **calibration** close the
+gap?*
+
+The answer is a named result — **bus utilization ≠ latency** — framed in the standard
+comp-arch vocabulary for what the simulator is (a **loosely-timed (LT) transaction-level
+model**), and then *corrected*: a Vitis RTL cosim **sweep** calibrates the LT model so
+its latency tracks real hardware. The headline figure is *committed* and regenerates
+with **no Vitis**.
+
+## The system
+
+One host, one accelerator, one shared memory, over a single `m_axi` master:
+
+```
+   host ──AXI-MM command queue──▶ VMAC ──m_axi (gmem)──▶ shared memory
+ (vmac_host.py)                 (vmac_queue_sim.py)        A | B | Y regions
+```
+
+The host enqueues commands; VMAC dequeues them, reads its operand matrices `A`
+(and `B`) from memory over `m_axi`, computes, and writes the result `Y` back to
+the same bundle. Modeled in
+[`examples/vmac/vmac_queue_sim.py`](../../../examples/vmac/vmac_queue_sim.py) and
+[`examples/vmac/vmac_host.py`](../../../examples/vmac/vmac_host.py); the
+synthesizable kernel is
+[`examples/vmac/vmac_compute_impl.tpp`](../../../examples/vmac/vmac_compute_impl.tpp).
+
+### Two commands, same opcode
+
+Both scenarios run the **same** `inner_prod` opcode (`R = A·conj(B)`) at PF=1 on
+4×4 operands, 100 MHz — they differ only in *where* `B` points:
+
+- **`anorm`** — `b_addr == a_addr`. `B` aliases `A` (an auto-correlation / norm).
+  The kernel derives a loop-invariant **`ab_eq`** flag from `a_addr == b_addr` and
+  fills `b_lane` from `a_lane` **instead of issuing a second read burst**.
+- **`abcorr`** — `b_addr != a_addr`. The ordinary case: both `A` and `B` are read.
+
+`ab_eq` is a *runtime* flag, so HLS fixes **one static II** for the loop at the
+worst case (b-read present). It does not reschedule shorter when `ab_eq` holds — it
+only **predicates whether the AXI transaction fires**. That is the whole study:
+*same cycle count, B's bus beat suppressed.*
+
+## The starting point: a transaction-gated LT sim
+
+The SimPy run logs a **source-agnostic** timeline — per-command memory
+transactions (`rw`/`name`/`addr`/`nwords`/`tstart`/`tend`), latency, read-word
+counts, and the command-queue occupancy. The Stage-1 LT model issues **one
+whole-matrix block per operand** (16 words in a single bus transaction) and made a
+command's latency the **sum of its transfer blocks** — *transaction-gated*. Its
+prediction:
+
+| scenario | read words | latency (naive LT) |
+| --- | --- | --- |
+| `anorm` (ab_eq) | 16 | 630 ns |
+| `abcorr`        | 32 | 940 ns |
+
+Half the reads **and** lower latency for `anorm` — the intuitive "fewer reads →
+faster" reading. **Both halves of that turn out to be wrong about latency**, and the
+RTL cosim is what exposes it.
+
+## What the RTL actually does
+
+Vitis RTL cosim measures the truth. At 4×4 the kernel takes **347 cycles** for
+*both* scenarios — `anorm` and `abcorr` are **identical in latency**, and `anorm`
+genuinely issues **half** the read-bus words:
+
+| scenario | read words (RTL) | latency (RTL) |
+| --- | --- | --- |
+| `anorm` (ab_eq) | **16** | **3470 ns** |
+| `abcorr`        | **32** | **3470 ns** |
+
+Two distinct errors in the naive sim fall out:
+
+1. **Ordering.** The sim said `anorm` is faster; the fixed-II RTL says **equal
+   latency, freed bus** — eliding B's read frees bandwidth, it does not shorten the
+   pipeline. *(bus utilization ≠ latency)*
+2. **Absolute scale.** The sim's 630–940 ns sit **~5× below** the RTL's 3470 ns: the
+   block model counts *transfer time*, not the kernel's *pipeline depth*.
+
+Both are the same root cause — a transaction-gated model can't see a pipeline whose
+latency decouples from the transaction count.
+
+## The fix: cosim-calibrated II-decoupling
+
+The repair is **II-decoupling** (TLM's LT→AT escalation — add just enough timing
+structure for the question at hand): make a command's latency the kernel **pipeline
+schedule** instead of the transfer sum,
+
+```
+latency_cycles ≈ depth + II · trips,   trips = n_rows · ⌈n_cols / PF⌉
+```
+
+while still *issuing* the bus transactions for occupancy. Latency becomes
+**II-driven** (depends only on `trips`, so `anorm` latency == `abcorr` latency — the
+fixed-II behaviour) and occupancy stays **transaction-driven** (`anorm` still issues
+half the reads). It lives entirely in the sim timing model
+([`VmacAccel.run_proc`](../../../examples/vmac/vmac.py)); the byte-exact golden
+`execute()` is untouched.
+
+### Calibration is a *sweep*, validated on a held-out point
+
+Fitting `(depth, II)` to the single 4×4 point would be tautological — one free
+parameter against one measurement always matches. So
+[`vmac_cosim_sweep.py`](../../../examples/vmac/vmac_cosim_sweep.py) cosims **four**
+sizes spanning distinct trip counts and commits the swept RTL cycles to
+[`calibration/vmac_calibration.json`](../../../examples/vmac/calibration/vmac_calibration.json):
+
+| size | trips | RTL cycles | RTL latency |
+| --- | --- | --- | --- |
+| 4×4 | 16 | 347 | 3470 ns |
+| 6×6 | 36 | 725 | 7250 ns |
+| 8×8 | 64 | 1258 | 12580 ns |
+| 8×16 | 128 | 2435 | 24350 ns |
+
+[`vmac_calibrate.py`](../../../examples/vmac/vmac_calibrate.py) fits the model on
+**three** of them and validates the prediction on the **held-out** fourth:
+
+- Fit on {4×4, 6×6, 8×8}: **depth = 42.7 cycles, II = 19.0 cycles/trip** (R² = 1.0000).
+  The data is cleanly linear in `trips`; `II ≈ 19` is the memory-gated inner-loop
+  interval, `depth ≈ 43` the fill/drain + reduce-loop overhead.
+- **Held-out 8×16** (trips 128): predicted 2472 cycles vs **actual 2435** —
+  **1.54 % error**. Leave-one-out over all four sizes stays ≤ 3.6 %.
+
+The same `(depth, II)` predict an un-fit configuration — that is what makes this a
+*calibration*, not a curve-trace. (It also seeds the DSE vision: the calibrated LT
+model now predicts un-cosim'd configs fast.)
+
+## The corrected result
+
+![VMAC loosely-timed sim, cosim-calibrated by II-decoupling, PF=1, 100 MHz. Panel (a): command latency vs trips across the 4×4/6×6/8×8/8×16 sweep — the naive transaction-gated LT curve sits ~5× below truth, while the calibrated LT curve (depth + II·trips, fit on three sizes) lands on the RTL cosim curve, including the circled held-out 8×16 point at 1.5% prediction error. Panel (b): m_axi read-bus words, anorm vs abcorr, per size — anorm is half across the sweep, so occupancy stays transaction-driven. Panel (c): calibrated latency anorm vs abcorr per size — equal bars (fixed-II), the "same latency, freed bus" result.](images/sim_vs_cosim.svg)
+
+The calibrated sim now reproduces both facts the naive model missed, while keeping
+the one it got right:
+
+| | naive LT | calibrated LT | RTL |
+| --- | --- | --- | --- |
+| `anorm` latency (4×4) | 630 ns | **3464 ns** | 3470 ns |
+| `abcorr` latency (4×4) | 940 ns | **3464 ns** | 3470 ns |
+| `anorm` vs `abcorr` latency | anorm faster ✗ | **equal ✓** | equal |
+| `anorm` read words | 16 (half ✓) | 16 (half ✓) | 16 (half) |
+
+- Panel **(a)** — *off → calibrated → tracks RTL*: the naive curve underestimates ~5×;
+  the calibrated curve sits on the RTL line across the whole sweep, **including the
+  held-out 8×16 point** it was never fit to.
+- Panel **(b)** — **bus still halved**: `anorm` reads half of `abcorr` at every size.
+  Occupancy stayed transaction-driven; the II-decoupling only touched latency.
+- Panel **(c)** — **fixed-II**: calibrated `anorm` latency == `abcorr` latency at every
+  size — the *"same latency, freed bus"* result, now correctly modeled.
+
+The named teaching result stands and is now *quantified*: **`ab_eq` frees the
+read-bus but does not shorten the pipeline** — and on a shared interconnect that freed
+bandwidth is exactly what another master (a CG matmul tile) would consume. The full
+numeric writeup is the committed
+[`calibration/vmac_calibration.json`](../../../examples/vmac/calibration/vmac_calibration.json)
+and [`timeline/sim_sweep.json`](../../../examples/vmac/timeline/sim_sweep.json).
+
+## What this says about the model (loosely-timed TLM)
+
+Waveflow's simulator is a **loosely-timed (LT) transaction-level model** in the
+SystemC TLM-2.0 sense: each transfer is a single timed *block* that holds a
+capacity-1 bus resource for its whole duration, and concurrent masters serialize
+on it (an implicit arbiter). This is accepted, standard practice — LT is how
+industry virtual platforms run fast — **not** a Waveflow shortcut. Framing the
+result, *and its repair*, in that vocabulary is the point of the example.
+
+**What LT captures faithfully here:**
+
+- Total interconnect **occupancy** (Σ of held block durations).
+- Multi-master **contention / arbitration** (serialization on the capacity-1 bus).
+- **First-order, burst-granular** memory-access timing — including the `ab_eq`
+  read-word halving, which the sim gets *right* in every mode.
+
+**What LT abstracts away (the boundary):**
+
+- **Sub-transaction interleaving / exact beat ordering** — a block is contiguous,
+  never "every other cycle."
+- Consequently **latency is mispredicted wherever it decouples from transaction
+  count** — the pipeline-depth and `ab_eq` cases above.
+
+**Fidelity per validation target, and how the calibration moves it:**
+
+| Target | Fidelity under the LT block model |
+| --- | --- |
+| Queue occupancy | **Robust** — command-level granularity; the block model is plenty fine |
+| Per-burst / total memory occupancy | **Robust** — the bus resource sums it correctly |
+| `ab_eq` latency & absolute latency | **Recoverable** — closed by the `(depth, II)` cosim calibration |
+| Sub-transaction ordering / fine contention | **Irreducible gap** — the block can't say who's on the bus *which* cycle |
+
+Escalating from *transaction-gated* to *II-parameterized* latency is Waveflow's analog
+of TLM's **LT→AT escalation**: the calibrated `(depth, II)` add just enough timing
+structure to answer the latency question, no more — sub-cycle ordering remains
+deliberately out of scope.
+
+> **Scope note.** Queue occupancy is a **sim-only** quantity here: the cosim kernel
+> has an `m_axi` but no command ring, so the calibration validates per-burst memory
+> timing and the `ab_eq` read-word result against RTL; occupancy is reported by the
+> sim alone and not fabricated for cosim.
+
+## The committed figure (regenerates without Vitis)
+
+The figure is rendered by
+[`examples/vmac/vmac_figures.py`](../../../examples/vmac/vmac_figures.py) from the
+**committed sweep timeline alone** —
+[`timeline/sim_sweep.json`](../../../examples/vmac/timeline/sim_sweep.json), which
+carries the naive, calibrated, and RTL latencies per size — no Vitis, no cosim
+re-run, no VCD read. That is the "committed figure" property: the docs build never
+needs the toolchain.
+
+```bash
+cd examples/vmac
+python vmac_calibrate.py         # print the fit + held-out validation (reads the calibration JSON)
+python vmac_queue_sim.py         # re-emit timeline/sim_timeline.json + timeline/sim_sweep.json
+python vmac_figures.py           # re-render docs/examples/mmqueue/images/sim_vs_cosim.svg
+python vmac_figures.py --check   # render to a temp file, byte-compare vs the committed SVG
+```
+
+The SVG is deterministic (a fixed `svg.hashsalt`, no embedded timestamp, mirroring
+[`shared_mem_figures.py`](../../../examples/shared_mem/shared_mem_figures.py)), so a
+re-render is **byte-identical** when nothing changed. `images/sync_status.json` records
+the source-JSON hash and the SVG hash, a cheap staleness signal a docs lint can check
+without re-running anything. The RTL truth was captured once by the Vitis-only
+[`vmac_cosim_sweep.py`](../../../examples/vmac/vmac_cosim_sweep.py) (and the 4×4
+headline by [`vmac_cosim_stage3.py`](../../../examples/vmac/vmac_cosim_stage3.py)) and
+committed.
+
+## Where this sits
+
+- The [VMAC example overview](./) — the rest of the walkthrough this timing study
+  caps: the command schema, the one-golden model, the SimPy sim, the generated top,
+  and the RTL conformance whose cycle counts feed the calibration here.
+- The [C and RTL simulation](./rtlsim.md) page — where the committed RTL cycle
+  counts this calibration fits come from.
+- The [Shared Memory (histogram)](../shared_mem/) example — the previous step in the
+  [examples progression](../), where the `m_axi` shared-memory pattern is introduced,
+  with its own [RTL cosim](../shared_mem/rtlsim.md) and
+  [committed timing figures](../shared_mem/timing.md).

--- a/docs/examples/mmqueue/vmac.md
+++ b/docs/examples/mmqueue/vmac.md
@@ -1,0 +1,86 @@
+---
+title: What we're building
+parent: AXI-MM Command Queue (VMAC)
+nav_order: 1
+has_children: false
+---
+
+# What we're building
+
+VMAC is a **complex vector-MAC accelerator**: a small ALU over complex fixed-point
+matrices, driven by commands the host leaves in shared memory. This page sets up
+*what* it computes and *how* the host talks to it; the later pages build each layer.
+
+## The motivating computation
+
+The worked scenario is a **host-driven complex correlation**. The host has two
+complex matrices `A` and `B` in memory and wants a normalized correlation
+`rho = abcorr / anorm`, where
+
+- `anorm` is the auto-correlation energy `A · conj(A)`, reduced to one row, and
+- `abcorr` is the cross-correlation `A · conj(B)`, reduced to one row.
+
+The split between hardware and host is deliberate:
+
+1. The host writes `A` and `B` into their memory regions.
+2. It **enqueues two commands** — both `inner_prod` with `reduce` set: one with
+   `B` aimed at `A` (giving `anorm`), one with `B` aimed at `B` (giving `abcorr`) —
+   then an `end` sentinel.
+3. VMAC dequeues each command, reads the operands over `m_axi`, computes the reduced
+   inner product, and writes the result `Y` back to memory.
+4. The host reads both `Y` regions back and computes the **division**
+   `rho = abcorr / anorm` itself.
+
+The division stays on the host on purpose: it is the one step that is awkward to
+synthesize (a complex/real reciprocal), so it is an explicit **hardware/host split**
+— the accelerator does the bandwidth-heavy multiply-accumulate, the host does the
+single scalar divide. This is modeled in
+[`examples/vmac/vmac_host.py`](../../../examples/vmac/vmac_host.py).
+
+## The operation set
+
+VMAC is not single-purpose; the correlation above uses one of its **three
+element-wise operations plus an optional reduce**. Presented as a general complex
+vector ALU:
+
+| `op` | computes (per element `i,j`) | second operand | scalar |
+| --- | --- | --- | --- |
+| `scalar_mult` | `α[i] · A[i,j]` | — | `α` (immediate or per-row) |
+| `inner_prod`  | `A[i,j] · conj(B[i,j])` | `B` | — |
+| `sum`         | `A[i,j] + B[i,j]` | `B` | — |
+
+The `reduce` flag, when set, sums each result down its rows to a single output row
+(`Y[j] = Σ_i R[i,j]`). A fourth opcode, `end`, carries no computation — it is the
+**sentinel** that breaks the accelerator's run loop. The correlation example uses
+`inner_prod + reduce`; the conformance suite exercises all three ops with and
+without reduce. The opcodes and the command that carries them are the subject of the
+[data types](./datatypes.md) page.
+
+## The system
+
+One host, one accelerator, one shared memory, over a single `m_axi` master:
+
+```
+   host ──AXI-MM command queue──▶ VMAC ──m_axi (gmem)──▶ shared memory
+ (vmac_host.py)                  (vmac.py)                A | B | Y regions
+```
+
+What makes VMAC distinctive among the [examples](../) is that the host does **not**
+push commands down a dedicated control stream. It appends them to a **ring buffer in
+the same shared memory** the operands live in, and a free-running accelerator
+dequeues them. That ring is the
+[AXI-MM command queue](../../guide/interface/mmqueue.md) interface; here it carries
+`VmacCmd`s. Control and data share one interconnect.
+
+## Roadmap
+
+The remaining pages build VMAC bottom-up:
+
+- [Data types](./datatypes.md) and [arithmetic](./arithmetic.md) — the command, its
+  element/format types, and the fixed-point datapath.
+- [The Python model](./pymodel.md) and [Python simulation](./pysim.md) — the one
+  author-written golden, the synthesizable shell, and the SimPy queue sim.
+- [Code generation](./codegen.md) and [the kernel hook](./hook.md) — the generated
+  synthesizable top and the hand-written complex datapath.
+- [C and RTL simulation](./rtlsim.md) and [timing](./timing.md) — Vitis conformance
+  and the loosely-timed-model calibration that is this example's headline.

--- a/docs/guide/custom_hooks/index.md
+++ b/docs/guide/custom_hooks/index.md
@@ -61,6 +61,7 @@ writes results back — all hand-written, bit-exact with the Python golden by co
 
 - [Writing a hook](./writing.md) — the templated `.tpp` signature, how it plugs into the generated kernel, and the csynth gotchas (scalar `*_core` args, `#pragma HLS INLINE`), walked through VMAC.
 - [Kernel patterns](./patterns.md) — moving data over an `m_axi` / stream port inside a hook (`read_array_lane` / `read_array_slice` / `read_stream_lane`, `TLAST`) and the common loop shapes.
+- [Memory command queue](./queue.md) — the ring-dequeue hook (`queue_get`) that `AXIMMQueue.get` lowers to: poll the ring, read one slot, advance `head`, deserialize the typed command.
 
 ## See also
 

--- a/docs/guide/custom_hooks/queue.md
+++ b/docs/guide/custom_hooks/queue.md
@@ -1,0 +1,98 @@
+---
+title: Memory command queue
+parent: Custom Hooks
+nav_order: 3
+audience: hls
+api: [AXIMMQueue, AXIMMQueueGetStmt, queue_get, synthesizable]
+summary: "The synthesizable side of the AXI-MM command queue: AXIMMQueue.get lowers to AXIMMQueueGetStmt, emitted as a call to the hand-written ring-dequeue hook queue_get<CmdT, MEM_BW, BASE, CAP, EW> in aximm_queue_impl.tpp — read (head,tail), poll while empty, read one slot, advance head with a power-of-two mask, deserialize the typed command."
+---
+
+# Memory command queue — the ring-dequeue hook
+
+The [AXI-MM command queue](../interface/mmqueue.md) interface has a Python
+transactional model (`AXIMMQueue.write` / `get`) and a **synthesizable** side: when an
+accelerator dequeues a command inside a kernel, that `get` becomes a hand-written
+ring-dequeue hook. This page is that hook —
+[`waveflow/build/aximm_queue_impl.tpp`](../../../waveflow/build/aximm_queue_impl.tpp)'s
+`queue_get` — and how the extractor lowers a `get` call onto it. It is **merged and
+Vitis-verified**: the [VMAC generated top](../../examples/mmqueue/codegen.md) calls it
+and cosims bit-exact.
+
+It is a stmt-class hook, structurally like the [`vmac_compute` hook](./writing.md) —
+the general `.tpp` contract (templating, `#pragma HLS INLINE`, the generated packing
+helpers) is that page; this one is the queue-specific datapath.
+
+## What lowers to it
+
+In a synthesizable run loop, the consumer reads one typed command per iteration:
+
+```python
+cmd = yield from self.cmd_queue.get(self.Cmd)   # self.cmd_queue: AXIMMQueue
+```
+
+`AXIMMQueue.get` is decorated `@synthesizable(stmt_class=AXIMMQueueGetStmt)`. The
+single-element typed form (`get(schema_type)`) is the synthesizable one: the extractor
+emits an **`AXIMMQueueGetStmt`** — an IR node (a `SynthCallStmt`) whose `inputs[0]` is
+the element schema class and whose `outputs[0]` is the bound command variable. This is
+the exact parallel of `StreamGetStmt` (a stream `get`) and the register-map `get`
+stmt; the queue is just a different transport.
+
+Codegen lowers that stmt in
+[`waveflow/build/hwgen.py`](../../../waveflow/build/hwgen.py) (`_emit_aximm_queue_get`)
+to a declaration of the command struct plus a **call** to the `queue_get` hook,
+passing the layout constants from the queue's `AXIMMQueueLayout` as template
+arguments. So the generated top contains no hand-rolled ring code — only a call into
+this hook.
+
+## The hook contract
+
+```cpp
+template <typename CmdT, int MEM_BW, int BASE, int CAP, int EW>
+void queue_get(ap_uint<MEM_BW>* gmem, CmdT& out);
+```
+
+| param | meaning |
+| --- | --- |
+| `CmdT` | the generated command struct (e.g. `VmacCmd`) |
+| `MEM_BW` | memory word width in bits (the `gmem` word) |
+| `BASE` | ring base **byte** address (word-aligned) |
+| `CAP` | ring capacity in slots (**power of two**) |
+| `EW` | words per slot (`== CmdT.nwords_per_inst(MEM_BW)`) |
+
+Two `static_assert`s enforce the synthesis preconditions: `CAP` is a power of two
+(`CAP >= 2 && (CAP & (CAP - 1)) == 0`) and `BASE` is word-aligned. Both come for free
+from `AXIMMQueueLayout`.
+
+## What it does
+
+The hook is the single-producer / single-consumer dequeue, in five steps:
+
+1. **Read `head` once.** The consumer owns `head`, so it is stable for the call — one
+   `m_axi` read.
+2. **Poll until non-empty.** While `tail == head` the ring is empty; the hook waits
+   with `poll_until_ne(tail_word, head)` — the synthesizable analogue of the Python
+   [`poll_until`](../interface/poll.md) wait — re-reading `tail` until the producer
+   advances it.
+3. **Read one slot.** Read `EW` words at `slot(head)` **before** advancing the pointer
+   (SPSC ordering: consume the data, then publish that the slot is free).
+4. **Advance `head`.** `head = (head + 1) & (CAP - 1)` — the `% capacity` wrap as a
+   bit-mask, which is exactly why `CAP` must be a power of two — and write it back so
+   the producer sees the freed slot.
+5. **Deserialize.** Turn the slot's raw words into the typed command with the
+   generated `out.read_array<MEM_BW>(slot)`, yielding the populated `CmdT& out`.
+
+The command never crosses an `s_axilite` boundary — it is read straight from memory
+and deserialized into a struct of scalars inside the kernel. That is what lets the
+[generated top be `m_axi`-only](../../examples/mmqueue/codegen.md#why-the-top-has-only-maxi--apctrl)
+and sidestep the nested-struct csynth pitfall.
+
+## See also
+
+- [AXI-MM Command Queue](../interface/mmqueue.md) — the Python `AXIMMQueue` model this
+  hook is the synthesizable half of.
+- [VMAC code generation](../../examples/mmqueue/codegen.md) — the generated top that
+  calls `queue_get`, and the worked end-to-end example.
+- [Writing a hook](./writing.md) / [Kernel patterns](./patterns.md) — the general
+  `.tpp` contract and the in-kernel transfer calls.
+- [Polling Overhead](../interface/poll.md) — the loosely-timed poll model behind the
+  empty-ring wait.

--- a/docs/guide/interface/index.md
+++ b/docs/guide/interface/index.md
@@ -19,6 +19,7 @@ This section is the **Python transactional model**: the interface classes, their
 - [Stream Interfaces](./stream.md) — unidirectional streams (`StreamIF`, `CrossBarIF`) and pipelined transfer.
 - [MM Interfaces](./aximm.md) — memory-mapped read/write (`AXIMMCrossBarIF`, `DirectMMIF`).
 - [Polling Overhead](./poll.md) — the loosely-timed polling model (`MMIFMaster.poll_until`): bandwidth steal + discovery latency.
+- [AXI-MM Command Queue](./mmqueue.md) — the in-memory command ring (`AXIMMQueue`): control moved off the stream and into shared memory.
 - [Register Maps](./regmap.md) — AXI-Lite control/status fields (`RegMap`, `VitisRegMap`).
 - [Schema Transfer Interface](./schema_transfer.md) — carrying serializable schema objects over a transport.
 - [Array Transfer Interface](./array_transfer.md) — carrying a variable-length typed array over a transport.

--- a/docs/guide/interface/mmqueue.md
+++ b/docs/guide/interface/mmqueue.md
@@ -1,0 +1,120 @@
+---
+title: AXI-MM Command Queue
+parent: Interfaces
+nav_order: 4.5
+audience: python
+api: [AXIMMQueue, AXIMMQueueLayout, MMIFMaster, AXIMMCrossBarIF, DirectMMIF]
+summary: "The in-memory command queue — AXIMMQueue, a host-driven ring buffer over an MMIFMaster (m_axi). The AXIMMQueueLayout (head/tail/capacity + data slots), the producer write / consumer get operations, and the loosely-timed poll-on-empty / backpressure-on-full timing model."
+---
+
+# AXI-MM Command Queue
+
+The other interface pages move *data* off the control plane (memory-mapped reads
+in [MM Interfaces](./aximm.md)) or carry control *in band* on a stream. The
+**command queue** moves the control plane itself **into memory**: instead of the
+host pushing each command down a dedicated stream, it appends commands to a ring
+buffer in shared DRAM, and the accelerator dequeues them over its ordinary `m_axi`
+master. Control and data now share one memory bundle.
+
+This is the Python transactional model of that ring. `AXIMMQueue`
+([`waveflow/hw/aximm_queue.py`](../../../waveflow/hw/aximm_queue.py)) is **not a new
+endpoint** — it is a thin proxy over an existing
+[`MMIFMaster`](./aximm.md): the producer and the consumer each bind one to the same
+region of memory and talk through `write` / `get`. The synthesizable side (the
+consumer's `get` lowered to a hand-written ring-dequeue kernel) is documented in
+[Custom Hooks → Memory command queue](../custom_hooks/queue.md).
+
+## What the queue is
+
+A single-producer / single-consumer **ring buffer** laid out in memory by
+`AXIMMQueueLayout`. The first four words are control; the slots follow:
+
+```
+ word 0   head        consumer-owned read index
+ word 1   tail        producer-owned write index
+ word 2   capacity    number of slots (informational)
+ word 3   reserved    (room for status/flags)
+ ─────────────────────────────────────────────
+ data     capacity × elem_words   the command slots
+```
+
+`AXIMMQueueLayout(base_addr, capacity, elem_words, mem_bw)` computes the byte
+addresses — `head_addr`, `tail_addr`, `capacity_addr`, `data_base`, and
+`slot_addr(idx)` — from the base address and the memory word width. The ring is
+**empty** when `head == tail` and **full** when `(tail + 1) % capacity == head`, so
+the usable depth is `capacity - 1` (one slot distinguishes full from empty).
+
+Contrast this with the stream command path of the
+[shared-memory histogram](../../examples/shared_mem/) example, where the command
+rides a dedicated AXI4-Stream: there the control channel is a separate port; here it
+is just another region of the same memory, and ordering between producer and
+consumer is mediated entirely by the two pointers.
+
+## Operations
+
+A queue is created from a bound master and a layout:
+
+```python
+queue = AXIMMQueue(master=mm_master, layout=AXIMMQueueLayout(base, cap, elem_words, mem_bw))
+```
+
+- **`reset()`** — zero `head` and `tail`, record `capacity` in word 2. Called once
+  by whichever side owns setup.
+- **`write(data, element_type=None)`** *(producer / host)* — enqueue, blocking until
+  the whole batch is in. With `element_type` given, `data` is serialized through the
+  schema; with `element_type=None`, `data` is a raw word array. It advances `tail`
+  by the number of slots written.
+- **`get(schema_type=None, count=None)`** *(consumer)* — dequeue. The
+  **typed single-element** form, `get(schema_type)`, reads one slot, deserializes it
+  into one schema instance, and advances `head`. This is the form the accelerator
+  uses in its run loop, and the one that lowers to hardware.
+
+Pointer advance wraps modulo capacity — `head = (head + 1) % capacity`. When
+`capacity` is a power of two (the synthesizable requirement), that modulo is a
+bit-mask `& (capacity - 1)`, which is why the layout enforces a power-of-two
+capacity on the hardware path.
+
+A free-running consumer is just a loop over `get`:
+
+```python
+while True:
+    cmd = yield from queue.get(Cmd)   # one command, deserialized
+    if cmd.op == OpCode.end:          # sentinel ends the stream
+        return
+    ...                               # act on cmd
+```
+
+## Timing model
+
+The queue inherits the **loosely-timed** model of its underlying `m_axi` master
+(see [MM Interfaces](./aximm.md) and [Polling Overhead](./poll.md)). A `get`
+reads `(head, tail)` and, when non-empty, one data slot — each a timed transaction
+on the shared bus.
+
+Two cases need the polling model:
+
+- **Empty ring (`head == tail`).** The consumer must wait for the producer to
+  advance `tail`. Rather than step every cycle, it uses the
+  [`poll_until`](./poll.md) loosely-timed model: a bandwidth-steal (`ov`) derating
+  on the shared bus plus a deterministic discovery-latency delay. The default poll
+  interval is configurable per queue (`poll_interval`, in cycles).
+- **Full ring.** The producer's `write` blocks (host backpressure) until the
+  consumer frees a slot by advancing `head`.
+
+Because the pointers and the data live in the same memory, occupancy and bus
+contention both fall out of the standard interconnect model — the queue adds no new
+timing primitive, only a new *use* of `m_axi` plus `poll_until`.
+
+## Vehicles
+
+- [`examples/interface/aximm_queue_demo.py`](../../../examples/interface/aximm_queue_demo.py)
+  — the minimal producer/consumer demo over one `AXIMMCrossBarIF`.
+- The [VMAC example](../../examples/mmqueue/) — the worked use: a host enqueues
+  `VmacCmd`s and a free-running accelerator dequeues and executes them.
+
+## See also
+
+- [MM Interfaces](./aximm.md) — the `MMIFMaster` the queue is built on.
+- [Polling Overhead](./poll.md) — the `poll_until` model the empty-ring wait uses.
+- [Custom Hooks → Memory command queue](../custom_hooks/queue.md) — the
+  synthesizable side: `AXIMMQueue.get` lowered to the ring-dequeue kernel hook.


### PR DESCRIPTION
Promotes the VMAC / AXI-MM-command-queue example from a single timing-study page into a full multi-page walkthrough, and adds the two guide pages the mm queue was missing. **Docs-only** — no code, schema, kernel, or figure files changed (15 files, all under `docs/`).

## Guide
- `docs/guide/interface/mmqueue.md` — the Python `AXIMMQueue` command-ring model (layout, reset/write/get, poll-on-empty, backpressure).
- `docs/guide/custom_hooks/queue.md` — the synthesizable `queue_get` ring-dequeue hook and how `AXIMMQueue.get → AXIMMQueueGetStmt` lowers onto it.

## Example (`docs/examples/mmqueue/`)
Thin `index.md` + `vmac` (intro), `datatypes` (`VmacCmd`/`VmacFormats`), `arithmetic` (fixed-point/number formats), `pymodel` (one-golden anatomy + `Region`), `pysim` (the SimPy queue sim), `codegen` (the generated m_axi-only top), `hook` (`vmac_compute_impl.tpp`), `rtlsim` (Vitis csim/cosim + throughput), and `timing` (the timing study, relocated from the old index). `docs/examples/index.md` row 5 reconciled to the built example.

## Notes
- Independent accuracy audit passed (signatures, ring layout, op math, number formats, build-stage names, and committed cosim numbers verified against code; no fabricated numbers).
- The documented kernel is memory-bandwidth-bound (II≈19, interleaved A/B access); the principled load-compute-store rework is captured in `plans/dataflow_composition.md` as a follow-up arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)