### PR TITLE
rowwise_fir: fix the hook's m_axi transfer (lane loop, not read_array_slice) — ~1.5x faster

### DIFF
--- a/examples/rowwise_fir/fir.py
+++ b/examples/rowwise_fir/fir.py
@@ -23,6 +23,17 @@ as in the kernel (``load(N+1) ∥ store(N)``).  The per-stage durations come fro
 **period** (the bottleneck), ``load`` + ``compute`` carry the pipeline **fill**, so a batch of
 ``n`` jobs takes ``fill + n*period`` — matching the cosim (``704`` cyc/job @ 4×64, fill ≈ ``396``).
 The functional truth (``execute``) is bit-exact-shared with the kernel; only the timing is modeled.
+
+**⚠ TIMING MODEL STALE (2026-07-01).**  This ``FIRTiming`` models the OLD *buffered* kernel (the
+``read_array_slice`` 2-pass), which serialized load/store (``period ≈ occupancy·β``, β≈1.45).  The
+hook was since fixed to stream direct (lane loop, ``fir_pipeline_impl.tpp``): it now runs ~1.5×
+faster (704→473 cyc/job @ 4×64), **full-duplex** (load ∥ store), with β≈1.0 — AND streams
+*within* a job (load/compute/store overlap), so the single-job latency is no longer the serial
+stage sum.  Re-calibrating needs a **double-buffered / streaming-timing** model (per-element or
+anchored overlap; cf. the atomic-stage sim here gives ~186% latency error on the fixed kernel).
+Deferred to a focused task — see [[project-fir-slice-vs-laneloop-rootcause]] and
+``plans/fir_freerun_integration.md``.  **The functional golden is unaffected** (bit-exactness does
+not depend on timing); only the *cycle numbers* the sim reports are stale.
 """
 from __future__ import annotations
 

--- a/examples/rowwise_fir/fir_pipeline_impl.tpp
+++ b/examples/rowwise_fir/fir_pipeline_impl.tpp
@@ -30,7 +30,12 @@ namespace fir_impl {
 static const int FIR_T        = 8;       // FIR taps (tapped-delay-line depth)
 static const int FIR_NCOL_MAX = 1024;    // valid-size bound
 static const int FIR_MAX_ROWS = 64;      // valid-size bound
-static const int FIR_CHUNK    = 256;     // burst staging chunk (one X/Y burst per test job)
+
+// LW==1 only: the compute uses a scalar shift register sr[T] and emits one output/cycle, and the
+// load/store lane loops move one float/cycle.  A wider m_axi word (word_bw>32 -> LW>1) would need an
+// s[LW][T] window + an LW*T MAC array to retire LW outputs/cycle — not yet supported.  Fail loudly.
+static_assert(float32_array_utils::lane_capacity<32>() == 1,
+              "fir_pipeline_impl supports LW==1 only; LW>1 (vectorized bus) needs an s[LW][T] window.");
 
 // load: read each FIRCmd off s_in (built-in deserialize); validate; forward a FirMeta on the
 // 32-bit ctrl stream; for a good job read h (T taps) + X (CHUNK bursts) from mem via
@@ -72,17 +77,23 @@ LOAD_CMDS: while (!done) {
         m.write_stream<32>(ld_ctrl);
         if (!ok) continue;                           // bad job: no data streamed
 
+        // h (T taps) is genuinely resident — read once, cached in compute's tap registers — so a
+        // slice into a small buffer is the right pattern for it.
         float hb[FIR_T];
         float32_array_utils::read_array_slice<32>(mem, (int)cmd.h_off, (int)cmd.h_off + FIR_T, hb);
         for (int t = 0; t < FIR_T; ++t) ld_data.write(hb[t]);
 
+        // X is a STREAM: move gmem -> ld_data DIRECTLY, one II=1 pass, no intermediate buffer (the
+        // lane-loop shape for LW==1; docs/guide/vectorization/hls/raw.md).  Staging through a
+        // read_array_slice buffer (gmem -> cb -> FIFO, the "resident" path) serializes the m_axi and
+        // forfeits the full-duplex load||store overlap — see [[project-fir-slice-vs-laneloop-rootcause]].
+        // (NB the framework read_array_lane helper with a running pointer dangles the m_axi first read
+        // in this free-running DATAFLOW context — RTL reads x[0] as 0; direct mem[i] indexing is
+        // bit-exact.  A framework gotcha to fix; see [[reference-arrayutils-slice-codegen-gotchas]].)
         const int total = nr * nc;
-        float cb[FIR_CHUNK];
-    LOAD_X: for (int base = 0; base < total; base += FIR_CHUNK) {
-            const int k = (total - base < FIR_CHUNK) ? (total - base) : FIR_CHUNK;
-            float32_array_utils::read_array_slice<32>(mem, (int)cmd.x_off + base,
-                                                      (int)cmd.x_off + base + k, cb);
-            for (int i = 0; i < k; ++i) ld_data.write(cb[i]);
+    LOAD_X: for (int i = 0; i < total; ++i) {
+#pragma HLS PIPELINE II=1
+            ld_data.write(streamutils::uint_to_float((uint32_t)mem[(int)cmd.x_off + i]));
         }
     }
 }
@@ -147,12 +158,11 @@ STORE_CMDS: while (!done) {
             const int nc = (int)m.n_cols, nr = (int)m.n_rows;
             const int out_len = nc - FIR_T + 1;
             const int total = nr * out_len;
-            float cb[FIR_CHUNK];
-        STORE_Y: for (int base = 0; base < total; base += FIR_CHUNK) {
-                const int k = (total - base < FIR_CHUNK) ? (total - base) : FIR_CHUNK;
-                for (int i = 0; i < k; ++i) cb[i] = cp_data.read();
-                float32_array_utils::write_array_slice<32>(cb, mem, (int)m.y_off + base,
-                                                           (int)m.y_off + base + k);
+            // Y is a STREAM: cp_data -> gmem DIRECTLY (one II=1 pass, no cb buffer) — the symmetric
+            // fix to the load (see [[project-fir-slice-vs-laneloop-rootcause]]).
+        STORE_Y: for (int i = 0; i < total; ++i) {
+#pragma HLS PIPELINE II=1
+                mem[(int)m.y_off + i] = streamutils::float_to_uint(cp_data.read());
             }
         }
         FIRResp resp;

--- a/examples/rowwise_fir/sandbox/.gitignore
+++ b/examples/rowwise_fir/sandbox/.gitignore
@@ -5,5 +5,11 @@
 *.out
 logs/
 __pycache__/
-# Regenerable measurement output (findings live in freerun_notes.md)
+# Regenerable measurement output (findings live in freerun_notes.md / LADDER.md)
 results_*/
+# VCD dumps, xsim/dfx runtime + console/result text dumps (regenerable)
+vcd/
+data/
+dump.vcd
+*.txt
+*.jou

--- a/examples/rowwise_fir/sandbox/LADDER.md
+++ b/examples/rowwise_fir/sandbox/LADDER.md
@@ -1,0 +1,36 @@
+# FIR full-duplex investigation — the isolation ladder
+
+Why does the free-running FIR's steady period ≈ **bus occupancy** (`read+write` ADD, ~704 cyc/job @
+4×64) instead of `max(read,write)` (~306)? i.e. it does *not* exploit the full-duplex `gmem` bundle
+even multi-job. Each rung below is a standalone Vitis cosim that removes one variable. (`N`=256/job.)
+
+| rung | dir | what it isolates | result |
+|---|---|---|---|
+| — | `duplex_toy/` | is one `gmem` bundle full- or half-duplex? | **FULL-duplex** (read+write ≈ max), for 1 process AND 2 DATAFLOW processes |
+| 1 | `compute_iso/` | the FIR compute alone (X from BRAM, no m_axi) | **II=1.000**, per-row L1≈0, L0=56 — compute is clean |
+| 2 | `loadstore_iso/` | load ‖ store, **no compute** | period ≈ **max** — overlaps, full-duplex USED |
+| 3 | `lcs_iso/` | load → *pass-through* → store, sweep FIFO depth | **overlaps at every depth** (256…2048) — skeleton/depth ruled out |
+| 4 | `fir_skel/` | the **real** shift-register FIR compute in the skeleton | **direct gmem↔FIFO = 306 (OVERLAP)**; **2-pass buffer (`-DFS_BUF`) = 534 (SERIALIZED)** |
+| — | `halfpipe/` | lc (load+compute) vs cs (compute+store) — read vs write side | built; moot once the pass-through skeleton already overlapped |
+
+## Conclusion
+
+The slowdown is **not** the bus, compute, FIFO depth, or per-job structure. It is the **transfer
+pattern**: the hook (`fir_pipeline_impl.tpp`) routes X/Y through `read_array_slice`/`write_array_slice`,
+which stage through an intermediate buffer (`gmem → cb → FIFO`, 2 passes). Per
+`docs/guide/vectorization/hls/raw.md` that is the *resident* path; the canonical **throughput** path is
+**"The lane loop"** — stream `gmem ↔ FIFO` directly (one II=1 pass, no buffer). Rung 4 shows the buffer
+alone flips full-duplex overlap (306) → serialized (534; the real kernel's 704 adds the `h`-read +
+`FIRCmd` deserialize on top).
+
+**Fix:** rewrite the hook load/store as the lane loop (done for LW==1; `static_assert` guards LW>1,
+which needs an `s[LW][T]` window + `LW·T` MAC array for `LW` samples/cycle). See the memory note
+`project-fir-slice-vs-laneloop-rootcause` and `plans/fir_freerun_integration.md`.
+
+## Running a rung
+
+```bash
+cd <rung_dir>
+PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_<name>.py   # see each runner's docstring
+```
+Each needs Vitis HLS 2025.1 + Vivado xsim. The `*_proj/`, `vcd/`, and `*.txt`/`*.log` outputs are scratch.

--- a/examples/rowwise_fir/sandbox/compute_iso/compute_iso.cpp
+++ b/examples/rowwise_fir/sandbox/compute_iso/compute_iso.cpp
@@ -1,0 +1,58 @@
+// compute_iso.cpp — Rung 1 of the FIR-overlap ladder: the streaming FIR compute in ISOLATION.
+//
+// Same shift-register FIR as the freerun sandbox's compute() stage, but X comes from on-chip
+// BRAM (not the load FIFO / m_axi) and Y is folded into an integer checksum (not the store FIFO /
+// m_axi). So there is NO load and NO store — the cosim transaction latency (cmd in -> resp out)
+// IS the pure compute time. We then fit:
+//
+//     compute_time = L0 + L1*nrow + II*(nrow*ncol)
+//
+// Goal: show the inner COLS loop achieves II = 1 in COSIM (not just csynth), with a small per-row
+// term L1 (the window flush) and a fixed L0 (the ~47 FP-pipeline fill + cmd/resp handshake). If
+// II != 1 here, the compute itself is the problem; if II = 1, the ~2.9 cyc/sample seen in the full
+// FIR is a stage-overlap / bus issue, not compute.
+#include <ap_int.h>
+#include <cstdint>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int T = 8;
+static const int MAXE = 1024;          // max nrow*ncol on the sweep grid (e.g. 4x256, 1x1024)
+
+static ap_uint<32> f2u(float f) { union { uint32_t i; float f; } c; c.f = f; return ap_uint<32>(c.i); }
+
+// X is a BRAM (ap_memory) port the testbench fills — on-chip (no m_axi, so compute is isolated),
+// but a RUNTIME input so csynth cannot constant-fold the reads (which would DCE the whole loop).
+void compute_iso(const float xbuf[MAXE],
+                 hls::stream<ap_uint<MEM_DW> >& cmd_in,
+                 hls::stream<ap_uint<MEM_DW> >& resp_out) {
+#pragma HLS INTERFACE ap_memory port=xbuf
+#pragma HLS INTERFACE axis port=cmd_in
+#pragma HLS INTERFACE axis port=resp_out
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+    const int nrow = (int)cmd_in.read();
+    const int ncol = (int)cmd_in.read();
+
+    float h[T];
+#pragma HLS ARRAY_PARTITION variable=h complete
+    for (int t = 0; t < T; ++t) h[t] = (float)((t + 1) * 0.25f - 1.0f);
+
+    ap_uint<32> chk = 0;
+    ROWS: for (int r = 0; r < nrow; ++r) {
+        float sr[T];                                  // tapped delay line sr[t] = x[s-t]
+#pragma HLS ARRAY_PARTITION variable=sr complete
+        for (int k = 0; k < T; ++k) sr[k] = 0.0f;     // per-row window flush
+        COLS: for (int s = 0; s < ncol; ++s) {
+#pragma HLS PIPELINE II=1
+            float x = xbuf[r * ncol + s];
+            for (int k = T - 1; k >= 1; --k) sr[k] = sr[k - 1];
+            sr[0] = x;
+            if (s >= T - 1) {
+                float acc = 0.0f;
+                for (int t = 0; t < T; ++t) acc += h[t] * sr[t];
+                chk ^= f2u(acc);                      // integer XOR: 1-cyc recurrence, keeps II=1
+            }
+        }
+    }
+    resp_out.write(chk);
+}

--- a/examples/rowwise_fir/sandbox/compute_iso/compute_iso.tcl
+++ b/examples/rowwise_fir/sandbox/compute_iso/compute_iso.tcl
@@ -1,0 +1,23 @@
+# Vitis HLS driver for the isolated-compute toy: csim + csynth + cosim of one (nrow, ncol).
+#   WAVEFLOW_CI_NROW / WAVEFLOW_CI_NCOL   (defaults 4 / 64)
+set part {xc7z020clg484-1}
+set nrow 4
+if {[info exists ::env(WAVEFLOW_CI_NROW)]} { set nrow $::env(WAVEFLOW_CI_NROW) }
+set ncol 64
+if {[info exists ::env(WAVEFLOW_CI_NCOL)]} { set ncol $::env(WAVEFLOW_CI_NCOL) }
+set argv "$nrow $ncol"
+puts "WAVEFLOW_INFO: compute_iso nrow=$nrow ncol=$ncol"
+
+open_project -reset compute_iso_proj
+set_top compute_iso
+add_files compute_iso.cpp
+add_files -tb compute_iso_tb.cpp
+open_solution -reset "solution1"
+set_part $part
+create_clock -period 10
+
+if {[catch {csim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: csim"; puts $res; exit 1 }
+if {[catch {csynth_design} res]} { puts "WAVEFLOW_ERROR: csynth"; puts $res; exit 1 }
+if {[catch {cosim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: cosim"; puts $res; exit 1 }
+puts "WAVEFLOW_SUCCESS: compute_iso nrow=$nrow ncol=$ncol"
+exit 0

--- a/examples/rowwise_fir/sandbox/compute_iso/compute_iso_tb.cpp
+++ b/examples/rowwise_fir/sandbox/compute_iso/compute_iso_tb.cpp
@@ -1,0 +1,25 @@
+// compute_iso_tb.cpp — one (nrow, ncol) per cosim run; the transaction latency = compute time.
+#include <ap_int.h>
+#include <cstdio>
+#include <cstdlib>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int MAXE = 1024;
+void compute_iso(const float xbuf[MAXE], hls::stream<ap_uint<MEM_DW> >& cmd_in,
+                 hls::stream<ap_uint<MEM_DW> >& resp_out);
+
+int main(int argc, char** argv) {
+    int nrow = (argc > 1) ? std::atoi(argv[1]) : 4;
+    int ncol = (argc > 2) ? std::atoi(argv[2]) : 64;
+    static float xbuf[MAXE];
+    for (int i = 0; i < nrow * ncol && i < MAXE; ++i) xbuf[i] = (float)((i % 17) * 0.5f - 4.0f);
+    hls::stream<ap_uint<MEM_DW> > cmd_in("cmd_in"), resp_out("resp_out");
+    cmd_in.write((ap_uint<MEM_DW>)nrow);
+    cmd_in.write((ap_uint<MEM_DW>)ncol);
+    compute_iso(xbuf, cmd_in, resp_out);
+    if (resp_out.empty()) { std::fprintf(stderr, "WAVEFLOW_ERROR: no resp\n"); return 1; }
+    (void)resp_out.read();
+    std::printf("WAVEFLOW_COMPUTE_ISO_OK: nrow %d ncol %d\n", nrow, ncol);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/compute_iso/run_compute_iso.py
+++ b/examples/rowwise_fir/sandbox/compute_iso/run_compute_iso.py
@@ -1,0 +1,71 @@
+"""run_compute_iso.py — Rung 1: cosim the isolated FIR compute over a (nrow,ncol) grid; fit
+compute_time = L0 + L1*nrow + II*(nrow*ncol).
+
+No load/store/m_axi — the cosim transaction latency IS the compute time. The fit's II is the true
+per-sample compute interval (target 1); L1 is the per-row window-flush cost (target small); L0 the
+fixed FP-pipeline fill + cmd/resp handshake.
+
+Run (project venv, Vitis 2025.1)::
+
+    PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_compute_iso.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]
+sys.path.insert(0, str(REPO))
+
+from waveflow.toolchain import toolchain                  # noqa: E402
+from waveflow.utils.cosimparse import CosimReportParser   # noqa: E402
+
+TCL = HERE / "compute_iso.tcl"
+SOL = HERE / "compute_iso_proj" / "solution1"
+GRID = [(1, 16), (1, 32), (1, 64), (1, 128), (1, 256),
+        (4, 16), (4, 32), (4, 64), (4, 128), (4, 256)]
+HOLDOUT = (2, 96)
+
+
+def cosim(nrow: int, ncol: int) -> int:
+    env = {"WAVEFLOW_CI_NROW": str(nrow), "WAVEFLOW_CI_NCOL": str(ncol)}
+    last = ""
+    for _ in (1, 2):
+        res = toolchain.run_vitis_hls_result(TCL, work_dir=HERE, capture_output=True, env=env)
+        last = (res.get("stdout") or "") + (res.get("stderr") or "")
+        if "WAVEFLOW_SUCCESS" in last:
+            cyc = CosimReportParser(sol_path=str(SOL), top="compute_iso").get_transaction_cycles()
+            if cyc is not None:
+                return int(cyc)
+    raise RuntimeError(f"compute_iso {nrow}x{ncol} cosim failed:\n{last[-2500:]}")
+
+
+def main() -> None:
+    pts = []
+    for nr, nc in GRID + [HOLDOUT]:
+        cyc = cosim(nr, nc)
+        pts.append((nr, nc, nr * nc, cyc, (nr, nc) == HOLDOUT))
+        print(f"  {nr}x{nc}: {cyc} cyc  ({cyc / (nr * nc):.2f}/sample)", flush=True)
+
+    tr = [p for p in pts if not p[4]]
+    A = np.array([[1, p[0], p[2]] for p in tr], dtype=float)
+    y = np.array([p[3] for p in tr], dtype=float)
+    (L0, L1, II), *_ = np.linalg.lstsq(A, y, rcond=None)
+    pred = A @ np.array([L0, L1, II])
+    print("\nFIT compute_time = L0 + L1*nrow + II*(nrow*ncol)")
+    print(f"  L0={L0:.1f}  L1(per-row)={L1:.2f}  II(per-sample)={II:.3f}")
+    print(f"  train worst rel_err = {np.max(np.abs(pred - y) / y) * 100:.1f}%")
+    for p in pts:
+        if p[4]:
+            pr = L0 + L1 * p[0] + II * p[2]
+            print(f"  HOLDOUT {p[0]}x{p[1]}: pred={pr:.0f} actual={p[3]} "
+                  f"rel_err={abs(pr - p[3]) / p[3] * 100:.1f}%")
+    print(f"\n  VERDICT: compute II = {II:.2f} "
+          f"({'~1, compute pipelines cleanly' if II < 1.4 else 'NOT 1 — compute is the problem'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rowwise_fir/sandbox/fir_skel/fir_skel.cpp
+++ b/examples/rowwise_fir/sandbox/fir_skel/fir_skel.cpp
@@ -1,0 +1,138 @@
+// fir_skel.cpp — Rung 4: the REAL shift-register FIR compute in the controlled load/store skeleton.
+//
+// Identical free-running skeleton to Rung 2/3 (ap_ctrl_hs + DATAFLOW + while(!done) + one gmem
+// bundle + deep FIFOs), but the middle stage is now the ACTUAL FIR: per row, stream n_cols input
+// samples through a T-tap shift register and emit n_cols-T+1 outputs (the first T-1 samples fill
+// the window and produce no output). Two features vs the Rung-3 pass-through:
+//   (a) read != write rate:  reads n_cols/row, writes (n_cols-T+1)/row
+//   (b) per-row window flush + nested ROWS/COLS loop
+// Taps h are COMPILE-TIME constants (no h-read) — that simplification is already applied, so if the
+// overlap breaks here it is NOT the h-read. Job = (n_rows, n_cols). Measures period vs max/sum.
+#include <ap_int.h>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int T = 8;
+static const int CHUNK = 256;
+static const unsigned END_N = 0xFFFFFFFFu;
+#ifndef LSDEPTH
+#define LSDEPTH 2048
+#endif
+
+namespace {
+struct Cmd { int nr; int nc; unsigned xoff; unsigned yoff; bool done; };
+
+float u2f(ap_uint<MEM_DW> u) { union { unsigned i; float f; } c; c.i = (unsigned)u; return c.f; }
+ap_uint<MEM_DW> f2u(float f) { union { unsigned i; float f; } c; c.f = f; return ap_uint<MEM_DW>(c.i); }
+
+void fs_load(hls::stream<ap_uint<32> >& s_in, const ap_uint<MEM_DW>* gmem,
+             hls::stream<Cmd>& ld_ctrl, hls::stream<float>& ld_data) {
+    bool done = false;
+    LOAD: while (!done) {
+        unsigned nr = (unsigned)s_in.read();
+        if (nr == END_N) { Cmd c; c.nr = 0; c.nc = 0; c.xoff = 0; c.yoff = 0; c.done = true; ld_ctrl.write(c); break; }
+        unsigned nc = (unsigned)s_in.read(), xoff = (unsigned)s_in.read(), yoff = (unsigned)s_in.read();
+        Cmd c; c.nr = (int)nr; c.nc = (int)nc; c.xoff = xoff; c.yoff = yoff; c.done = false;
+        ld_ctrl.write(c);
+        int total = (int)nr * (int)nc;
+        LX: for (int base = 0; base < total; base += CHUNK) {
+            int k = (total - base < CHUNK) ? total - base : CHUNK;
+#ifdef FS_BUF
+            // 2-pass like read_array_slice: gmem -> cb (burst) THEN cb -> FIFO (the framework path)
+            float cb[CHUNK];
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                cb[i] = u2f(gmem[xoff + base + i]);
+            }
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                ld_data.write(cb[i]);
+            }
+#else
+            for (int i = 0; i < k; ++i) {     // direct gmem -> FIFO (one pass)
+#pragma HLS PIPELINE II=1
+                ld_data.write(u2f(gmem[xoff + base + i]));
+            }
+#endif
+        }
+    }
+}
+
+void fs_compute(hls::stream<Cmd>& ld_ctrl, hls::stream<float>& ld_data,
+                hls::stream<Cmd>& cp_ctrl, hls::stream<float>& cp_data) {
+    float h[T];
+#pragma HLS ARRAY_PARTITION variable=h complete
+    for (int t = 0; t < T; ++t) h[t] = (float)((t + 1) * 0.25f - 1.0f);   // constant taps (no h-read)
+    bool done = false;
+    COMP: while (!done) {
+        Cmd c = ld_ctrl.read();
+        cp_ctrl.write(c);
+        if (c.done) { done = true; break; }
+        ROWS: for (int r = 0; r < c.nr; ++r) {
+            float sr[T];
+#pragma HLS ARRAY_PARTITION variable=sr complete
+            for (int k = 0; k < T; ++k) sr[k] = 0.0f;      // per-row window flush
+            COLS: for (int s = 0; s < c.nc; ++s) {
+#pragma HLS PIPELINE II=1
+                float x = ld_data.read();
+                for (int k = T - 1; k >= 1; --k) sr[k] = sr[k - 1];
+                sr[0] = x;
+                if (s >= T - 1) {
+                    float acc = 0.0f;
+                    for (int t = 0; t < T; ++t) acc += h[t] * sr[t];
+                    cp_data.write(acc);                    // read n_cols, write n_cols-T+1
+                }
+            }
+        }
+    }
+}
+
+void fs_store(hls::stream<Cmd>& cp_ctrl, hls::stream<float>& cp_data,
+              ap_uint<MEM_DW>* gmem, hls::stream<ap_uint<32> >& m_out) {
+    bool done = false;
+    STORE: while (!done) {
+        Cmd c = cp_ctrl.read();
+        if (c.done) { done = true; break; }
+        int total = c.nr * (c.nc - T + 1);
+        SY: for (int base = 0; base < total; base += CHUNK) {
+            int k = (total - base < CHUNK) ? total - base : CHUNK;
+#ifdef FS_BUF
+            // 2-pass like write_array_slice: FIFO -> cb THEN cb -> gmem (burst) (the framework path)
+            float cb[CHUNK];
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                cb[i] = cp_data.read();
+            }
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                gmem[c.yoff + base + i] = f2u(cb[i]);
+            }
+#else
+            for (int i = 0; i < k; ++i) {     // direct FIFO -> gmem (one pass)
+#pragma HLS PIPELINE II=1
+                gmem[c.yoff + base + i] = f2u(cp_data.read());
+            }
+#endif
+        }
+        m_out.write((ap_uint<32>)total);
+    }
+}
+}  // namespace
+
+void fir_skel(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+              ap_uint<MEM_DW>* gmem) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE m_axi port=gmem bundle=gmem offset=slave depth=16384
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+#pragma HLS DATAFLOW
+    hls::stream<Cmd> ld_ctrl("ld_ctrl"), cp_ctrl("cp_ctrl");
+#pragma HLS STREAM variable=ld_ctrl depth=16
+#pragma HLS STREAM variable=cp_ctrl depth=16
+    hls::stream<float> ld_data("ld_data"), cp_data("cp_data");
+#pragma HLS STREAM variable=ld_data depth=LSDEPTH
+#pragma HLS STREAM variable=cp_data depth=LSDEPTH
+    fs_load(s_in, gmem, ld_ctrl, ld_data);
+    fs_compute(ld_ctrl, ld_data, cp_ctrl, cp_data);
+    fs_store(cp_ctrl, cp_data, gmem, m_out);
+}

--- a/examples/rowwise_fir/sandbox/fir_skel/fir_skel.tcl
+++ b/examples/rowwise_fir/sandbox/fir_skel/fir_skel.tcl
@@ -1,0 +1,31 @@
+# Vitis HLS driver for the real-FIR-compute skeleton: csim + csynth + cosim (port trace).
+#   WAVEFLOW_FS_NROW / WAVEFLOW_FS_NCOL / WAVEFLOW_FS_NJ / WAVEFLOW_FS_DEPTH  (4 / 64 / 6 / 2048)
+set part {xc7z020clg484-1}
+set nr 4
+if {[info exists ::env(WAVEFLOW_FS_NROW)]}  { set nr    $::env(WAVEFLOW_FS_NROW) }
+set nc 64
+if {[info exists ::env(WAVEFLOW_FS_NCOL)]}  { set nc    $::env(WAVEFLOW_FS_NCOL) }
+set nj 6
+if {[info exists ::env(WAVEFLOW_FS_NJ)]}    { set nj    $::env(WAVEFLOW_FS_NJ) }
+set depth 2048
+if {[info exists ::env(WAVEFLOW_FS_DEPTH)]} { set depth $::env(WAVEFLOW_FS_DEPTH) }
+set cflags "-DLSDEPTH=$depth"
+if {[info exists ::env(WAVEFLOW_FS_BUF)] && $::env(WAVEFLOW_FS_BUF) == "1"} {
+    set cflags "$cflags -DFS_BUF"     ;# 2-pass buffered slice (the framework read/write_array_slice path)
+}
+set argv "$nr $nc $nj"
+puts "WAVEFLOW_INFO: fir_skel nr=$nr nc=$nc nj=$nj depth=$depth cflags=$cflags"
+
+open_project -reset fir_skel_proj
+set_top fir_skel
+add_files fir_skel.cpp -cflags "$cflags"
+add_files -tb fir_skel_tb.cpp
+open_solution -reset "solution1"
+set_part $part
+create_clock -period 10
+
+if {[catch {csim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: csim"; puts $res; exit 1 }
+if {[catch {csynth_design} res]} { puts "WAVEFLOW_ERROR: csynth"; puts $res; exit 1 }
+if {[catch {cosim_design -argv "$argv" -trace_level port} res]} { puts "WAVEFLOW_ERROR: cosim"; puts $res; exit 1 }
+puts "WAVEFLOW_SUCCESS: fir_skel nr=$nr nc=$nc nj=$nj depth=$depth"
+exit 0

--- a/examples/rowwise_fir/sandbox/fir_skel/fir_skel_tb.cpp
+++ b/examples/rowwise_fir/sandbox/fir_skel/fir_skel_tb.cpp
@@ -1,0 +1,41 @@
+// fir_skel_tb.cpp — NJOBS back-to-back FIR jobs of (NROW x NCOL) (one cosim run).
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define MEM_DW 32
+static const int T = 8;
+static const unsigned END_N = 0xFFFFFFFFu;
+void fir_skel(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+              ap_uint<MEM_DW>* gmem);
+
+int main(int argc, char** argv) {
+    int nr = (argc > 1) ? std::atoi(argv[1]) : 4;
+    int nc = (argc > 2) ? std::atoi(argv[2]) : 64;
+    int nj = (argc > 3) ? std::atoi(argv[3]) : 6;
+    int outlen = nc - T + 1;
+    std::vector<ap_uint<MEM_DW> > gmem(16384, 0);
+    hls::stream<ap_uint<32> > s_in("s_in"), m_out("m_out");
+    unsigned off = 0;
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = off; off += (unsigned)(nr * nc);
+        unsigned yoff = off; off += (unsigned)(nr * outlen);
+        for (int i = 0; i < nr * nc; ++i) {
+            union { float f; unsigned u; } cv; cv.f = (float)((i % 17) * 0.5f - 4.0f + j);
+            gmem[xoff + i] = (ap_uint<MEM_DW>)cv.u;
+        }
+        s_in.write((ap_uint<32>)nr);
+        s_in.write((ap_uint<32>)nc);
+        s_in.write((ap_uint<32>)xoff);
+        s_in.write((ap_uint<32>)yoff);
+    }
+    s_in.write((ap_uint<32>)END_N);
+    fir_skel(s_in, m_out, gmem.data());
+    int resp = 0;
+    while (!m_out.empty()) { (void)m_out.read(); ++resp; }
+    if (resp != nj) { std::fprintf(stderr, "WAVEFLOW_ERROR: fir_skel %dx%d nj=%d got %d\n", nr, nc, nj, resp); return 1; }
+    std::printf("WAVEFLOW_SUCCESS: fir_skel %dx%d nj=%d (%d resp)\n", nr, nc, nj, resp);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/fir_skel/run_fir_skel.py
+++ b/examples/rowwise_fir/sandbox/fir_skel/run_fir_skel.py
@@ -1,0 +1,108 @@
+"""run_fir_skel.py — Rung 4: REAL FIR compute in the controlled load/store skeleton.
+
+Same skeleton as Rung 2/3 (which overlapped at every depth), but the middle stage is the actual
+shift-register FIR (read n_cols/row, write n_cols-T+1/row, per-row window flush; taps constant, no
+h-read). Measures the steady period from the Y write-burst spacing and compares to:
+
+  max(read_words, write_words)  = the overlapped ideal (what Rung 3 achieved)
+  read_words + write_words      = serialized (the real FIR's ~704 behavior)
+
+If period ~ sum, the real compute breaks the overlap -> morph it feature by feature. If ~ max, the
+break is elsewhere (e.g. the h-read or the generated FIFO depths).
+
+Run (project venv, Vitis 2025.1 + xsim)::
+
+    PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_fir_skel.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]
+sys.path.insert(0, str(REPO))
+
+from waveflow.toolchain import toolchain                  # noqa: E402
+from waveflow.utils.cosimparse import CosimReportParser   # noqa: E402
+
+T = 8
+TCL = HERE / "fir_skel.tcl"
+SOL = HERE / "fir_skel_proj" / "solution1"
+WORD_BYTES = 4
+
+
+def _end(bursts, lo_w, hi_w):
+    lo, hi = lo_w * WORD_BYTES, hi_w * WORD_BYTES
+    sel = [b for b in bursts if lo <= int(b["addr"]) < hi]
+    return max((float(b["data_tend"]) for b in sel), default=None)
+
+
+def run(nr, nc, nj, depth, buf=False):
+    from vcdvcd import VCDVCD
+    from waveflow.scripts.xsim_vcd import run_xsim_vcd
+    from waveflow.utils.vcd import VcdParser
+
+    env = {"WAVEFLOW_FS_NROW": str(nr), "WAVEFLOW_FS_NCOL": str(nc), "WAVEFLOW_FS_NJ": str(nj),
+           "WAVEFLOW_FS_DEPTH": str(depth), "WAVEFLOW_FS_BUF": "1" if buf else "0"}
+    last = ""
+    for _ in (1, 2):
+        res = toolchain.run_vitis_hls_result(TCL, work_dir=HERE, capture_output=True, env=env)
+        last = (res.get("stdout") or "") + (res.get("stderr") or "")
+        if "WAVEFLOW_SUCCESS" in last:
+            break
+    if "WAVEFLOW_SUCCESS" not in last:
+        raise RuntimeError(f"{nr}x{nc} cosim failed:\n{last[-2000:]}")
+    total = CosimReportParser(sol_path=str(SOL), top="fir_skel").get_transaction_cycles()
+
+    vcd = run_xsim_vcd(top="fir_skel", comp="fir_skel_proj", out="dump.vcd", soln="solution1",
+                       trace_level="port", workdir=HERE)
+    vp = VcdParser(VCDVCD(str(vcd), signals=None, store_tvs=True))
+    clk = vp.add_clock_signal()
+    sigs, _ = vp.add_aximm_signals(prefix="m_axi_gmem_", dir="both", lite_only=False,
+                                   short_name_prefix="gmem_")
+    wb, _rb, clk_ns = vp.extract_aximm_bursts(clk_name=clk, aximm_sigs=sigs)
+    clk_ns = float(clk_ns)
+    outlen = nc - T + 1
+    off, ends = 0, []
+    for _j in range(nj):
+        off += nr * nc                 # skip this job's X region
+        yoff = off
+        off += nr * outlen             # this job's Y region
+        e = _end(wb, yoff, yoff + nr * outlen)
+        if e is not None:
+            ends.append(e / clk_ns)
+    period = None
+    if len(ends) >= 3:
+        sp = [ends[i + 1] - ends[i] for i in range(len(ends) - 1)]
+        period = sp[len(sp) // 2 - 1]
+    read_w, write_w = nr * nc, nr * outlen
+    return {"nr": nr, "nc": nc, "read": read_w, "write": write_w, "total": int(total) if total else None,
+            "period": round(period, 1) if period else None,
+            "maxrw": max(read_w, write_w), "sumrw": read_w + write_w}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nj", type=int, default=6)
+    ap.add_argument("--depth", type=int, default=2048)
+    ap.add_argument("--points", type=str, default="4x64,1x256")
+    ap.add_argument("--buf", action="store_true", help="use the 2-pass buffered slice (framework path)")
+    args = ap.parse_args()
+    pts = [tuple(int(v) for v in p.split("x")) for p in args.points.split(",")]
+    mode = "BUFFERED 2-pass (read/write_array_slice path)" if args.buf else "DIRECT gmem<->FIFO"
+    print(f"fir_skel (REAL compute)  NJOBS={args.nj}  depth={args.depth}  m_axi={mode}\n")
+    print(f"{'size':>8} {'period':>8} {'max(r,w)':>9} {'sum(r,w)':>9}  verdict")
+    for nr, nc in pts:
+        r = run(nr, nc, args.nj, args.depth, buf=args.buf)
+        p = r["period"]
+        if not p:
+            print(f"{f'{nr}x{nc}':>8} {'None':>8}")
+            continue
+        verd = "OVERLAP (~max)" if p < 0.5 * (r["maxrw"] + r["sumrw"]) else "SERIALIZED (~sum)"
+        print(f"{f'{nr}x{nc}':>8} {p:>8.0f} {r['maxrw']:>9} {r['sumrw']:>9}  {verd}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rowwise_fir/sandbox/halfpipe/cs_iso.cpp
+++ b/examples/rowwise_fir/sandbox/halfpipe/cs_iso.cpp
@@ -1,0 +1,86 @@
+// cs_iso.cpp — half-pipe: FAKE load (from BRAM) + compute + real m_axi STORE (no m_axi read).
+//
+// Isolates the write-side: load reads X from an on-chip BRAM port (no m_axi read), compute is the
+// trivial II=1 pass-through, store writes Y to gmem (m_axi WRITE). Only the WRITE channel touches
+// the bus. Multi-job, free-running. Mirror of lc_iso for the opposite direction.
+#include <ap_int.h>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int CHUNK = 256;
+static const int MAXE = 2048;
+static const unsigned END_N = 0xFFFFFFFFu;
+#ifndef LSDEPTH
+#define LSDEPTH 1024
+#endif
+
+namespace {
+struct Cmd { int n; unsigned yoff; bool done; };
+
+void cs_fakeload(hls::stream<ap_uint<32> >& s_in, const float xbuf[MAXE],
+                 hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data) {
+    bool done = false;
+    LOAD: while (!done) {
+        unsigned n = (unsigned)s_in.read();
+        if (n == END_N) { Cmd c; c.n = 0; c.yoff = 0; c.done = true; ld_ctrl.write(c); break; }
+        unsigned yoff = (unsigned)s_in.read();
+        Cmd c; c.n = (int)n; c.yoff = yoff; c.done = false;
+        ld_ctrl.write(c);
+        LX: for (int i = 0; i < (int)n; ++i) {
+#pragma HLS PIPELINE II=1
+            union { float f; unsigned u; } cv; cv.f = xbuf[i];   // BRAM read (no m_axi)
+            ld_data.write(ap_uint<MEM_DW>(cv.u));
+        }
+    }
+}
+
+void cs_compute(hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data,
+                hls::stream<Cmd>& cp_ctrl, hls::stream<ap_uint<MEM_DW> >& cp_data) {
+    bool done = false;
+    COMP: while (!done) {
+        Cmd c = ld_ctrl.read();
+        cp_ctrl.write(c);
+        if (c.done) { done = true; break; }
+        CC: for (int i = 0; i < c.n; ++i) {
+#pragma HLS PIPELINE II=1
+            cp_data.write(ld_data.read() + 1);
+        }
+    }
+}
+
+void cs_store(hls::stream<Cmd>& cp_ctrl, hls::stream<ap_uint<MEM_DW> >& cp_data,
+              ap_uint<MEM_DW>* gmem, hls::stream<ap_uint<32> >& m_out) {
+    bool done = false;
+    STORE: while (!done) {
+        Cmd c = cp_ctrl.read();
+        if (c.done) { done = true; break; }
+        SY: for (int base = 0; base < c.n; base += CHUNK) {
+            int k = (c.n - base < CHUNK) ? c.n - base : CHUNK;
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                gmem[c.yoff + base + i] = cp_data.read();
+            }
+        }
+        m_out.write((ap_uint<32>)c.n);
+    }
+}
+}  // namespace
+
+void cs_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+            const float xbuf[MAXE], ap_uint<MEM_DW>* gmem) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE ap_memory port=xbuf
+#pragma HLS INTERFACE m_axi port=gmem bundle=gmem offset=slave depth=8192
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+#pragma HLS DATAFLOW
+    hls::stream<Cmd> ld_ctrl("ld_ctrl"), cp_ctrl("cp_ctrl");
+#pragma HLS STREAM variable=ld_ctrl depth=16
+#pragma HLS STREAM variable=cp_ctrl depth=16
+    hls::stream<ap_uint<MEM_DW> > ld_data("ld_data"), cp_data("cp_data");
+#pragma HLS STREAM variable=ld_data depth=LSDEPTH
+#pragma HLS STREAM variable=cp_data depth=LSDEPTH
+    cs_fakeload(s_in, xbuf, ld_ctrl, ld_data);
+    cs_compute(ld_ctrl, ld_data, cp_ctrl, cp_data);
+    cs_store(cp_ctrl, cp_data, gmem, m_out);
+}

--- a/examples/rowwise_fir/sandbox/halfpipe/cs_iso_tb.cpp
+++ b/examples/rowwise_fir/sandbox/halfpipe/cs_iso_tb.cpp
@@ -1,0 +1,33 @@
+// cs_iso_tb.cpp — NJOBS compute+store jobs of N words (fake BRAM load, real m_axi write).
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define MEM_DW 32
+static const int MAXE = 2048;
+static const unsigned END_N = 0xFFFFFFFFu;
+void cs_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+            const float xbuf[MAXE], ap_uint<MEM_DW>* gmem);
+
+int main(int argc, char** argv) {
+    int n  = (argc > 1) ? std::atoi(argv[1]) : 256;
+    int nj = (argc > 2) ? std::atoi(argv[2]) : 6;
+    static float xbuf[MAXE];
+    for (int i = 0; i < n && i < MAXE; ++i) xbuf[i] = (float)((i % 17) * 0.5f - 4.0f);
+    std::vector<ap_uint<MEM_DW> > gmem(8192, 0);
+    hls::stream<ap_uint<32> > s_in("s_in"), m_out("m_out");
+    for (int j = 0; j < nj; ++j) {
+        unsigned yoff = (unsigned)(j * n);
+        s_in.write((ap_uint<32>)n);
+        s_in.write((ap_uint<32>)yoff);
+    }
+    s_in.write((ap_uint<32>)END_N);
+    cs_iso(s_in, m_out, xbuf, gmem.data());
+    int resp = 0;
+    while (!m_out.empty()) { (void)m_out.read(); ++resp; }
+    if (resp != nj) { std::fprintf(stderr, "WAVEFLOW_ERROR: cs N=%d nj=%d got %d resp\n", n, nj, resp); return 1; }
+    std::printf("WAVEFLOW_SUCCESS: cs N=%d nj=%d (%d resp)\n", n, nj, resp);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/halfpipe/halfpipe.tcl
+++ b/examples/rowwise_fir/sandbox/halfpipe/halfpipe.tcl
@@ -1,0 +1,28 @@
+# Vitis HLS driver for the half-pipe toys: WAVEFLOW_HP_MODE = lc | cs.
+#   lc = real m_axi load + compute + fake store ;  cs = fake BRAM load + compute + real m_axi store
+#   WAVEFLOW_HP_N / WAVEFLOW_HP_NJ / WAVEFLOW_HP_DEPTH   (defaults 256 / 6 / 1024)
+set part {xc7z020clg484-1}
+set mode "lc"
+if {[info exists ::env(WAVEFLOW_HP_MODE)]}  { set mode  $::env(WAVEFLOW_HP_MODE) }
+set n 256
+if {[info exists ::env(WAVEFLOW_HP_N)]}     { set n     $::env(WAVEFLOW_HP_N) }
+set nj 6
+if {[info exists ::env(WAVEFLOW_HP_NJ)]}    { set nj    $::env(WAVEFLOW_HP_NJ) }
+set depth 1024
+if {[info exists ::env(WAVEFLOW_HP_DEPTH)]} { set depth $::env(WAVEFLOW_HP_DEPTH) }
+set argv "$n $nj"
+puts "WAVEFLOW_INFO: halfpipe mode=$mode n=$n nj=$nj depth=$depth"
+
+open_project -reset ${mode}_iso_proj
+set_top ${mode}_iso
+add_files ${mode}_iso.cpp -cflags "-DLSDEPTH=$depth"
+add_files -tb ${mode}_iso_tb.cpp
+open_solution -reset "solution1"
+set_part $part
+create_clock -period 10
+
+if {[catch {csim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: csim"; puts $res; exit 1 }
+if {[catch {csynth_design} res]} { puts "WAVEFLOW_ERROR: csynth"; puts $res; exit 1 }
+if {[catch {cosim_design -argv "$argv" -trace_level port} res]} { puts "WAVEFLOW_ERROR: cosim"; puts $res; exit 1 }
+puts "WAVEFLOW_SUCCESS: halfpipe mode=$mode n=$n nj=$nj depth=$depth"
+exit 0

--- a/examples/rowwise_fir/sandbox/halfpipe/lc_iso.cpp
+++ b/examples/rowwise_fir/sandbox/halfpipe/lc_iso.cpp
@@ -1,0 +1,85 @@
+// lc_iso.cpp — half-pipe: real m_axi LOAD + compute + FAKE store (no m_axi write).
+//
+// Isolates the read-side: load reads X from gmem (m_axi READ), compute is the trivial II=1
+// pass-through, and "store" folds the result into a checksum (no m_axi write). Only the READ
+// channel touches the bus. Multi-job, free-running. If period ~= n (1 cyc/sample) the read-side +
+// compute is clean; if it's ~2n the read+compute interaction itself is the slowdown.
+#include <ap_int.h>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int CHUNK = 256;
+static const unsigned END_N = 0xFFFFFFFFu;
+#ifndef LSDEPTH
+#define LSDEPTH 1024
+#endif
+
+namespace {
+struct Cmd { int n; unsigned xoff; bool done; };
+
+void lc_load(hls::stream<ap_uint<32> >& s_in, const ap_uint<MEM_DW>* gmem,
+             hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data) {
+    bool done = false;
+    LOAD: while (!done) {
+        unsigned n = (unsigned)s_in.read();
+        if (n == END_N) { Cmd c; c.n = 0; c.xoff = 0; c.done = true; ld_ctrl.write(c); break; }
+        unsigned xoff = (unsigned)s_in.read();
+        Cmd c; c.n = (int)n; c.xoff = xoff; c.done = false;
+        ld_ctrl.write(c);
+        LX: for (int base = 0; base < (int)n; base += CHUNK) {
+            int k = ((int)n - base < CHUNK) ? (int)n - base : CHUNK;
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                ld_data.write(gmem[xoff + base + i]);
+            }
+        }
+    }
+}
+
+void lc_compute(hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data,
+                hls::stream<Cmd>& cp_ctrl, hls::stream<ap_uint<MEM_DW> >& cp_data) {
+    bool done = false;
+    COMP: while (!done) {
+        Cmd c = ld_ctrl.read();
+        cp_ctrl.write(c);
+        if (c.done) { done = true; break; }
+        CC: for (int i = 0; i < c.n; ++i) {
+#pragma HLS PIPELINE II=1
+            cp_data.write(ld_data.read() + 1);
+        }
+    }
+}
+
+void lc_fakestore(hls::stream<Cmd>& cp_ctrl, hls::stream<ap_uint<MEM_DW> >& cp_data,
+                  hls::stream<ap_uint<32> >& m_out) {
+    bool done = false;
+    STORE: while (!done) {
+        Cmd c = cp_ctrl.read();
+        if (c.done) { done = true; break; }
+        ap_uint<32> chk = 0;
+        SY: for (int i = 0; i < c.n; ++i) {
+#pragma HLS PIPELINE II=1
+            chk ^= cp_data.read();            // fold (no m_axi write) — keeps the datapath live
+        }
+        m_out.write(chk);
+    }
+}
+}  // namespace
+
+void lc_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+            const ap_uint<MEM_DW>* gmem) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE m_axi port=gmem bundle=gmem offset=slave depth=8192
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+#pragma HLS DATAFLOW
+    hls::stream<Cmd> ld_ctrl("ld_ctrl"), cp_ctrl("cp_ctrl");
+#pragma HLS STREAM variable=ld_ctrl depth=16
+#pragma HLS STREAM variable=cp_ctrl depth=16
+    hls::stream<ap_uint<MEM_DW> > ld_data("ld_data"), cp_data("cp_data");
+#pragma HLS STREAM variable=ld_data depth=LSDEPTH
+#pragma HLS STREAM variable=cp_data depth=LSDEPTH
+    lc_load(s_in, gmem, ld_ctrl, ld_data);
+    lc_compute(ld_ctrl, ld_data, cp_ctrl, cp_data);
+    lc_fakestore(cp_ctrl, cp_data, m_out);
+}

--- a/examples/rowwise_fir/sandbox/halfpipe/lc_iso_tb.cpp
+++ b/examples/rowwise_fir/sandbox/halfpipe/lc_iso_tb.cpp
@@ -1,0 +1,31 @@
+// lc_iso_tb.cpp — NJOBS load+compute jobs of N words (real m_axi read, fake store).
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define MEM_DW 32
+static const unsigned END_N = 0xFFFFFFFFu;
+void lc_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+            const ap_uint<MEM_DW>* gmem);
+
+int main(int argc, char** argv) {
+    int n  = (argc > 1) ? std::atoi(argv[1]) : 256;
+    int nj = (argc > 2) ? std::atoi(argv[2]) : 6;
+    std::vector<ap_uint<MEM_DW> > gmem(8192, 0);
+    hls::stream<ap_uint<32> > s_in("s_in"), m_out("m_out");
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = (unsigned)(j * n);
+        for (int i = 0; i < n; ++i) gmem[xoff + i] = (ap_uint<MEM_DW>)(i + 3 * j + 1);
+        s_in.write((ap_uint<32>)n);
+        s_in.write((ap_uint<32>)xoff);
+    }
+    s_in.write((ap_uint<32>)END_N);
+    lc_iso(s_in, m_out, gmem.data());
+    int resp = 0;
+    while (!m_out.empty()) { (void)m_out.read(); ++resp; }
+    if (resp != nj) { std::fprintf(stderr, "WAVEFLOW_ERROR: lc N=%d nj=%d got %d resp\n", n, nj, resp); return 1; }
+    std::printf("WAVEFLOW_SUCCESS: lc N=%d nj=%d (%d resp)\n", n, nj, resp);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/halfpipe/run_halfpipe.py
+++ b/examples/rowwise_fir/sandbox/halfpipe/run_halfpipe.py
@@ -1,0 +1,99 @@
+"""run_halfpipe.py — half-pipe decomposition: load+compute (read-only) vs compute+store (write-only).
+
+Each mode uses only ONE m_axi direction, so there's no read+write contention — it isolates each
+direction's interaction with the compute middle stage:
+  lc = real m_axi LOAD  + compute + fake store  -> period from READ-burst spacing
+  cs = fake BRAM load   + compute + real STORE  -> period from WRITE-burst spacing
+
+If both ~= n (1 cyc/sample), each direction+compute is clean and the FIR slowdown is a 3-way
+read+write+compute effect; if one is ~2n, that direction+compute is the culprit.
+
+Run (project venv, Vitis 2025.1 + xsim)::
+
+    PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_halfpipe.py --n 256 --nj 6
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]
+sys.path.insert(0, str(REPO))
+
+from waveflow.toolchain import toolchain                  # noqa: E402
+from waveflow.utils.cosimparse import CosimReportParser   # noqa: E402
+
+TCL = HERE / "halfpipe.tcl"
+WORD_BYTES = 4
+
+
+def _beats(b):
+    return sum(1 for bt in b.get("beat_type", []) if bt == 0)
+
+
+def _span(bursts, lo_w, hi_w):
+    lo, hi = lo_w * WORD_BYTES, hi_w * WORD_BYTES
+    sel = [b for b in bursts if lo <= int(b["addr"]) < hi]
+    if not sel:
+        return None
+    return max(float(b["data_tend"]) for b in sel)
+
+
+def run(mode: str, n: int, nj: int, depth: int) -> dict:
+    from vcdvcd import VCDVCD
+    from waveflow.scripts.xsim_vcd import run_xsim_vcd
+    from waveflow.utils.vcd import VcdParser
+
+    proj = f"{mode}_iso_proj"
+    sol = HERE / proj / "solution1"
+    env = {"WAVEFLOW_HP_MODE": mode, "WAVEFLOW_HP_N": str(n), "WAVEFLOW_HP_NJ": str(nj),
+           "WAVEFLOW_HP_DEPTH": str(depth)}
+    last = ""
+    for _ in (1, 2):
+        res = toolchain.run_vitis_hls_result(TCL, work_dir=HERE, capture_output=True, env=env)
+        last = (res.get("stdout") or "") + (res.get("stderr") or "")
+        if "WAVEFLOW_SUCCESS" in last:
+            break
+    if "WAVEFLOW_SUCCESS" not in last:
+        raise RuntimeError(f"{mode} cosim failed:\n{last[-2000:]}")
+    total = CosimReportParser(sol_path=str(sol), top=f"{mode}_iso").get_transaction_cycles()
+
+    vcd = run_xsim_vcd(top=f"{mode}_iso", comp=proj, out="dump.vcd", soln="solution1",
+                       trace_level="port", workdir=HERE)
+    vp = VcdParser(VCDVCD(str(vcd), signals=None, store_tvs=True))
+    clk = vp.add_clock_signal()
+    sigs, _ = vp.add_aximm_signals(prefix="m_axi_gmem_", dir="both", lite_only=False,
+                                   short_name_prefix="gmem_")
+    wb, rb, clk_ns = vp.extract_aximm_bursts(clk_name=clk, aximm_sigs=sigs)
+    clk_ns = float(clk_ns)
+    bursts = rb if mode == "lc" else wb     # lc reads X at j*n; cs writes Y at j*n
+    ends = [e / clk_ns for j in range(nj) if (e := _span(bursts, j * n, j * n + n)) is not None]
+    period = None
+    if len(ends) >= 3:
+        sp = [ends[i + 1] - ends[i] for i in range(len(ends) - 1)]
+        period = sp[len(sp) // 2 - 1]
+    return {"mode": mode, "total": int(total) if total else None,
+            "period": round(period, 1) if period else None}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=256)
+    ap.add_argument("--nj", type=int, default=6)
+    ap.add_argument("--depth", type=int, default=1024)
+    args = ap.parse_args()
+    print(f"half-pipe  N={args.n}/job  NJOBS={args.nj}  depth={args.depth}")
+    print(f"  ideal per-job ~= n = {args.n}  (one m_axi direction + compute, II=1)\n")
+    print(f"{'mode':>6} {'period':>8} {'cyc/sample':>11}  meaning")
+    for mode, desc in (("lc", "real LOAD + compute (read-only)"),
+                       ("cs", "compute + real STORE (write-only)")):
+        r = run(mode, args.n, args.nj, args.depth)
+        p = r["period"]
+        cw = f"{p / args.n:.2f}" if p else "-"
+        print(f"{mode:>6} {str(p):>8} {cw:>11}  {desc}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rowwise_fir/sandbox/lcs_iso/lcs_iso.cpp
+++ b/examples/rowwise_fir/sandbox/lcs_iso/lcs_iso.cpp
@@ -1,0 +1,90 @@
+// lcs_iso.cpp — Rung 3: free-running load -> compute -> store, multi-job, with a DEPTH knob.
+//
+// Rung 2 showed load||store (no compute) overlaps read+write (period ~= max). This inserts a
+// MIDDLE stage between them — a trivial II=1 pass-through (y = x + 1), so it carries compute's
+// *position and timing* without the FIR specifics — and exposes the inter-stage FIFO DEPTH as a
+// compile knob (-DLSDEPTH). Question:
+//   * Does adding a middle stage collapse the period from ~max back to ~sum? (then it's structural)
+//   * Does increasing DEPTH (letting load run more jobs ahead) restore period -> ~max?
+// This isolates whether the FIR's lost full-duplex is a depth/run-ahead problem or a deeper one.
+#include <ap_int.h>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int CHUNK = 256;
+static const unsigned END_N = 0xFFFFFFFFu;
+#ifndef LSDEPTH
+#define LSDEPTH 1024            // inter-stage data-FIFO depth (the run-ahead knob)
+#endif
+
+namespace {
+struct Cmd { int n; unsigned xoff; unsigned yoff; bool done; };
+
+void lcs_load(hls::stream<ap_uint<32> >& s_in, const ap_uint<MEM_DW>* gmem,
+              hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data) {
+    bool done = false;
+    LOAD: while (!done) {
+        unsigned n = (unsigned)s_in.read();
+        if (n == END_N) { Cmd c; c.n = 0; c.xoff = 0; c.yoff = 0; c.done = true; ld_ctrl.write(c); break; }
+        unsigned xoff = (unsigned)s_in.read(), yoff = (unsigned)s_in.read();
+        Cmd c; c.n = (int)n; c.xoff = xoff; c.yoff = yoff; c.done = false;
+        ld_ctrl.write(c);
+        LX: for (int base = 0; base < (int)n; base += CHUNK) {
+            int k = ((int)n - base < CHUNK) ? (int)n - base : CHUNK;
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                ld_data.write(gmem[xoff + base + i]);
+            }
+        }
+    }
+}
+
+void lcs_compute(hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data,
+                 hls::stream<Cmd>& cp_ctrl, hls::stream<ap_uint<MEM_DW> >& cp_data) {
+    bool done = false;
+    COMP: while (!done) {
+        Cmd c = ld_ctrl.read();
+        cp_ctrl.write(c);
+        if (c.done) { done = true; break; }
+        CC: for (int i = 0; i < c.n; ++i) {
+#pragma HLS PIPELINE II=1
+            cp_data.write(ld_data.read() + 1);     // trivial II=1 pass-through (compute's stand-in)
+        }
+    }
+}
+
+void lcs_store(hls::stream<Cmd>& cp_ctrl, hls::stream<ap_uint<MEM_DW> >& cp_data,
+               ap_uint<MEM_DW>* gmem, hls::stream<ap_uint<32> >& m_out) {
+    bool done = false;
+    STORE: while (!done) {
+        Cmd c = cp_ctrl.read();
+        if (c.done) { done = true; break; }
+        SY: for (int base = 0; base < c.n; base += CHUNK) {
+            int k = (c.n - base < CHUNK) ? c.n - base : CHUNK;
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                gmem[c.yoff + base + i] = cp_data.read();
+            }
+        }
+        m_out.write((ap_uint<32>)c.n);
+    }
+}
+}  // namespace
+
+void lcs_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+             ap_uint<MEM_DW>* gmem) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE m_axi port=gmem bundle=gmem offset=slave depth=8192
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+#pragma HLS DATAFLOW
+    hls::stream<Cmd> ld_ctrl("ld_ctrl"), cp_ctrl("cp_ctrl");
+#pragma HLS STREAM variable=ld_ctrl depth=16
+#pragma HLS STREAM variable=cp_ctrl depth=16
+    hls::stream<ap_uint<MEM_DW> > ld_data("ld_data"), cp_data("cp_data");
+#pragma HLS STREAM variable=ld_data depth=LSDEPTH
+#pragma HLS STREAM variable=cp_data depth=LSDEPTH
+    lcs_load(s_in, gmem, ld_ctrl, ld_data);
+    lcs_compute(ld_ctrl, ld_data, cp_ctrl, cp_data);
+    lcs_store(cp_ctrl, cp_data, gmem, m_out);
+}

--- a/examples/rowwise_fir/sandbox/lcs_iso/lcs_iso.tcl
+++ b/examples/rowwise_fir/sandbox/lcs_iso/lcs_iso.tcl
@@ -1,0 +1,25 @@
+# Vitis HLS driver for the load->compute->store toy: csim + csynth + cosim (port trace).
+#   WAVEFLOW_LCS_N / WAVEFLOW_LCS_NJ / WAVEFLOW_LCS_DEPTH   (defaults 256 / 5 / 1024)
+set part {xc7z020clg484-1}
+set n 256
+if {[info exists ::env(WAVEFLOW_LCS_N)]}     { set n     $::env(WAVEFLOW_LCS_N) }
+set nj 5
+if {[info exists ::env(WAVEFLOW_LCS_NJ)]}    { set nj    $::env(WAVEFLOW_LCS_NJ) }
+set depth 1024
+if {[info exists ::env(WAVEFLOW_LCS_DEPTH)]} { set depth $::env(WAVEFLOW_LCS_DEPTH) }
+set argv "$n $nj"
+puts "WAVEFLOW_INFO: lcs n=$n nj=$nj depth=$depth"
+
+open_project -reset lcs_iso_proj
+set_top lcs_iso
+add_files lcs_iso.cpp -cflags "-DLSDEPTH=$depth"
+add_files -tb lcs_iso_tb.cpp
+open_solution -reset "solution1"
+set_part $part
+create_clock -period 10
+
+if {[catch {csim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: csim"; puts $res; exit 1 }
+if {[catch {csynth_design} res]} { puts "WAVEFLOW_ERROR: csynth"; puts $res; exit 1 }
+if {[catch {cosim_design -argv "$argv" -trace_level port} res]} { puts "WAVEFLOW_ERROR: cosim"; puts $res; exit 1 }
+puts "WAVEFLOW_SUCCESS: lcs n=$n nj=$nj depth=$depth"
+exit 0

--- a/examples/rowwise_fir/sandbox/lcs_iso/lcs_iso_tb.cpp
+++ b/examples/rowwise_fir/sandbox/lcs_iso/lcs_iso_tb.cpp
@@ -1,0 +1,41 @@
+// lcs_iso_tb.cpp — NJOBS back-to-back load->compute(+1)->store jobs of N words (one cosim run).
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define MEM_DW 32
+static const unsigned END_N = 0xFFFFFFFFu;
+void lcs_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+             ap_uint<MEM_DW>* gmem);
+
+int main(int argc, char** argv) {
+    int n  = (argc > 1) ? std::atoi(argv[1]) : 256;
+    int nj = (argc > 2) ? std::atoi(argv[2]) : 4;
+    std::vector<ap_uint<MEM_DW> > gmem(8192, 0);
+    hls::stream<ap_uint<32> > s_in("s_in"), m_out("m_out");
+
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = 2u * j * n, yoff = 2u * j * n + n;
+        for (int i = 0; i < n; ++i) gmem[xoff + i] = (ap_uint<MEM_DW>)(i + 7 * j + 1);
+        s_in.write((ap_uint<32>)n);
+        s_in.write((ap_uint<32>)xoff);
+        s_in.write((ap_uint<32>)yoff);
+    }
+    s_in.write((ap_uint<32>)END_N);
+
+    lcs_iso(s_in, m_out, gmem.data());
+
+    int resp = 0;
+    while (!m_out.empty()) { (void)m_out.read(); ++resp; }
+    int fails = (resp != nj) ? 1 : 0;
+    for (int j = 0; j < nj && !fails; ++j) {
+        unsigned xoff = 2u * j * n, yoff = 2u * j * n + n;
+        for (int i = 0; i < n; ++i)
+            if ((unsigned)gmem[yoff + i] != (unsigned)gmem[xoff + i] + 1) { fails = 1; break; }
+    }
+    if (fails) { std::fprintf(stderr, "WAVEFLOW_ERROR: lcs N=%d nj=%d FAILED\n", n, nj); return 1; }
+    std::printf("WAVEFLOW_SUCCESS: lcs N=%d nj=%d (%d resp)\n", n, nj, resp);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/lcs_iso/run_lcs_iso.py
+++ b/examples/rowwise_fir/sandbox/lcs_iso/run_lcs_iso.py
@@ -1,0 +1,102 @@
+"""run_lcs_iso.py — Rung 3: free-running load -> compute -> store, sweep the run-ahead DEPTH.
+
+Inserts a trivial II=1 pass-through compute between load and store (Rung 2's load||store + a
+middle stage) and sweeps the inter-stage FIFO depth. For N=256/job:
+  depth < ~2*N  => load can't run a full job ahead of store -> period ~ sum (no overlap)
+  depth >= ~2*N => load(N+1) overlaps store(N-1) -> period -> ~max (full-duplex restored)
+
+If period drops toward ~max as depth grows, the FIR's lost full-duplex is a run-ahead/depth issue.
+If it stays ~sum regardless, the 3-stage free-running DATAFLOW serializes structurally.
+
+Run (project venv, Vitis 2025.1 + xsim)::
+
+    PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_lcs_iso.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]
+sys.path.insert(0, str(REPO))
+
+from waveflow.toolchain import toolchain                  # noqa: E402
+from waveflow.utils.cosimparse import CosimReportParser   # noqa: E402
+
+TCL = HERE / "lcs_iso.tcl"
+SOL = HERE / "lcs_iso_proj" / "solution1"
+WORD_BYTES = 4
+
+
+def _beats(b):
+    return sum(1 for bt in b.get("beat_type", []) if bt == 0)
+
+
+def _span(bursts, lo_w, hi_w):
+    lo, hi = lo_w * WORD_BYTES, hi_w * WORD_BYTES
+    sel = [b for b in bursts if lo <= int(b["addr"]) < hi]
+    if not sel:
+        return None
+    t0 = min(float(b.get("data_tstart", b["tstart"])) for b in sel)
+    t1 = max(float(b["data_tend"]) for b in sel)
+    return t0, t1
+
+
+def cosim(n, nj, depth):
+    from vcdvcd import VCDVCD
+    from waveflow.scripts.xsim_vcd import run_xsim_vcd
+    from waveflow.utils.vcd import VcdParser
+
+    env = {"WAVEFLOW_LCS_N": str(n), "WAVEFLOW_LCS_NJ": str(nj), "WAVEFLOW_LCS_DEPTH": str(depth)}
+    last = ""
+    for _ in (1, 2):
+        res = toolchain.run_vitis_hls_result(TCL, work_dir=HERE, capture_output=True, env=env)
+        last = (res.get("stdout") or "") + (res.get("stderr") or "")
+        if "WAVEFLOW_SUCCESS" in last:
+            break
+    if "WAVEFLOW_SUCCESS" not in last:
+        raise RuntimeError(f"depth {depth} cosim failed:\n{last[-2000:]}")
+    total = CosimReportParser(sol_path=str(SOL), top="lcs_iso").get_transaction_cycles()
+
+    vcd = run_xsim_vcd(top="lcs_iso", comp="lcs_iso_proj", out="dump.vcd", soln="solution1",
+                       trace_level="port", workdir=HERE)
+    vp = VcdParser(VCDVCD(str(vcd), signals=None, store_tvs=True))
+    clk = vp.add_clock_signal()
+    sigs, _ = vp.add_aximm_signals(prefix="m_axi_gmem_", dir="both", lite_only=False,
+                                   short_name_prefix="gmem_")
+    wb, rb, clk_ns = vp.extract_aximm_bursts(clk_name=clk, aximm_sigs=sigs)
+    clk_ns = float(clk_ns)
+    store_ends = []
+    for j in range(nj):
+        wr = _span(wb, 2 * j * n + n, 2 * j * n + 2 * n)
+        if wr:
+            store_ends.append(wr[1] / clk_ns)
+    period = None
+    if len(store_ends) >= 3:
+        sp = [store_ends[i + 1] - store_ends[i] for i in range(len(store_ends) - 1)]
+        period = sp[len(sp) // 2 - 1]
+    return {"depth": depth, "total": int(total) if total else None,
+            "period": round(period, 1) if period else None}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=256)
+    ap.add_argument("--nj", type=int, default=6)
+    ap.add_argument("--depths", type=int, nargs="+", default=[64, 256, 512, 1024, 2048])
+    args = ap.parse_args()
+    print(f"lcs (load->compute->store)  N={args.n}/job  NJOBS={args.nj}")
+    print(f"  ideal max(read,write)={args.n}   serialized read+write={2 * args.n}\n")
+    print(f"{'depth':>6} {'depth/N':>8} {'period':>8} {'cyc/word':>9}  verdict")
+    for d in args.depths:
+        r = cosim(args.n, args.nj, d)
+        p = r["period"]
+        verd = "-" if not p else ("OVERLAP (~max)" if p < 1.5 * args.n else "serialized (~sum)")
+        cw = f"{p / args.n:.2f}" if p else "-"
+        print(f"{d:>6} {d / args.n:>8.2f} {str(p):>8} {cw:>9}  {verd}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rowwise_fir/sandbox/loadstore_iso/loadstore_iso.cpp
+++ b/examples/rowwise_fir/sandbox/loadstore_iso/loadstore_iso.cpp
@@ -1,0 +1,73 @@
+// loadstore_iso.cpp — Rung 2 of the FIR-overlap ladder: free-running load ‖ store, NO compute.
+//
+// Same free-running DATAFLOW shape as the FIR (ap_ctrl_hs + while(!done) stages + END drain + one
+// shared `gmem` m_axi bundle + a deep ld_data FIFO so load can run a job ahead), but the compute
+// stage is removed — `store` just copies what `load` read. Multi-job, back-to-back.
+//
+// Question: does load(job N)'s read burst overlap store(job N-1)'s write burst on the one bundle?
+//   period -> max(read,write)/job   => YES, the per-job free-running structure exploits full-duplex
+//                                       (so COMPUTE is what de-phases them in the real FIR)
+//   period -> read+write /job       => NO, the per-job/burst structure itself serializes the bus
+// The duplex toy already proved the *bundle* is full-duplex; this asks whether *this structure* uses it.
+#include <ap_int.h>
+#include <hls_stream.h>
+
+#define MEM_DW 32
+static const int CHUNK = 256;
+static const unsigned END_N = 0xFFFFFFFFu;
+
+namespace {
+struct Cmd { int n; unsigned xoff; unsigned yoff; bool done; };
+
+void ls_load(hls::stream<ap_uint<32> >& s_in, const ap_uint<MEM_DW>* gmem,
+             hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data) {
+    bool done = false;
+    LOAD: while (!done) {
+        unsigned n = (unsigned)s_in.read();
+        if (n == END_N) { Cmd c; c.n = 0; c.xoff = 0; c.yoff = 0; c.done = true; ld_ctrl.write(c); break; }
+        unsigned xoff = (unsigned)s_in.read();
+        unsigned yoff = (unsigned)s_in.read();
+        Cmd c; c.n = (int)n; c.xoff = xoff; c.yoff = yoff; c.done = false;
+        ld_ctrl.write(c);
+        LX: for (int base = 0; base < (int)n; base += CHUNK) {
+            int k = ((int)n - base < CHUNK) ? (int)n - base : CHUNK;
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                ld_data.write(gmem[xoff + base + i]);
+            }
+        }
+    }
+}
+
+void ls_store(hls::stream<Cmd>& ld_ctrl, hls::stream<ap_uint<MEM_DW> >& ld_data,
+              ap_uint<MEM_DW>* gmem, hls::stream<ap_uint<32> >& m_out) {
+    bool done = false;
+    STORE: while (!done) {
+        Cmd c = ld_ctrl.read();
+        if (c.done) { done = true; break; }
+        SY: for (int base = 0; base < c.n; base += CHUNK) {
+            int k = (c.n - base < CHUNK) ? c.n - base : CHUNK;
+            for (int i = 0; i < k; ++i) {
+#pragma HLS PIPELINE II=1
+                gmem[c.yoff + base + i] = ld_data.read();
+            }
+        }
+        m_out.write((ap_uint<32>)c.n);
+    }
+}
+}  // namespace
+
+void loadstore_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+                   ap_uint<MEM_DW>* gmem) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE m_axi port=gmem bundle=gmem offset=slave depth=8192
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+#pragma HLS DATAFLOW
+    hls::stream<Cmd> ld_ctrl("ld_ctrl");
+#pragma HLS STREAM variable=ld_ctrl depth=8
+    hls::stream<ap_uint<MEM_DW> > ld_data("ld_data");
+#pragma HLS STREAM variable=ld_data depth=1024
+    ls_load(s_in, gmem, ld_ctrl, ld_data);
+    ls_store(ld_ctrl, ld_data, gmem, m_out);
+}

--- a/examples/rowwise_fir/sandbox/loadstore_iso/loadstore_iso.tcl
+++ b/examples/rowwise_fir/sandbox/loadstore_iso/loadstore_iso.tcl
@@ -1,0 +1,23 @@
+# Vitis HLS driver for the load‖store toy: csim + csynth + cosim (port trace) of NJOBS×N.
+#   WAVEFLOW_LS_N / WAVEFLOW_LS_NJ   (defaults 256 / 3)
+set part {xc7z020clg484-1}
+set n 256
+if {[info exists ::env(WAVEFLOW_LS_N)]}  { set n  $::env(WAVEFLOW_LS_N) }
+set nj 3
+if {[info exists ::env(WAVEFLOW_LS_NJ)]} { set nj $::env(WAVEFLOW_LS_NJ) }
+set argv "$n $nj"
+puts "WAVEFLOW_INFO: loadstore n=$n nj=$nj"
+
+open_project -reset loadstore_iso_proj
+set_top loadstore_iso
+add_files loadstore_iso.cpp
+add_files -tb loadstore_iso_tb.cpp
+open_solution -reset "solution1"
+set_part $part
+create_clock -period 10
+
+if {[catch {csim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: csim"; puts $res; exit 1 }
+if {[catch {csynth_design} res]} { puts "WAVEFLOW_ERROR: csynth"; puts $res; exit 1 }
+if {[catch {cosim_design -argv "$argv" -trace_level port} res]} { puts "WAVEFLOW_ERROR: cosim"; puts $res; exit 1 }
+puts "WAVEFLOW_SUCCESS: loadstore n=$n nj=$nj"
+exit 0

--- a/examples/rowwise_fir/sandbox/loadstore_iso/loadstore_iso_tb.cpp
+++ b/examples/rowwise_fir/sandbox/loadstore_iso/loadstore_iso_tb.cpp
@@ -1,0 +1,42 @@
+// loadstore_iso_tb.cpp — NJOBS back-to-back copy jobs of N words each (one cosim run).
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define MEM_DW 32
+static const unsigned END_N = 0xFFFFFFFFu;
+void loadstore_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+                   ap_uint<MEM_DW>* gmem);
+
+int main(int argc, char** argv) {
+    int n  = (argc > 1) ? std::atoi(argv[1]) : 256;
+    int nj = (argc > 2) ? std::atoi(argv[2]) : 3;
+    std::vector<ap_uint<MEM_DW> > gmem(8192, 0);
+    hls::stream<ap_uint<32> > s_in("s_in"), m_out("m_out");
+
+    // job j: X at [2*j*n, 2*j*n+n), Y at [2*j*n+n, 2*j*n+2*n)
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = 2u * j * n, yoff = 2u * j * n + n;
+        for (int i = 0; i < n; ++i) gmem[xoff + i] = (ap_uint<MEM_DW>)(i + 7 * j + 1);
+        s_in.write((ap_uint<32>)n);
+        s_in.write((ap_uint<32>)xoff);
+        s_in.write((ap_uint<32>)yoff);
+    }
+    s_in.write((ap_uint<32>)END_N);
+
+    loadstore_iso(s_in, m_out, gmem.data());
+
+    int resp = 0;
+    while (!m_out.empty()) { (void)m_out.read(); ++resp; }
+    int fails = (resp != nj) ? 1 : 0;
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = 2u * j * n, yoff = 2u * j * n + n;
+        for (int i = 0; i < n; ++i)
+            if ((unsigned)gmem[yoff + i] != (unsigned)gmem[xoff + i]) { ++fails; break; }
+    }
+    if (fails) { std::fprintf(stderr, "WAVEFLOW_ERROR: loadstore N=%d nj=%d FAILED\n", n, nj); return 1; }
+    std::printf("WAVEFLOW_SUCCESS: loadstore N=%d nj=%d (%d resp)\n", n, nj, nj);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/loadstore_iso/run_loadstore_iso.py
+++ b/examples/rowwise_fir/sandbox/loadstore_iso/run_loadstore_iso.py
@@ -1,0 +1,115 @@
+"""run_loadstore_iso.py — Rung 2: free-running load||store (no compute), multi-job.
+
+Cosims NJOBS copy jobs of N words on one gmem bundle, port-traces the VCD, and asks: does
+load(job N)'s read burst overlap store(job N-1)'s write burst in time?
+
+  period -> ~max(N,N) = N   => the free-running per-job structure DOES exploit full-duplex
+  period -> ~N+N = 2N       => it serializes read+write (the FIR's behavior) — so the per-job/
+                               burst structure itself is the cause, independent of compute
+
+Run (project venv, Vitis 2025.1 + xsim)::
+
+    PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_loadstore_iso.py --n 256 --nj 3
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]
+sys.path.insert(0, str(REPO))
+
+from waveflow.toolchain import toolchain                  # noqa: E402
+from waveflow.utils.cosimparse import CosimReportParser   # noqa: E402
+
+TCL = HERE / "loadstore_iso.tcl"
+SOL = HERE / "loadstore_iso_proj" / "solution1"
+WORD_BYTES = 4
+
+
+def _beats(b: dict) -> int:
+    return sum(1 for bt in b.get("beat_type", []) if bt == 0)
+
+
+def _attr(bursts, lo_w, hi_w):
+    lo, hi = lo_w * WORD_BYTES, hi_w * WORD_BYTES
+    sel = [b for b in bursts if lo <= int(b["addr"]) < hi]
+    if not sel:
+        return None
+    t0 = min(float(b.get("data_tstart", b["tstart"])) for b in sel)
+    t1 = max(float(b["data_tend"]) for b in sel)
+    return t0, t1, sum(_beats(b) for b in sel)
+
+
+def run(n: int, nj: int) -> dict:
+    from vcdvcd import VCDVCD
+    from waveflow.scripts.xsim_vcd import run_xsim_vcd
+    from waveflow.utils.vcd import VcdParser
+
+    env = {"WAVEFLOW_LS_N": str(n), "WAVEFLOW_LS_NJ": str(nj)}
+    last = ""
+    for _ in (1, 2):
+        res = toolchain.run_vitis_hls_result(TCL, work_dir=HERE, capture_output=True, env=env)
+        last = (res.get("stdout") or "") + (res.get("stderr") or "")
+        if "WAVEFLOW_SUCCESS" in last:
+            break
+    if "WAVEFLOW_SUCCESS" not in last:
+        raise RuntimeError(f"cosim failed:\n{last[-2500:]}")
+    total = CosimReportParser(sol_path=str(SOL), top="loadstore_iso").get_transaction_cycles()
+
+    vcd = run_xsim_vcd(top="loadstore_iso", comp="loadstore_iso_proj", out="dump.vcd",
+                       soln="solution1", trace_level="port", workdir=HERE)
+    vp = VcdParser(VCDVCD(str(vcd), signals=None, store_tvs=True))
+    clk = vp.add_clock_signal()
+    sigs, _ = vp.add_aximm_signals(prefix="m_axi_gmem_", dir="both", lite_only=False,
+                                   short_name_prefix="gmem_")
+    wbursts, rbursts, clk_ns = vp.extract_aximm_bursts(clk_name=clk, aximm_sigs=sigs)
+    clk_ns = float(clk_ns)
+
+    jobs = []
+    for j in range(nj):
+        xoff, yoff = 2 * j * n, 2 * j * n + n
+        rd = _attr(rbursts, xoff, xoff + n)
+        wr = _attr(wbursts, yoff, yoff + n)
+        jobs.append({"j": j,
+                     "load": (rd[0] / clk_ns, rd[1] / clk_ns) if rd else None,
+                     "store": (wr[0] / clk_ns, wr[1] / clk_ns) if wr else None})
+
+    # overlap of load(N) read window with store(N-1) write window (cycles), and steady period
+    overlaps, store_ends = [], []
+    for j in range(nj):
+        if jobs[j]["store"]:
+            store_ends.append(jobs[j]["store"][1])
+        if j >= 1 and jobs[j]["load"] and jobs[j - 1]["store"]:
+            l0, l1 = jobs[j]["load"]
+            s0, s1 = jobs[j - 1]["store"]
+            overlaps.append(max(0.0, min(l1, s1) - max(l0, s0)))
+    period = None
+    if len(store_ends) >= 3:
+        sp = [store_ends[i + 1] - store_ends[i] for i in range(len(store_ends) - 1)]
+        period = sp[len(sp) // 2 - 1]
+    elif len(store_ends) >= 2:
+        period = store_ends[1] - store_ends[0]
+    return {"n": n, "nj": nj, "total": int(total) if total else None,
+            "period": round(period, 1) if period else None,
+            "load_store_overlap_cyc": [round(o, 1) for o in overlaps], "jobs": jobs}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=256)
+    ap.add_argument("--nj", type=int, default=4)
+    args = ap.parse_args()
+    r = run(args.n, args.nj)
+    print(f"\nload||store  N={r['n']}  NJOBS={r['nj']}  total={r['total']}  period={r['period']}")
+    print(f"  load(N) || store(N-1) time-overlap (cyc): {r['load_store_overlap_cyc']}")
+    p = r["period"]
+    if p:
+        print(f"  period vs max(read,write)={r['n']}  vs  read+write={2 * r['n']}")
+        print(f"  -> {'OVERLAPS (~max, full-duplex used)' if p < 1.5 * r['n'] else 'SERIALIZES (~sum)'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rowwise_fir/sandbox/mem_read_iso/mem_read_iso.cpp
+++ b/examples/rowwise_fir/sandbox/mem_read_iso/mem_read_iso.cpp
@@ -1,0 +1,95 @@
+// mem_read_iso.cpp — isolate the m_axi read FORM that broke cosim in the FIR hook.
+//
+// Same free-running DATAFLOW load->store copy as loadstore_iso (ap_ctrl_hs + while(!done) + END +
+// one gmem bundle), but the LOAD's read of each element is selected by -DREAD_MODE:
+//
+//   0  indexed direct      : x = u2f(mem[xoff + i])                 (the fix; loadstore_iso form)
+//   1  helper, recomputed  : my_read_lane(mem + xoff + i, &x, 1)    (read_array_slice's wp+e*WPU form)
+//   2  helper, running ptr : my_read_lane(p, &x, 1); ++p            (the form that FAILED in the hook)
+//   3  direct, base+index  : x = u2f(p[i])                          (pointer, but indexed, no ++)
+//   4  direct, running ptr : x = u2f(*p); ++p                       (running ptr WITHOUT the helper)
+//
+// `my_read_lane` replicates read_array_lane's shape exactly: #pragma HLS INLINE + a nullptr/n guard
+// + a single src[0] read through a pointer parameter — so no generated headers are needed and the
+// helper structure is the controlled variable.  The tb checks the copy is bit-exact; a mode that
+// reads the first element as 0 (the observed RTL failure) produces a mismatch at element 0.
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdint>
+
+#define MEM_DW 32
+static const unsigned END_N = 0xFFFFFFFFu;
+#ifndef READ_MODE
+#define READ_MODE 0
+#endif
+
+namespace {
+struct Cmd { int n; unsigned xoff; unsigned yoff; bool done; };
+
+inline float u2f(ap_uint<MEM_DW> u) { union { unsigned i; float f; } c; c.i = (unsigned)u; return c.f; }
+inline ap_uint<MEM_DW> f2u(float f) { union { unsigned i; float f; } c; c.f = f; return ap_uint<MEM_DW>(c.i); }
+
+// Replica of read_array_lane<32>: INLINE + guard + one read through the pointer param.
+inline void my_read_lane(const ap_uint<MEM_DW>* src, float* out, int n) {
+#pragma HLS INLINE
+    if (n > 0 && src != nullptr) out[0] = u2f(src[0]);
+}
+
+void mr_load(hls::stream<ap_uint<32> >& s_in, const ap_uint<MEM_DW>* mem,
+             hls::stream<Cmd>& ld_ctrl, hls::stream<float>& ld_data) {
+    bool done = false;
+    LOAD: while (!done) {
+        unsigned n = (unsigned)s_in.read();
+        if (n == END_N) { Cmd c; c.n = 0; c.xoff = 0; c.yoff = 0; c.done = true; ld_ctrl.write(c); break; }
+        unsigned xoff = (unsigned)s_in.read(), yoff = (unsigned)s_in.read();
+        Cmd c; c.n = (int)n; c.xoff = xoff; c.yoff = yoff; c.done = false;
+        ld_ctrl.write(c);
+        const ap_uint<MEM_DW>* p = mem + xoff;             // running/base pointer (modes 2,3,4)
+        LX: for (int i = 0; i < (int)n; ++i) {
+#pragma HLS PIPELINE II=1
+            float x;
+#if READ_MODE == 0
+            x = u2f(mem[xoff + i]);
+#elif READ_MODE == 1
+            my_read_lane(mem + xoff + i, &x, 1);
+#elif READ_MODE == 2
+            my_read_lane(p, &x, 1); ++p;
+#elif READ_MODE == 3
+            x = u2f(p[i]);
+#elif READ_MODE == 4
+            x = u2f(*p); ++p;
+#endif
+            ld_data.write(x);
+        }
+    }
+}
+
+void mr_store(hls::stream<Cmd>& ld_ctrl, hls::stream<float>& ld_data,
+              ap_uint<MEM_DW>* mem, hls::stream<ap_uint<32> >& m_out) {
+    bool done = false;
+    STORE: while (!done) {
+        Cmd c = ld_ctrl.read();
+        if (c.done) { done = true; break; }
+        SY: for (int i = 0; i < c.n; ++i) {
+#pragma HLS PIPELINE II=1
+            mem[c.yoff + i] = f2u(ld_data.read());
+        }
+        m_out.write((ap_uint<32>)c.n);
+    }
+}
+}  // namespace
+
+void mem_read_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+                  ap_uint<MEM_DW>* mem) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=m_out
+#pragma HLS INTERFACE m_axi port=mem bundle=gmem offset=slave depth=8192
+#pragma HLS INTERFACE ap_ctrl_hs port=return
+#pragma HLS DATAFLOW
+    hls::stream<Cmd> ld_ctrl("ld_ctrl");
+#pragma HLS STREAM variable=ld_ctrl depth=8
+    hls::stream<float> ld_data("ld_data");
+#pragma HLS STREAM variable=ld_data depth=1024
+    mr_load(s_in, mem, ld_ctrl, ld_data);
+    mr_store(ld_ctrl, ld_data, mem, m_out);
+}

--- a/examples/rowwise_fir/sandbox/mem_read_iso/mem_read_iso.tcl
+++ b/examples/rowwise_fir/sandbox/mem_read_iso/mem_read_iso.tcl
@@ -1,0 +1,25 @@
+# Vitis HLS driver for the m_axi read-form isolation: csim + csynth + cosim of one READ_MODE.
+#   WAVEFLOW_MR_MODE  0..4   (see mem_read_iso.cpp)     WAVEFLOW_MR_N / WAVEFLOW_MR_NJ  (64 / 3)
+set part {xc7z020clg484-1}
+set mode 0
+if {[info exists ::env(WAVEFLOW_MR_MODE)]} { set mode $::env(WAVEFLOW_MR_MODE) }
+set n 64
+if {[info exists ::env(WAVEFLOW_MR_N)]}    { set n    $::env(WAVEFLOW_MR_N) }
+set nj 3
+if {[info exists ::env(WAVEFLOW_MR_NJ)]}   { set nj   $::env(WAVEFLOW_MR_NJ) }
+set argv "$n $nj"
+puts "WAVEFLOW_INFO: mem_read_iso mode=$mode n=$n nj=$nj"
+
+open_project -reset mem_read_iso_proj
+set_top mem_read_iso
+add_files mem_read_iso.cpp -cflags "-DREAD_MODE=$mode"
+add_files -tb mem_read_iso_tb.cpp
+open_solution -reset "solution1"
+set_part $part
+create_clock -period 10
+
+if {[catch {csim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: csim"; puts $res; exit 1 }
+if {[catch {csynth_design} res]} { puts "WAVEFLOW_ERROR: csynth"; puts $res; exit 1 }
+if {[catch {cosim_design -argv "$argv"} res]} { puts "WAVEFLOW_ERROR: cosim"; puts $res; exit 1 }
+puts "WAVEFLOW_SUCCESS: mem_read_iso mode=$mode n=$n nj=$nj"
+exit 0

--- a/examples/rowwise_fir/sandbox/mem_read_iso/mem_read_iso_tb.cpp
+++ b/examples/rowwise_fir/sandbox/mem_read_iso/mem_read_iso_tb.cpp
@@ -1,0 +1,47 @@
+// mem_read_iso_tb.cpp — NJOBS copy jobs of N words; check bit-exact + report first mismatch index.
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#define MEM_DW 32
+static const unsigned END_N = 0xFFFFFFFFu;
+void mem_read_iso(hls::stream<ap_uint<32> >& s_in, hls::stream<ap_uint<32> >& m_out,
+                  ap_uint<MEM_DW>* mem);
+
+static ap_uint<MEM_DW> f2u(float f) { union { unsigned i; float f; } c; c.f = f; return ap_uint<MEM_DW>(c.i); }
+
+int main(int argc, char** argv) {
+    int n  = (argc > 1) ? std::atoi(argv[1]) : 64;
+    int nj = (argc > 2) ? std::atoi(argv[2]) : 3;
+    std::vector<ap_uint<MEM_DW> > mem(8192, 0);
+    hls::stream<ap_uint<32> > s_in("s_in"), m_out("m_out");
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = 2u * j * n, yoff = 2u * j * n + n;
+        for (int i = 0; i < n; ++i) mem[xoff + i] = f2u((float)((i % 17) * 0.5f - 4.0f + j));  // x[0] != 0
+        s_in.write((ap_uint<32>)n);
+        s_in.write((ap_uint<32>)xoff);
+        s_in.write((ap_uint<32>)yoff);
+    }
+    s_in.write((ap_uint<32>)END_N);
+    mem_read_iso(s_in, m_out, mem.data());
+    while (!m_out.empty()) (void)m_out.read();
+
+    int fails = 0;
+    for (int j = 0; j < nj; ++j) {
+        unsigned xoff = 2u * j * n, yoff = 2u * j * n + n;
+        for (int i = 0; i < n; ++i) {
+            if ((uint32_t)mem[yoff + i] != (uint32_t)mem[xoff + i]) {
+                if (fails < 4)
+                    std::fprintf(stderr, "  job %d elem %d: got 0x%08x exp 0x%08x\n",
+                                 j, i, (uint32_t)mem[yoff + i], (uint32_t)mem[xoff + i]);
+                ++fails;
+            }
+        }
+    }
+    if (fails) { std::fprintf(stderr, "WAVEFLOW_ERROR: READ_MODE mismatch, %d elems\n", fails); return 1; }
+    std::printf("WAVEFLOW_SUCCESS: mem_read_iso N=%d nj=%d bit-exact\n", n, nj);
+    return 0;
+}

--- a/examples/rowwise_fir/sandbox/mem_read_iso/run_mem_read_iso.py
+++ b/examples/rowwise_fir/sandbox/mem_read_iso/run_mem_read_iso.py
@@ -1,0 +1,57 @@
+"""run_mem_read_iso.py — isolate the m_axi read FORM that broke cosim in the FIR hook.
+
+Cosims a load->store copy for each READ_MODE and reports PASS (cosim bit-exact) / FAIL (first-read
+or other mismatch). Pins whether the trigger is the running pointer, the helper, or the combination:
+
+  0 indexed direct      | 1 helper+recomputed addr | 2 helper+running ptr
+  3 direct base+index   | 4 direct running ptr
+
+Run (project venv, Vitis 2025.1)::
+
+    PYTHONPATH=../../../.. ../../../../pysilicon-venv/Scripts/python.exe run_mem_read_iso.py
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[4]
+sys.path.insert(0, str(REPO))
+
+from waveflow.toolchain import toolchain   # noqa: E402
+
+TCL = HERE / "mem_read_iso.tcl"
+MODES = {
+    0: "indexed direct        mem[xoff+i]",
+    1: "helper + recomputed   my_read_lane(mem+xoff+i)   (read_array_slice's form)",
+    2: "helper + running ptr  my_read_lane(p); ++p       (the hook's failing form)",
+    3: "direct base+index     p[i]  (pointer, indexed, no ++)",
+    4: "direct running ptr    *p; ++p  (running ptr, no helper)",
+}
+
+
+def run(mode: int, n: int, nj: int) -> tuple[bool, str]:
+    env = {"WAVEFLOW_MR_MODE": str(mode), "WAVEFLOW_MR_N": str(n), "WAVEFLOW_MR_NJ": str(nj)}
+    res = toolchain.run_vitis_hls_result(TCL, work_dir=HERE, capture_output=True, env=env)
+    out = (res.get("stdout") or "") + (res.get("stderr") or "")
+    ok = "WAVEFLOW_SUCCESS" in out and "RTL co-simulation failed" not in out
+    m = re.search(r"job \d+ elem \d+: got 0x[0-9a-f]+ exp 0x[0-9a-f]+", out)
+    detail = m.group(0) if m else ("bit-exact" if ok else "cosim failed")
+    return ok, detail
+
+
+def main() -> None:
+    n, nj = 64, 3
+    print(f"mem_read_iso  N={n}/job  NJOBS={nj}   (does the read FORM change RTL correctness?)\n")
+    print(f"{'mode':>4}  {'verdict':>10}  form / first-mismatch")
+    for mode, desc in MODES.items():
+        ok, detail = run(mode, n, nj)
+        print(f"{mode:>4}  {('PASS' if ok else 'FAIL'):>10}  {desc}", flush=True)
+        if not ok:
+            print(f"        -> {detail}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
The free-running FIR forfeited ~1.5–1.8× throughput because the hand-written hook (`fir_pipeline_impl.tpp`) routed every X/Y transfer through `read_array_slice`/`write_array_slice` — the **resident-buffer** path (`gmem→cb→FIFO`, 2 passes) — instead of the canonical **lane loop** (stream `gmem↔FIFO` directly), per `docs/guide/vectorization/hls/raw.md`. The 2-pass buffer serialized the m_axi and killed the full-duplex `load‖store` overlap.

**Fix:** stream X/Y direct (one-pass `mem[i]` indexing + `streamutils` bit-cast, the LW=1 lane-loop shape); keep `h` as a slice (genuinely resident); `static_assert(LW==1)` guards the vectorized case.

**Result:** bit-exact on all scenarios (single/two/three/clean/error); **period 704→473 (~1.49×), single-job latency 1100→608 (~1.81×)**; occupancy unchanged.

## Isolation ladder (root-cause evidence, `sandbox/`)
- `compute_iso` — compute alone II=1.000 (not the bottleneck)
- `loadstore_iso` — load‖store (no compute) overlaps (~max)
- `lcs_iso` — load→passthrough→store overlaps at every FIFO depth
- `fir_skel` — REAL FIR compute: direct=306 OVERLAP, buffered (`-DFS_BUF`)=534 SERIALIZED
- `halfpipe`, `mem_read_iso`, `LADDER.md`

## Findings captured (deferred, not lost)
- **`read_array_lane` m_axi first-read trigger** — running pointer *exonerated* in isolation (`mem_read_iso`, all 5 forms pass); FIR-hook trigger (slice→lane mix / real helper) still open.
- **Stage B timing model marked STALE** — the fixed kernel is now a full-duplex streaming pipeline (β≈1, partial size-dependent overlap, within-job streaming), needing the double-buffered timing model, not a coefficient swap. Golden unaffected; only the sim's cycle numbers are stale. Re-model deferred to a focused task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)