### PR TITLE
Timing rung: RtlSim + ExtractBursts steps, figures, and split docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,11 @@ examples/vmac/topgen/
 examples/vmac/tput/
 examples/vmac/results/
 
+# mem_copy build outputs: the trace manifest + timing table + the rendered figures.  The figures
+# are promoted into docs/examples/memcpy/images/ by SyncDocsFiguresStep and committed THERE, so a
+# docs asset only changes when you mean it to and the change is a reviewable diff.
+examples/mem_copy/results/
+
 examples/_archive/conv2d/include/
 examples/_archive/conv2d/waveflow_conv2d_proj/
 examples/_archive/conv2d/logs/

--- a/docs/examples/memcpy/images/firing_spans.svg
+++ b/docs/examples/memcpy/images/firing_spans.svg
@@ -1,0 +1,2297 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="667.965625pt" height="289.855917pt" viewBox="0 0 667.965625 289.855917" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 289.855917 
+L 667.965625 289.855917 
+L 667.965625 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 46.965625 220.382437 
+L 660.765625 220.382437 
+L 660.765625 20.798437 
+L 46.965625 20.798437 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 74.865625 220.382437 
+L 84.283347 220.382437 
+L 84.283347 212.748077 
+L 74.865625 212.748077 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 110.182081 220.382437 
+L 119.599802 220.382437 
+L 119.599802 214.929323 
+L 110.182081 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 145.498536 220.382437 
+L 154.916258 220.382437 
+L 154.916258 214.929323 
+L 145.498536 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 180.814992 220.382437 
+L 190.232714 220.382437 
+L 190.232714 214.929323 
+L 180.814992 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 216.131448 220.382437 
+L 225.549169 220.382437 
+L 225.549169 214.929323 
+L 216.131448 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 251.447903 220.382437 
+L 260.865625 220.382437 
+L 260.865625 214.929323 
+L 251.447903 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 286.764359 220.382437 
+L 296.182081 220.382437 
+L 296.182081 214.929323 
+L 286.764359 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 322.080815 220.382437 
+L 331.498536 220.382437 
+L 331.498536 214.929323 
+L 322.080815 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 357.397271 220.382437 
+L 366.814992 220.382437 
+L 366.814992 214.929323 
+L 357.397271 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 392.713726 220.382437 
+L 402.131448 220.382437 
+L 402.131448 214.929323 
+L 392.713726 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 428.030182 220.382437 
+L 437.447903 220.382437 
+L 437.447903 214.929323 
+L 428.030182 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 463.346638 220.382437 
+L 472.764359 220.382437 
+L 472.764359 214.929323 
+L 463.346638 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 498.663093 220.382437 
+L 508.080815 220.382437 
+L 508.080815 214.929323 
+L 498.663093 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 533.979549 220.382437 
+L 543.397271 220.382437 
+L 543.397271 214.929323 
+L 533.979549 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 569.296005 220.382437 
+L 578.713726 220.382437 
+L 578.713726 214.929323 
+L 569.296005 214.929323 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 604.61246 220.382437 
+L 614.030182 220.382437 
+L 614.030182 213.8387 
+L 604.61246 213.8387 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #4c78a8"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 74.865625 212.748077 
+L 84.283347 212.748077 
+L 84.283347 211.657454 
+L 74.865625 211.657454 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 110.182081 214.929323 
+L 119.599802 214.929323 
+L 119.599802 54.607749 
+L 110.182081 54.607749 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 145.498536 214.929323 
+L 154.916258 214.929323 
+L 154.916258 21.88906 
+L 145.498536 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 180.814992 214.929323 
+L 190.232714 214.929323 
+L 190.232714 21.88906 
+L 180.814992 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 216.131448 214.929323 
+L 225.549169 214.929323 
+L 225.549169 21.88906 
+L 216.131448 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 251.447903 214.929323 
+L 260.865625 214.929323 
+L 260.865625 21.88906 
+L 251.447903 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 286.764359 214.929323 
+L 296.182081 214.929323 
+L 296.182081 21.88906 
+L 286.764359 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 322.080815 214.929323 
+L 331.498536 214.929323 
+L 331.498536 21.88906 
+L 322.080815 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 357.397271 214.929323 
+L 366.814992 214.929323 
+L 366.814992 21.88906 
+L 357.397271 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 392.713726 214.929323 
+L 402.131448 214.929323 
+L 402.131448 21.88906 
+L 392.713726 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 428.030182 214.929323 
+L 437.447903 214.929323 
+L 437.447903 21.88906 
+L 428.030182 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 463.346638 214.929323 
+L 472.764359 214.929323 
+L 472.764359 21.88906 
+L 463.346638 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 498.663093 214.929323 
+L 508.080815 214.929323 
+L 508.080815 21.88906 
+L 498.663093 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 533.979549 214.929323 
+L 543.397271 214.929323 
+L 543.397271 21.88906 
+L 533.979549 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 569.296005 214.929323 
+L 578.713726 214.929323 
+L 578.713726 21.88906 
+L 569.296005 21.88906 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 604.61246 213.8387 
+L 614.030182 213.8387 
+L 614.030182 20.798437 
+L 604.61246 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 84.283347 220.382437 
+L 93.701068 220.382437 
+L 93.701068 53.517126 
+L 84.283347 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 119.599802 220.382437 
+L 129.017524 220.382437 
+L 129.017524 53.517126 
+L 119.599802 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 154.916258 220.382437 
+L 164.333979 220.382437 
+L 164.333979 53.517126 
+L 154.916258 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 190.232714 220.382437 
+L 199.650435 220.382437 
+L 199.650435 53.517126 
+L 190.232714 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 225.549169 220.382437 
+L 234.966891 220.382437 
+L 234.966891 53.517126 
+L 225.549169 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 260.865625 220.382437 
+L 270.283347 220.382437 
+L 270.283347 53.517126 
+L 260.865625 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 296.182081 220.382437 
+L 305.599802 220.382437 
+L 305.599802 53.517126 
+L 296.182081 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 331.498536 220.382437 
+L 340.916258 220.382437 
+L 340.916258 53.517126 
+L 331.498536 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 366.814992 220.382437 
+L 376.232714 220.382437 
+L 376.232714 53.517126 
+L 366.814992 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 402.131448 220.382437 
+L 411.549169 220.382437 
+L 411.549169 53.517126 
+L 402.131448 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 437.447903 220.382437 
+L 446.865625 220.382437 
+L 446.865625 53.517126 
+L 437.447903 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 472.764359 220.382437 
+L 482.182081 220.382437 
+L 482.182081 53.517126 
+L 472.764359 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 508.080815 220.382437 
+L 517.498536 220.382437 
+L 517.498536 53.517126 
+L 508.080815 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 543.397271 220.382437 
+L 552.814992 220.382437 
+L 552.814992 53.517126 
+L 543.397271 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 578.713726 220.382437 
+L 588.131448 220.382437 
+L 588.131448 53.517126 
+L 578.713726 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 614.030182 220.382437 
+L 623.447903 220.382437 
+L 623.447903 53.517126 
+L 614.030182 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #e45756"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 84.283347 53.517126 
+L 93.701068 53.517126 
+L 93.701068 53.517126 
+L 84.283347 53.517126 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 119.599802 53.517126 
+L 129.017524 53.517126 
+L 129.017524 20.798437 
+L 119.599802 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 154.916258 53.517126 
+L 164.333979 53.517126 
+L 164.333979 20.798437 
+L 154.916258 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 190.232714 53.517126 
+L 199.650435 53.517126 
+L 199.650435 20.798437 
+L 190.232714 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 225.549169 53.517126 
+L 234.966891 53.517126 
+L 234.966891 20.798437 
+L 225.549169 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_56">
+    <path d="M 260.865625 53.517126 
+L 270.283347 53.517126 
+L 270.283347 20.798437 
+L 260.865625 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 296.182081 53.517126 
+L 305.599802 53.517126 
+L 305.599802 20.798437 
+L 296.182081 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 331.498536 53.517126 
+L 340.916258 53.517126 
+L 340.916258 20.798437 
+L 331.498536 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 366.814992 53.517126 
+L 376.232714 53.517126 
+L 376.232714 20.798437 
+L 366.814992 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 402.131448 53.517126 
+L 411.549169 53.517126 
+L 411.549169 20.798437 
+L 402.131448 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 437.447903 53.517126 
+L 446.865625 53.517126 
+L 446.865625 20.798437 
+L 437.447903 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_62">
+    <path d="M 472.764359 53.517126 
+L 482.182081 53.517126 
+L 482.182081 20.798437 
+L 472.764359 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_63">
+    <path d="M 508.080815 53.517126 
+L 517.498536 53.517126 
+L 517.498536 20.798437 
+L 508.080815 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_64">
+    <path d="M 543.397271 53.517126 
+L 552.814992 53.517126 
+L 552.814992 20.798437 
+L 543.397271 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_65">
+    <path d="M 578.713726 53.517126 
+L 588.131448 53.517126 
+L 588.131448 20.798437 
+L 578.713726 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_66">
+    <path d="M 614.030182 53.517126 
+L 623.447903 53.517126 
+L 623.447903 20.798437 
+L 614.030182 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #e45756; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_67">
+    <path d="M 93.701068 220.382437 
+L 103.11879 220.382437 
+L 103.11879 20.798437 
+L 93.701068 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_68">
+    <path d="M 129.017524 220.382437 
+L 138.435245 220.382437 
+L 138.435245 20.798437 
+L 129.017524 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_69">
+    <path d="M 164.333979 220.382437 
+L 173.751701 220.382437 
+L 173.751701 20.798437 
+L 164.333979 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_70">
+    <path d="M 199.650435 220.382437 
+L 209.068157 220.382437 
+L 209.068157 20.798437 
+L 199.650435 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_71">
+    <path d="M 234.966891 220.382437 
+L 244.384612 220.382437 
+L 244.384612 20.798437 
+L 234.966891 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_72">
+    <path d="M 270.283347 220.382437 
+L 279.701068 220.382437 
+L 279.701068 20.798437 
+L 270.283347 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_73">
+    <path d="M 305.599802 220.382437 
+L 315.017524 220.382437 
+L 315.017524 20.798437 
+L 305.599802 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_74">
+    <path d="M 340.916258 220.382437 
+L 350.333979 220.382437 
+L 350.333979 20.798437 
+L 340.916258 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_75">
+    <path d="M 376.232714 220.382437 
+L 385.650435 220.382437 
+L 385.650435 20.798437 
+L 376.232714 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_76">
+    <path d="M 411.549169 220.382437 
+L 420.966891 220.382437 
+L 420.966891 20.798437 
+L 411.549169 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_77">
+    <path d="M 446.865625 220.382437 
+L 456.283347 220.382437 
+L 456.283347 20.798437 
+L 446.865625 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_78">
+    <path d="M 482.182081 220.382437 
+L 491.599802 220.382437 
+L 491.599802 20.798437 
+L 482.182081 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_79">
+    <path d="M 517.498536 220.382437 
+L 526.916258 220.382437 
+L 526.916258 20.798437 
+L 517.498536 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_80">
+    <path d="M 552.814992 220.382437 
+L 562.232714 220.382437 
+L 562.232714 20.798437 
+L 552.814992 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_81">
+    <path d="M 588.131448 220.382437 
+L 597.549169 220.382437 
+L 597.549169 20.798437 
+L 588.131448 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_82">
+    <path d="M 623.447903 220.382437 
+L 632.865625 220.382437 
+L 632.865625 20.798437 
+L 623.447903 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #54a24b"/>
+   </g>
+   <g id="patch_83">
+    <path d="M 93.701068 20.798437 
+L 103.11879 20.798437 
+L 103.11879 20.798437 
+L 93.701068 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_84">
+    <path d="M 129.017524 20.798437 
+L 138.435245 20.798437 
+L 138.435245 20.798437 
+L 129.017524 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_85">
+    <path d="M 164.333979 20.798437 
+L 173.751701 20.798437 
+L 173.751701 20.798437 
+L 164.333979 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_86">
+    <path d="M 199.650435 20.798437 
+L 209.068157 20.798437 
+L 209.068157 20.798437 
+L 199.650435 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_87">
+    <path d="M 234.966891 20.798437 
+L 244.384612 20.798437 
+L 244.384612 20.798437 
+L 234.966891 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_88">
+    <path d="M 270.283347 20.798437 
+L 279.701068 20.798437 
+L 279.701068 20.798437 
+L 270.283347 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_89">
+    <path d="M 305.599802 20.798437 
+L 315.017524 20.798437 
+L 315.017524 20.798437 
+L 305.599802 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_90">
+    <path d="M 340.916258 20.798437 
+L 350.333979 20.798437 
+L 350.333979 20.798437 
+L 340.916258 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_91">
+    <path d="M 376.232714 20.798437 
+L 385.650435 20.798437 
+L 385.650435 20.798437 
+L 376.232714 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_92">
+    <path d="M 411.549169 20.798437 
+L 420.966891 20.798437 
+L 420.966891 20.798437 
+L 411.549169 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_93">
+    <path d="M 446.865625 20.798437 
+L 456.283347 20.798437 
+L 456.283347 20.798437 
+L 446.865625 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_94">
+    <path d="M 482.182081 20.798437 
+L 491.599802 20.798437 
+L 491.599802 20.798437 
+L 482.182081 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_95">
+    <path d="M 517.498536 20.798437 
+L 526.916258 20.798437 
+L 526.916258 20.798437 
+L 517.498536 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_96">
+    <path d="M 552.814992 20.798437 
+L 562.232714 20.798437 
+L 562.232714 20.798437 
+L 552.814992 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_97">
+    <path d="M 588.131448 20.798437 
+L 597.549169 20.798437 
+L 597.549169 20.798437 
+L 588.131448 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_98">
+    <path d="M 623.447903 20.798437 
+L 632.865625 20.798437 
+L 632.865625 20.798437 
+L 623.447903 20.798437 
+z
+" clip-path="url(#pf6f828ec16)" style="fill: #c7c7c7; stroke: #54a24b; stroke-width: 0.4; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m91400e4105" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m91400e4105" x="88.992207" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(85.810957 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m91400e4105" x="124.308663" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 -->
+      <g transform="translate(121.127413 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m91400e4105" x="159.625119" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 2 -->
+      <g transform="translate(156.443869 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m91400e4105" x="194.941574" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 3 -->
+      <g transform="translate(191.760324 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m91400e4105" x="230.25803" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4 -->
+      <g transform="translate(227.07678 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m91400e4105" x="265.574486" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 5 -->
+      <g transform="translate(262.393236 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m91400e4105" x="300.890941" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 6 -->
+      <g transform="translate(297.709691 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m91400e4105" x="336.207397" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 7 -->
+      <g transform="translate(333.026147 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m91400e4105" x="371.523853" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 8 -->
+      <g transform="translate(368.342603 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m91400e4105" x="406.840309" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 9 -->
+      <g transform="translate(403.659059 234.980875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-39"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m91400e4105" x="442.156764" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 -->
+      <g transform="translate(435.794264 234.980875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m91400e4105" x="477.47322" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 11 -->
+      <g transform="translate(471.11072 234.980875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m91400e4105" x="512.789676" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 12 -->
+      <g transform="translate(506.427176 234.980875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m91400e4105" x="548.106131" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 13 -->
+      <g transform="translate(541.743631 234.980875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m91400e4105" x="583.422587" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 14 -->
+      <g transform="translate(577.060087 234.980875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m91400e4105" x="618.739043" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 15 -->
+      <g transform="translate(612.376543 234.980875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- firing (job index) -->
+     <g transform="translate(312.546094 248.659) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6a" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-66"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(35.205078 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(62.988281 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(104.101562 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(131.884766 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(195.263672 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(258.740234 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(290.527344 0)"/>
+      <use xlink:href="#DejaVuSans-6a" transform="translate(329.541016 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(357.324219 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(418.505859 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(481.982422 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(513.769531 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(541.552734 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(604.931641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(668.408203 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(728.181641 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(787.361328 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_17">
+      <path d="M 46.965625 220.382437 
+L 660.765625 220.382437 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <defs>
+       <path id="mdb56eb61dd" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="220.382437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0 -->
+      <g transform="translate(33.603125 224.181656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_19">
+      <path d="M 46.965625 193.116864 
+L 660.765625 193.116864 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="193.116864" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 25 -->
+      <g transform="translate(27.240625 196.916082) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_21">
+      <path d="M 46.965625 165.85129 
+L 660.765625 165.85129 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="165.85129" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 50 -->
+      <g transform="translate(27.240625 169.650509) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_23">
+      <path d="M 46.965625 138.585716 
+L 660.765625 138.585716 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="138.585716" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 75 -->
+      <g transform="translate(27.240625 142.384935) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_25">
+      <path d="M 46.965625 111.320142 
+L 660.765625 111.320142 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="111.320142" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 100 -->
+      <g transform="translate(20.878125 115.119361) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_27">
+      <path d="M 46.965625 84.054569 
+L 660.765625 84.054569 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="84.054569" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 125 -->
+      <g transform="translate(20.878125 87.853787) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_29">
+      <path d="M 46.965625 56.788995 
+L 660.765625 56.788995 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="56.788995" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 150 -->
+      <g transform="translate(20.878125 60.588214) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_31">
+      <path d="M 46.965625 29.523421 
+L 660.765625 29.523421 
+" clip-path="url(#pf6f828ec16)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="46.965625" y="29.523421" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 175 -->
+      <g transform="translate(20.878125 33.32264) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_26">
+     <!-- span (cycles) -->
+     <g transform="translate(14.798437 153.620906) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-73"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(52.099609 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(115.576172 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(176.855469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(240.234375 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(272.021484 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(311.035156 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(366.015625 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(425.195312 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(480.175781 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(507.958984 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(569.482422 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(621.582031 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_99">
+    <path d="M 46.965625 220.382437 
+L 46.965625 20.798437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_100">
+    <path d="M 46.965625 220.382437 
+L 660.765625 220.382437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_27">
+    <!-- per-firing span — colour is the component's own work, grey is waiting -->
+    <g transform="translate(179.313281 14.798437) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-27" d="M 1147 4666 
+L 1147 2931 
+L 616 2931 
+L 616 4666 
+L 1147 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-70"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(125 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(159.738281 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(195.822266 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(231.027344 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(258.810547 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(299.923828 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(327.707031 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(391.085938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(454.5625 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(486.349609 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(538.449219 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(601.925781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(663.205078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(726.583984 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(758.371094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(858.371094 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(890.158203 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(945.138672 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1006.320312 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1034.103516 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1095.285156 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1158.664062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1199.777344 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1231.564453 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1259.347656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1311.447266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1343.234375 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(1382.443359 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1445.822266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1507.345703 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1539.132812 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1594.113281 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1655.294922 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1752.707031 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1816.183594 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1877.365234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1940.744141 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2002.267578 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2065.646484 0)"/>
+     <use xlink:href="#DejaVuSans-27" transform="translate(2104.855469 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2132.345703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2184.445312 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2216.232422 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(2277.414062 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2359.201172 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2422.580078 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(2454.367188 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2536.154297 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2597.335938 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(2638.449219 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2696.359375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2728.146484 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2759.933594 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2823.410156 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2862.273438 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(2923.796875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2982.976562 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3014.763672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3042.546875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3094.646484 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(3126.433594 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3208.220703 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3269.5 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3297.283203 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3336.492188 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3364.275391 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(3427.654297 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_101">
+     <path d="M 135.3125 277.569667 
+L 151.3125 277.569667 
+L 151.3125 271.969667 
+L 135.3125 271.969667 
+z
+" style="fill: #4c78a8"/>
+    </g>
+    <g id="text_28">
+     <!-- mem_seq -->
+     <g transform="translate(157.7125 277.569667) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(158.935547 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(256.347656 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(306.347656 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(358.447266 0)"/>
+      <use xlink:href="#DejaVuSans-71" transform="translate(419.970703 0)"/>
+     </g>
+    </g>
+    <g id="patch_102">
+     <path d="M 212.38875 277.569667 
+L 228.38875 277.569667 
+L 228.38875 271.969667 
+L 212.38875 271.969667 
+z
+" style="fill: #c7c7c7; stroke: #4c78a8; stroke-width: 0.4; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_29">
+     <!-- blocked (waiting on a full channel) -->
+     <g transform="translate(234.78875 277.569667) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-62"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(91.259766 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(152.441406 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(207.421875 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(261.707031 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(323.230469 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(386.707031 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(418.494141 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(457.507812 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(539.294922 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(600.574219 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(628.357422 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(667.566406 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(695.349609 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(758.728516 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(822.205078 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(853.992188 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(915.173828 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(978.552734 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1010.339844 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1071.619141 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(1103.40625 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1138.611328 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1201.990234 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1229.773438 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1257.556641 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(1289.34375 0)"/>
+      <use xlink:href="#DejaVuSans-68" transform="translate(1344.324219 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1407.703125 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1468.982422 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1532.361328 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1595.740234 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1657.263672 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1685.046875 0)"/>
+     </g>
+    </g>
+    <g id="patch_103">
+     <path d="M 388.7125 277.569667 
+L 404.7125 277.569667 
+L 404.7125 271.969667 
+L 388.7125 271.969667 
+z
+" style="fill: #e45756"/>
+    </g>
+    <g id="text_30">
+     <!-- mem_r_stream -->
+     <g transform="translate(411.1125 277.569667) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(158.935547 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(256.347656 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(306.347656 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(347.460938 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(397.460938 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(449.560547 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(488.769531 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(527.632812 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(589.15625 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(650.435547 0)"/>
+     </g>
+    </g>
+    <g id="patch_104">
+     <path d="M 486.93875 277.569667 
+L 502.93875 277.569667 
+L 502.93875 271.969667 
+L 486.93875 271.969667 
+z
+" style="fill: #54a24b"/>
+    </g>
+    <g id="text_31">
+     <!-- mem_w_stream -->
+     <g transform="translate(509.33875 277.569667) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(158.935547 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(256.347656 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(306.347656 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(388.134766 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(438.134766 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(490.234375 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(529.443359 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(568.306641 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(629.830078 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(691.109375 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pf6f828ec16">
+   <rect x="46.965625" y="20.798437" width="613.8" height="199.584"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/examples/memcpy/images/timeline_full.svg
+++ b/docs/examples/memcpy/images/timeline_full.svg
@@ -1,0 +1,3951 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="688.70125pt" height="291.202688pt" viewBox="0 0 688.70125 291.202688" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M -0 291.202688 
+L 688.70125 291.202688 
+L 688.70125 0 
+L -0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 67.70125 253.646438 
+L 681.50125 253.646438 
+L 681.50125 20.798437 
+L 67.70125 20.798437 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 67.70125 253.646438 
+L 67.70125 20.798437 
+" clip-path="url(#p7bea268345)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m91400e4105" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m91400e4105" x="67.70125" y="253.646438" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(64.52 268.244875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 170.446479 253.646438 
+L 170.446479 20.798437 
+" clip-path="url(#p7bea268345)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m91400e4105" x="170.446479" y="253.646438" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 500 -->
+      <g transform="translate(160.902729 268.244875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 273.191709 253.646438 
+L 273.191709 20.798437 
+" clip-path="url(#p7bea268345)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m91400e4105" x="273.191709" y="253.646438" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1000 -->
+      <g transform="translate(260.466709 268.244875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 375.936938 253.646438 
+L 375.936938 20.798437 
+" clip-path="url(#p7bea268345)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m91400e4105" x="375.936938" y="253.646438" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1500 -->
+      <g transform="translate(363.211938 268.244875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 478.682167 253.646438 
+L 478.682167 20.798437 
+" clip-path="url(#p7bea268345)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m91400e4105" x="478.682167" y="253.646438" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 2000 -->
+      <g transform="translate(465.957167 268.244875) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 581.427397 253.646438 
+L 581.427397 20.798437 
+" clip-path="url(#p7bea268345)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m91400e4105" x="581.427397" y="253.646438" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 2500 -->
+      <g transform="translate(568.702397 268.244875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_7">
+     <!-- clock cycle -->
+     <g transform="translate(347.246563 281.923) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(82.763672 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(143.945312 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(198.925781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(256.835938 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(288.623047 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(343.603516 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(402.783203 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(457.763672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(485.546875 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_13">
+      <defs>
+       <path id="mdb56eb61dd" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="235.627396" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- s_done out -->
+      <g transform="translate(16.92375 238.666771) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(52.099609 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(102.099609 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(165.576172 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(226.757812 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(290.136719 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(351.660156 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-75" transform="translate(444.628906 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(508.007812 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="213.759628" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- gmem1 W -->
+      <g transform="translate(19.5725 216.799003) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(415.234375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="191.891859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- gmem1 AW -->
+      <g transform="translate(14.54 194.931234) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-41" transform="translate(415.234375 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(478.142578 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="170.02409" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- copy_data rd -->
+      <g transform="translate(8.80375 173.063465) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(116.162109 0)"/>
+       <use xlink:href="#DejaVuSans-79" transform="translate(179.638672 0)"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(238.818359 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(288.818359 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(352.294922 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(413.574219 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(452.783203 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(514.0625 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(545.849609 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(585.212891 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="148.156322" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- copy_data wr -->
+      <g transform="translate(7.2 151.195697) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(116.162109 0)"/>
+       <use xlink:href="#DejaVuSans-79" transform="translate(179.638672 0)"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(238.818359 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(288.818359 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(352.294922 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(413.574219 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(452.783203 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(514.0625 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(545.849609 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(627.636719 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="126.288553" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- gmem0 R -->
+      <g transform="translate(21.92375 129.327928) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(415.234375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="104.420785" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- gmem0 AR -->
+      <g transform="translate(16.45125 107.46016) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-41" transform="translate(415.234375 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(483.642578 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="82.553016" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- cmd read -->
+      <g transform="translate(22.87625 85.592391) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(152.392578 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(215.869141 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(247.65625 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(286.519531 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(348.042969 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(409.322266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="60.685247" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- cmd write -->
+      <g transform="translate(20.77625 63.724622) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(152.392578 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(215.869141 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(247.65625 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(329.443359 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(370.556641 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(398.339844 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(437.548828 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="38.817479" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- s_cmd in -->
+      <g transform="translate(25.42875 41.856854) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(52.099609 0)"/>
+       <use xlink:href="#DejaVuSans-63" transform="translate(102.099609 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(157.080078 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(254.492188 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(317.96875 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(349.755859 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(377.539062 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="PolyCollection_1">
+    <path d="M 71.194588 46.25252 
+L 71.194588 31.382437 
+L 71.811059 31.382437 
+L 71.811059 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 73.044002 46.25252 
+L 73.044002 31.382437 
+L 73.249492 31.382437 
+L 73.249492 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 104.484042 46.25252 
+L 104.484042 31.382437 
+L 104.689533 31.382437 
+L 104.689533 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 142.088796 46.25252 
+L 142.088796 31.382437 
+L 142.294286 31.382437 
+L 142.294286 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 179.69355 46.25252 
+L 179.69355 31.382437 
+L 179.89904 31.382437 
+L 179.89904 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 217.298304 46.25252 
+L 217.298304 31.382437 
+L 217.503794 31.382437 
+L 217.503794 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 254.903058 46.25252 
+L 254.903058 31.382437 
+L 255.108548 31.382437 
+L 255.108548 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 292.507812 46.25252 
+L 292.507812 31.382437 
+L 292.713302 31.382437 
+L 292.713302 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 330.112566 46.25252 
+L 330.112566 31.382437 
+L 330.318056 31.382437 
+L 330.318056 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 367.71732 46.25252 
+L 367.71732 31.382437 
+L 367.92281 31.382437 
+L 367.92281 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 405.322074 46.25252 
+L 405.322074 31.382437 
+L 405.527564 31.382437 
+L 405.527564 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 442.926828 46.25252 
+L 442.926828 31.382437 
+L 443.132318 31.382437 
+L 443.132318 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 480.531581 46.25252 
+L 480.531581 31.382437 
+L 480.737072 31.382437 
+L 480.737072 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 518.136335 46.25252 
+L 518.136335 31.382437 
+L 518.341826 31.382437 
+L 518.341826 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 555.741089 46.25252 
+L 555.741089 31.382437 
+L 555.94658 31.382437 
+L 555.94658 46.25252 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_2">
+    <path d="M 71.605569 68.120289 
+L 71.605569 53.250206 
+L 73.249492 53.250206 
+L 73.249492 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 103.45659 68.120289 
+L 103.45659 53.250206 
+L 104.484042 53.250206 
+L 104.484042 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 110.648756 68.120289 
+L 110.648756 53.250206 
+L 110.854246 53.250206 
+L 110.854246 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 141.061344 68.120289 
+L 141.061344 53.250206 
+L 142.088796 53.250206 
+L 142.088796 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 148.25351 68.120289 
+L 148.25351 53.250206 
+L 148.459 53.250206 
+L 148.459 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 178.666098 68.120289 
+L 178.666098 53.250206 
+L 179.69355 53.250206 
+L 179.69355 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 185.858264 68.120289 
+L 185.858264 53.250206 
+L 186.063754 53.250206 
+L 186.063754 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 216.270852 68.120289 
+L 216.270852 53.250206 
+L 217.298304 53.250206 
+L 217.298304 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 223.463018 68.120289 
+L 223.463018 53.250206 
+L 223.668508 53.250206 
+L 223.668508 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 253.875606 68.120289 
+L 253.875606 53.250206 
+L 254.903058 53.250206 
+L 254.903058 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 261.067772 68.120289 
+L 261.067772 53.250206 
+L 261.273262 53.250206 
+L 261.273262 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 291.480359 68.120289 
+L 291.480359 53.250206 
+L 292.507812 53.250206 
+L 292.507812 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 298.672526 68.120289 
+L 298.672526 53.250206 
+L 298.878016 53.250206 
+L 298.878016 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 329.085113 68.120289 
+L 329.085113 53.250206 
+L 330.112566 53.250206 
+L 330.112566 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 336.277279 68.120289 
+L 336.277279 53.250206 
+L 336.48277 53.250206 
+L 336.48277 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 366.689867 68.120289 
+L 366.689867 53.250206 
+L 367.71732 53.250206 
+L 367.71732 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 373.882033 68.120289 
+L 373.882033 53.250206 
+L 374.087524 53.250206 
+L 374.087524 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 404.294621 68.120289 
+L 404.294621 53.250206 
+L 405.322074 53.250206 
+L 405.322074 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 411.486787 68.120289 
+L 411.486787 53.250206 
+L 411.692278 53.250206 
+L 411.692278 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 441.899375 68.120289 
+L 441.899375 53.250206 
+L 442.926828 53.250206 
+L 442.926828 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 449.091541 68.120289 
+L 449.091541 53.250206 
+L 449.297032 53.250206 
+L 449.297032 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 479.504129 68.120289 
+L 479.504129 53.250206 
+L 480.531581 53.250206 
+L 480.531581 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 486.696295 68.120289 
+L 486.696295 53.250206 
+L 486.901786 53.250206 
+L 486.901786 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 517.108883 68.120289 
+L 517.108883 53.250206 
+L 518.136335 53.250206 
+L 518.136335 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 524.301049 68.120289 
+L 524.301049 53.250206 
+L 524.50654 53.250206 
+L 524.50654 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 554.713637 68.120289 
+L 554.713637 53.250206 
+L 555.741089 53.250206 
+L 555.741089 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 561.905803 68.120289 
+L 561.905803 53.250206 
+L 562.111294 53.250206 
+L 562.111294 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 592.318391 68.120289 
+L 592.318391 53.250206 
+L 593.345843 53.250206 
+L 593.345843 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 599.510557 68.120289 
+L 599.510557 53.250206 
+L 599.716047 53.250206 
+L 599.716047 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 629.923145 68.120289 
+L 629.923145 53.250206 
+L 630.539616 53.250206 
+L 630.539616 68.120289 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_3">
+    <path d="M 71.811059 89.988057 
+L 71.811059 75.117975 
+L 72.838511 75.117975 
+L 72.838511 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 103.251099 89.988057 
+L 103.251099 75.117975 
+L 104.073061 75.117975 
+L 104.073061 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 110.443265 89.988057 
+L 110.443265 75.117975 
+L 110.648756 75.117975 
+L 110.648756 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 140.855853 89.988057 
+L 140.855853 75.117975 
+L 141.677815 75.117975 
+L 141.677815 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 148.048019 89.988057 
+L 148.048019 75.117975 
+L 148.25351 75.117975 
+L 148.25351 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 178.460607 89.988057 
+L 178.460607 75.117975 
+L 179.282569 75.117975 
+L 179.282569 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 185.652773 89.988057 
+L 185.652773 75.117975 
+L 185.858264 75.117975 
+L 185.858264 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 216.065361 89.988057 
+L 216.065361 75.117975 
+L 216.887323 75.117975 
+L 216.887323 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 223.257527 89.988057 
+L 223.257527 75.117975 
+L 223.463018 75.117975 
+L 223.463018 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 253.670115 89.988057 
+L 253.670115 75.117975 
+L 254.492077 75.117975 
+L 254.492077 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 260.862281 89.988057 
+L 260.862281 75.117975 
+L 261.067772 75.117975 
+L 261.067772 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 291.274869 89.988057 
+L 291.274869 75.117975 
+L 292.096831 75.117975 
+L 292.096831 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 298.467035 89.988057 
+L 298.467035 75.117975 
+L 298.672526 75.117975 
+L 298.672526 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 328.879623 89.988057 
+L 328.879623 75.117975 
+L 329.701585 75.117975 
+L 329.701585 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 336.071789 89.988057 
+L 336.071789 75.117975 
+L 336.277279 75.117975 
+L 336.277279 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 366.484377 89.988057 
+L 366.484377 75.117975 
+L 367.306339 75.117975 
+L 367.306339 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 373.676543 89.988057 
+L 373.676543 75.117975 
+L 373.882033 75.117975 
+L 373.882033 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 404.089131 89.988057 
+L 404.089131 75.117975 
+L 404.911093 75.117975 
+L 404.911093 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 411.281297 89.988057 
+L 411.281297 75.117975 
+L 411.486787 75.117975 
+L 411.486787 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 441.693885 89.988057 
+L 441.693885 75.117975 
+L 442.515847 75.117975 
+L 442.515847 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 448.886051 89.988057 
+L 448.886051 75.117975 
+L 449.091541 75.117975 
+L 449.091541 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 479.298639 89.988057 
+L 479.298639 75.117975 
+L 480.120601 75.117975 
+L 480.120601 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 486.490805 89.988057 
+L 486.490805 75.117975 
+L 486.696295 75.117975 
+L 486.696295 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 516.903393 89.988057 
+L 516.903393 75.117975 
+L 517.725354 75.117975 
+L 517.725354 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 524.095559 89.988057 
+L 524.095559 75.117975 
+L 524.301049 75.117975 
+L 524.301049 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 554.508147 89.988057 
+L 554.508147 75.117975 
+L 555.330108 75.117975 
+L 555.330108 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 561.700313 89.988057 
+L 561.700313 75.117975 
+L 561.905803 75.117975 
+L 561.905803 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 592.1129 89.988057 
+L 592.1129 75.117975 
+L 592.934862 75.117975 
+L 592.934862 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 599.305067 89.988057 
+L 599.305067 75.117975 
+L 599.510557 75.117975 
+L 599.510557 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 629.717654 89.988057 
+L 629.717654 75.117975 
+L 630.539616 75.117975 
+L 630.539616 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+    <path d="M 636.90982 89.988057 
+L 636.90982 75.117975 
+L 637.115311 75.117975 
+L 637.115311 89.988057 
+z
+" clip-path="url(#p7bea268345)" style="fill: #4c78a8; stroke: #4c78a8; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_4">
+    <path d="M 74.482435 111.855826 
+L 74.482435 96.985743 
+L 74.687926 96.985743 
+L 74.687926 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 77.975773 111.855826 
+L 77.975773 96.985743 
+L 78.181263 96.985743 
+L 78.181263 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 81.469111 111.855826 
+L 81.469111 96.985743 
+L 81.674601 96.985743 
+L 81.674601 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 84.962449 111.855826 
+L 84.962449 96.985743 
+L 85.167939 96.985743 
+L 85.167939 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 88.455786 111.855826 
+L 88.455786 96.985743 
+L 88.661277 96.985743 
+L 88.661277 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 91.949124 111.855826 
+L 91.949124 96.985743 
+L 92.154615 96.985743 
+L 92.154615 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 95.442462 111.855826 
+L 95.442462 96.985743 
+L 95.647952 96.985743 
+L 95.647952 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 98.9358 111.855826 
+L 98.9358 96.985743 
+L 99.14129 96.985743 
+L 99.14129 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 112.087189 111.855826 
+L 112.087189 96.985743 
+L 112.29268 96.985743 
+L 112.29268 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 115.580527 111.855826 
+L 115.580527 96.985743 
+L 115.786017 96.985743 
+L 115.786017 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 119.073865 111.855826 
+L 119.073865 96.985743 
+L 119.279355 96.985743 
+L 119.279355 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 122.567202 111.855826 
+L 122.567202 96.985743 
+L 122.772693 96.985743 
+L 122.772693 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 126.06054 111.855826 
+L 126.06054 96.985743 
+L 126.266031 96.985743 
+L 126.266031 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 129.553878 111.855826 
+L 129.553878 96.985743 
+L 129.759369 96.985743 
+L 129.759369 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 133.047216 111.855826 
+L 133.047216 96.985743 
+L 133.252706 96.985743 
+L 133.252706 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 136.540554 111.855826 
+L 136.540554 96.985743 
+L 136.746044 96.985743 
+L 136.746044 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 149.691943 111.855826 
+L 149.691943 96.985743 
+L 149.897433 96.985743 
+L 149.897433 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 153.185281 111.855826 
+L 153.185281 96.985743 
+L 153.390771 96.985743 
+L 153.390771 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 156.678619 111.855826 
+L 156.678619 96.985743 
+L 156.884109 96.985743 
+L 156.884109 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 160.171956 111.855826 
+L 160.171956 96.985743 
+L 160.377447 96.985743 
+L 160.377447 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 163.665294 111.855826 
+L 163.665294 96.985743 
+L 163.870785 96.985743 
+L 163.870785 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 167.158632 111.855826 
+L 167.158632 96.985743 
+L 167.364122 96.985743 
+L 167.364122 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 170.65197 111.855826 
+L 170.65197 96.985743 
+L 170.85746 96.985743 
+L 170.85746 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 174.145308 111.855826 
+L 174.145308 96.985743 
+L 174.350798 96.985743 
+L 174.350798 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 187.296697 111.855826 
+L 187.296697 96.985743 
+L 187.502187 96.985743 
+L 187.502187 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 190.790035 111.855826 
+L 190.790035 96.985743 
+L 190.995525 96.985743 
+L 190.995525 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 194.283373 111.855826 
+L 194.283373 96.985743 
+L 194.488863 96.985743 
+L 194.488863 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 197.77671 111.855826 
+L 197.77671 96.985743 
+L 197.982201 96.985743 
+L 197.982201 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 201.270048 111.855826 
+L 201.270048 96.985743 
+L 201.475539 96.985743 
+L 201.475539 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 204.763386 111.855826 
+L 204.763386 96.985743 
+L 204.968876 96.985743 
+L 204.968876 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 208.256724 111.855826 
+L 208.256724 96.985743 
+L 208.462214 96.985743 
+L 208.462214 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 211.750062 111.855826 
+L 211.750062 96.985743 
+L 211.955552 96.985743 
+L 211.955552 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 224.901451 111.855826 
+L 224.901451 96.985743 
+L 225.106941 96.985743 
+L 225.106941 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 228.394789 111.855826 
+L 228.394789 96.985743 
+L 228.600279 96.985743 
+L 228.600279 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 231.888126 111.855826 
+L 231.888126 96.985743 
+L 232.093617 96.985743 
+L 232.093617 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 235.381464 111.855826 
+L 235.381464 96.985743 
+L 235.586955 96.985743 
+L 235.586955 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 238.874802 111.855826 
+L 238.874802 96.985743 
+L 239.080293 96.985743 
+L 239.080293 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 242.36814 111.855826 
+L 242.36814 96.985743 
+L 242.57363 96.985743 
+L 242.57363 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 245.861478 111.855826 
+L 245.861478 96.985743 
+L 246.066968 96.985743 
+L 246.066968 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 249.354815 111.855826 
+L 249.354815 96.985743 
+L 249.560306 96.985743 
+L 249.560306 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 262.506205 111.855826 
+L 262.506205 96.985743 
+L 262.711695 96.985743 
+L 262.711695 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 265.999543 111.855826 
+L 265.999543 96.985743 
+L 266.205033 96.985743 
+L 266.205033 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 269.49288 111.855826 
+L 269.49288 96.985743 
+L 269.698371 96.985743 
+L 269.698371 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 272.986218 111.855826 
+L 272.986218 96.985743 
+L 273.191709 96.985743 
+L 273.191709 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 276.479556 111.855826 
+L 276.479556 96.985743 
+L 276.685046 96.985743 
+L 276.685046 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 279.972894 111.855826 
+L 279.972894 96.985743 
+L 280.178384 96.985743 
+L 280.178384 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 283.466232 111.855826 
+L 283.466232 96.985743 
+L 283.671722 96.985743 
+L 283.671722 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 286.959569 111.855826 
+L 286.959569 96.985743 
+L 287.16506 96.985743 
+L 287.16506 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 300.110959 111.855826 
+L 300.110959 96.985743 
+L 300.316449 96.985743 
+L 300.316449 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 303.604297 111.855826 
+L 303.604297 96.985743 
+L 303.809787 96.985743 
+L 303.809787 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 307.097634 111.855826 
+L 307.097634 96.985743 
+L 307.303125 96.985743 
+L 307.303125 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 310.590972 111.855826 
+L 310.590972 96.985743 
+L 310.796463 96.985743 
+L 310.796463 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 314.08431 111.855826 
+L 314.08431 96.985743 
+L 314.2898 96.985743 
+L 314.2898 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 317.577648 111.855826 
+L 317.577648 96.985743 
+L 317.783138 96.985743 
+L 317.783138 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 321.070986 111.855826 
+L 321.070986 96.985743 
+L 321.276476 96.985743 
+L 321.276476 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 324.564323 111.855826 
+L 324.564323 96.985743 
+L 324.769814 96.985743 
+L 324.769814 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 337.715713 111.855826 
+L 337.715713 96.985743 
+L 337.921203 96.985743 
+L 337.921203 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 341.20905 111.855826 
+L 341.20905 96.985743 
+L 341.414541 96.985743 
+L 341.414541 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 344.702388 111.855826 
+L 344.702388 96.985743 
+L 344.907879 96.985743 
+L 344.907879 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 348.195726 111.855826 
+L 348.195726 96.985743 
+L 348.401217 96.985743 
+L 348.401217 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 351.689064 111.855826 
+L 351.689064 96.985743 
+L 351.894554 96.985743 
+L 351.894554 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 355.182402 111.855826 
+L 355.182402 96.985743 
+L 355.387892 96.985743 
+L 355.387892 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 358.675739 111.855826 
+L 358.675739 96.985743 
+L 358.88123 96.985743 
+L 358.88123 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 362.169077 111.855826 
+L 362.169077 96.985743 
+L 362.374568 96.985743 
+L 362.374568 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 375.320467 111.855826 
+L 375.320467 96.985743 
+L 375.525957 96.985743 
+L 375.525957 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 378.813804 111.855826 
+L 378.813804 96.985743 
+L 379.019295 96.985743 
+L 379.019295 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 382.307142 111.855826 
+L 382.307142 96.985743 
+L 382.512633 96.985743 
+L 382.512633 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 385.80048 111.855826 
+L 385.80048 96.985743 
+L 386.00597 96.985743 
+L 386.00597 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 389.293818 111.855826 
+L 389.293818 96.985743 
+L 389.499308 96.985743 
+L 389.499308 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 392.787156 111.855826 
+L 392.787156 96.985743 
+L 392.992646 96.985743 
+L 392.992646 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 396.280493 111.855826 
+L 396.280493 96.985743 
+L 396.485984 96.985743 
+L 396.485984 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 399.773831 111.855826 
+L 399.773831 96.985743 
+L 399.979322 96.985743 
+L 399.979322 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 412.925221 111.855826 
+L 412.925221 96.985743 
+L 413.130711 96.985743 
+L 413.130711 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 416.418558 111.855826 
+L 416.418558 96.985743 
+L 416.624049 96.985743 
+L 416.624049 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 419.911896 111.855826 
+L 419.911896 96.985743 
+L 420.117387 96.985743 
+L 420.117387 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 423.405234 111.855826 
+L 423.405234 96.985743 
+L 423.610724 96.985743 
+L 423.610724 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 426.898572 111.855826 
+L 426.898572 96.985743 
+L 427.104062 96.985743 
+L 427.104062 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 430.39191 111.855826 
+L 430.39191 96.985743 
+L 430.5974 96.985743 
+L 430.5974 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 433.885247 111.855826 
+L 433.885247 96.985743 
+L 434.090738 96.985743 
+L 434.090738 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 437.378585 111.855826 
+L 437.378585 96.985743 
+L 437.584076 96.985743 
+L 437.584076 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 450.529974 111.855826 
+L 450.529974 96.985743 
+L 450.735465 96.985743 
+L 450.735465 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 454.023312 111.855826 
+L 454.023312 96.985743 
+L 454.228803 96.985743 
+L 454.228803 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 457.51665 111.855826 
+L 457.51665 96.985743 
+L 457.722141 96.985743 
+L 457.722141 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 461.009988 111.855826 
+L 461.009988 96.985743 
+L 461.215478 96.985743 
+L 461.215478 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 464.503326 111.855826 
+L 464.503326 96.985743 
+L 464.708816 96.985743 
+L 464.708816 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 467.996663 111.855826 
+L 467.996663 96.985743 
+L 468.202154 96.985743 
+L 468.202154 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 471.490001 111.855826 
+L 471.490001 96.985743 
+L 471.695492 96.985743 
+L 471.695492 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 474.983339 111.855826 
+L 474.983339 96.985743 
+L 475.18883 96.985743 
+L 475.18883 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 488.134728 111.855826 
+L 488.134728 96.985743 
+L 488.340219 96.985743 
+L 488.340219 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 491.628066 111.855826 
+L 491.628066 96.985743 
+L 491.833557 96.985743 
+L 491.833557 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 495.121404 111.855826 
+L 495.121404 96.985743 
+L 495.326894 96.985743 
+L 495.326894 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 498.614742 111.855826 
+L 498.614742 96.985743 
+L 498.820232 96.985743 
+L 498.820232 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 502.10808 111.855826 
+L 502.10808 96.985743 
+L 502.31357 96.985743 
+L 502.31357 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 505.601417 111.855826 
+L 505.601417 96.985743 
+L 505.806908 96.985743 
+L 505.806908 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 509.094755 111.855826 
+L 509.094755 96.985743 
+L 509.300246 96.985743 
+L 509.300246 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 512.588093 111.855826 
+L 512.588093 96.985743 
+L 512.793583 96.985743 
+L 512.793583 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 525.739482 111.855826 
+L 525.739482 96.985743 
+L 525.944973 96.985743 
+L 525.944973 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 529.23282 111.855826 
+L 529.23282 96.985743 
+L 529.438311 96.985743 
+L 529.438311 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 532.726158 111.855826 
+L 532.726158 96.985743 
+L 532.931648 96.985743 
+L 532.931648 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 536.219496 111.855826 
+L 536.219496 96.985743 
+L 536.424986 96.985743 
+L 536.424986 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 539.712834 111.855826 
+L 539.712834 96.985743 
+L 539.918324 96.985743 
+L 539.918324 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 543.206171 111.855826 
+L 543.206171 96.985743 
+L 543.411662 96.985743 
+L 543.411662 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 546.699509 111.855826 
+L 546.699509 96.985743 
+L 546.905 96.985743 
+L 546.905 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 550.192847 111.855826 
+L 550.192847 96.985743 
+L 550.398337 96.985743 
+L 550.398337 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 563.344236 111.855826 
+L 563.344236 96.985743 
+L 563.549727 96.985743 
+L 563.549727 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 566.837574 111.855826 
+L 566.837574 96.985743 
+L 567.043065 96.985743 
+L 567.043065 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 570.330912 111.855826 
+L 570.330912 96.985743 
+L 570.536402 96.985743 
+L 570.536402 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 573.82425 111.855826 
+L 573.82425 96.985743 
+L 574.02974 96.985743 
+L 574.02974 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 577.317587 111.855826 
+L 577.317587 96.985743 
+L 577.523078 96.985743 
+L 577.523078 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 580.810925 111.855826 
+L 580.810925 96.985743 
+L 581.016416 96.985743 
+L 581.016416 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 584.304263 111.855826 
+L 584.304263 96.985743 
+L 584.509754 96.985743 
+L 584.509754 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 587.797601 111.855826 
+L 587.797601 96.985743 
+L 588.003091 96.985743 
+L 588.003091 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 600.94899 111.855826 
+L 600.94899 96.985743 
+L 601.154481 96.985743 
+L 601.154481 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 604.442328 111.855826 
+L 604.442328 96.985743 
+L 604.647818 96.985743 
+L 604.647818 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 607.935666 111.855826 
+L 607.935666 96.985743 
+L 608.141156 96.985743 
+L 608.141156 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 611.429004 111.855826 
+L 611.429004 96.985743 
+L 611.634494 96.985743 
+L 611.634494 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 614.922341 111.855826 
+L 614.922341 96.985743 
+L 615.127832 96.985743 
+L 615.127832 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 618.415679 111.855826 
+L 618.415679 96.985743 
+L 618.62117 96.985743 
+L 618.62117 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 621.909017 111.855826 
+L 621.909017 96.985743 
+L 622.114507 96.985743 
+L 622.114507 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 625.402355 111.855826 
+L 625.402355 96.985743 
+L 625.607845 96.985743 
+L 625.607845 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 638.553744 111.855826 
+L 638.553744 96.985743 
+L 638.759235 96.985743 
+L 638.759235 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 642.047082 111.855826 
+L 642.047082 96.985743 
+L 642.252572 96.985743 
+L 642.252572 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 645.54042 111.855826 
+L 645.54042 96.985743 
+L 645.74591 96.985743 
+L 645.74591 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 649.033758 111.855826 
+L 649.033758 96.985743 
+L 649.239248 96.985743 
+L 649.239248 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 652.527095 111.855826 
+L 652.527095 96.985743 
+L 652.732586 96.985743 
+L 652.732586 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 656.020433 111.855826 
+L 656.020433 96.985743 
+L 656.225924 96.985743 
+L 656.225924 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 659.513771 111.855826 
+L 659.513771 96.985743 
+L 659.719261 96.985743 
+L 659.719261 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 663.007109 111.855826 
+L 663.007109 96.985743 
+L 663.212599 96.985743 
+L 663.212599 111.855826 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_5">
+    <path d="M 74.687926 133.723595 
+L 74.687926 118.853512 
+L 102.223647 118.853512 
+L 102.223647 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 112.29268 133.723595 
+L 112.29268 118.853512 
+L 139.828401 118.853512 
+L 139.828401 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 149.897433 133.723595 
+L 149.897433 118.853512 
+L 177.433155 118.853512 
+L 177.433155 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 187.502187 133.723595 
+L 187.502187 118.853512 
+L 215.037909 118.853512 
+L 215.037909 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 225.106941 133.723595 
+L 225.106941 118.853512 
+L 252.642663 118.853512 
+L 252.642663 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 262.711695 133.723595 
+L 262.711695 118.853512 
+L 290.247417 118.853512 
+L 290.247417 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 300.316449 133.723595 
+L 300.316449 118.853512 
+L 327.852171 118.853512 
+L 327.852171 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 337.921203 133.723595 
+L 337.921203 118.853512 
+L 365.456925 118.853512 
+L 365.456925 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 375.525957 133.723595 
+L 375.525957 118.853512 
+L 403.061679 118.853512 
+L 403.061679 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 413.130711 133.723595 
+L 413.130711 118.853512 
+L 440.666432 118.853512 
+L 440.666432 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 450.735465 133.723595 
+L 450.735465 118.853512 
+L 478.271186 118.853512 
+L 478.271186 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 488.340219 133.723595 
+L 488.340219 118.853512 
+L 515.87594 118.853512 
+L 515.87594 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 525.944973 133.723595 
+L 525.944973 118.853512 
+L 553.480694 118.853512 
+L 553.480694 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 563.549727 133.723595 
+L 563.549727 118.853512 
+L 591.085448 118.853512 
+L 591.085448 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 601.154481 133.723595 
+L 601.154481 118.853512 
+L 628.690202 118.853512 
+L 628.690202 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+    <path d="M 638.759235 133.723595 
+L 638.759235 118.853512 
+L 666.294956 118.853512 
+L 666.294956 133.723595 
+z
+" clip-path="url(#p7bea268345)" style="fill: #e45756; stroke: #e45756; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_6">
+    <path d="M 72.427531 155.591363 
+L 72.427531 140.72128 
+L 72.838511 140.72128 
+L 72.838511 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 75.509887 155.591363 
+L 75.509887 140.72128 
+L 103.045609 140.72128 
+L 103.045609 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 103.867571 155.591363 
+L 103.867571 140.72128 
+L 104.073061 140.72128 
+L 104.073061 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 110.443265 155.591363 
+L 110.443265 140.72128 
+L 110.648756 140.72128 
+L 110.648756 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 113.114641 155.591363 
+L 113.114641 140.72128 
+L 140.650363 140.72128 
+L 140.650363 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 141.472325 155.591363 
+L 141.472325 140.72128 
+L 141.677815 140.72128 
+L 141.677815 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 148.048019 155.591363 
+L 148.048019 140.72128 
+L 148.25351 140.72128 
+L 148.25351 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 150.719395 155.591363 
+L 150.719395 140.72128 
+L 178.255117 140.72128 
+L 178.255117 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 179.077079 155.591363 
+L 179.077079 140.72128 
+L 179.282569 140.72128 
+L 179.282569 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 185.652773 155.591363 
+L 185.652773 140.72128 
+L 185.858264 140.72128 
+L 185.858264 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 188.324149 155.591363 
+L 188.324149 140.72128 
+L 215.859871 140.72128 
+L 215.859871 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 216.681833 155.591363 
+L 216.681833 140.72128 
+L 216.887323 140.72128 
+L 216.887323 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 223.257527 155.591363 
+L 223.257527 140.72128 
+L 223.463018 140.72128 
+L 223.463018 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 225.928903 155.591363 
+L 225.928903 140.72128 
+L 253.464625 140.72128 
+L 253.464625 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 254.286586 155.591363 
+L 254.286586 140.72128 
+L 254.492077 140.72128 
+L 254.492077 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 260.862281 155.591363 
+L 260.862281 140.72128 
+L 261.067772 140.72128 
+L 261.067772 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 263.533657 155.591363 
+L 263.533657 140.72128 
+L 291.069379 140.72128 
+L 291.069379 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 291.89134 155.591363 
+L 291.89134 140.72128 
+L 292.096831 140.72128 
+L 292.096831 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 298.467035 155.591363 
+L 298.467035 140.72128 
+L 298.672526 140.72128 
+L 298.672526 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 301.138411 155.591363 
+L 301.138411 140.72128 
+L 328.674132 140.72128 
+L 328.674132 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 329.496094 155.591363 
+L 329.496094 140.72128 
+L 329.701585 140.72128 
+L 329.701585 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 336.071789 155.591363 
+L 336.071789 140.72128 
+L 336.277279 140.72128 
+L 336.277279 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 338.743165 155.591363 
+L 338.743165 140.72128 
+L 366.278886 140.72128 
+L 366.278886 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 367.100848 155.591363 
+L 367.100848 140.72128 
+L 367.306339 140.72128 
+L 367.306339 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 373.676543 155.591363 
+L 373.676543 140.72128 
+L 373.882033 140.72128 
+L 373.882033 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 376.347919 155.591363 
+L 376.347919 140.72128 
+L 403.88364 140.72128 
+L 403.88364 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 404.705602 155.591363 
+L 404.705602 140.72128 
+L 404.911093 140.72128 
+L 404.911093 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 411.281297 155.591363 
+L 411.281297 140.72128 
+L 411.486787 140.72128 
+L 411.486787 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 413.952673 155.591363 
+L 413.952673 140.72128 
+L 441.488394 140.72128 
+L 441.488394 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 442.310356 155.591363 
+L 442.310356 140.72128 
+L 442.515847 140.72128 
+L 442.515847 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 448.886051 155.591363 
+L 448.886051 140.72128 
+L 449.091541 140.72128 
+L 449.091541 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 451.557427 155.591363 
+L 451.557427 140.72128 
+L 479.093148 140.72128 
+L 479.093148 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 479.91511 155.591363 
+L 479.91511 140.72128 
+L 480.120601 140.72128 
+L 480.120601 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 486.490805 155.591363 
+L 486.490805 140.72128 
+L 486.696295 140.72128 
+L 486.696295 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 489.162181 155.591363 
+L 489.162181 140.72128 
+L 516.697902 140.72128 
+L 516.697902 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 517.519864 155.591363 
+L 517.519864 140.72128 
+L 517.725354 140.72128 
+L 517.725354 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 524.095559 155.591363 
+L 524.095559 140.72128 
+L 524.301049 140.72128 
+L 524.301049 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 526.766935 155.591363 
+L 526.766935 140.72128 
+L 554.302656 140.72128 
+L 554.302656 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 555.124618 155.591363 
+L 555.124618 140.72128 
+L 555.330108 140.72128 
+L 555.330108 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 561.700313 155.591363 
+L 561.700313 140.72128 
+L 561.905803 140.72128 
+L 561.905803 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 564.371689 155.591363 
+L 564.371689 140.72128 
+L 591.90741 140.72128 
+L 591.90741 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 592.729372 155.591363 
+L 592.729372 140.72128 
+L 592.934862 140.72128 
+L 592.934862 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 599.305067 155.591363 
+L 599.305067 140.72128 
+L 599.510557 140.72128 
+L 599.510557 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 601.976443 155.591363 
+L 601.976443 140.72128 
+L 629.512164 140.72128 
+L 629.512164 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 630.334126 155.591363 
+L 630.334126 140.72128 
+L 630.539616 140.72128 
+L 630.539616 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 636.90982 155.591363 
+L 636.90982 140.72128 
+L 637.115311 140.72128 
+L 637.115311 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 639.581196 155.591363 
+L 639.581196 140.72128 
+L 667.116918 140.72128 
+L 667.116918 155.591363 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_7">
+    <path d="M 72.633021 177.459132 
+L 72.633021 162.589049 
+L 73.454983 162.589049 
+L 73.454983 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 75.715378 177.459132 
+L 75.715378 162.589049 
+L 103.251099 162.589049 
+L 103.251099 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 110.237775 177.459132 
+L 110.237775 162.589049 
+L 111.059737 162.589049 
+L 111.059737 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 113.320132 177.459132 
+L 113.320132 162.589049 
+L 140.855853 162.589049 
+L 140.855853 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 147.842529 177.459132 
+L 147.842529 162.589049 
+L 148.664491 162.589049 
+L 148.664491 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 150.924886 177.459132 
+L 150.924886 162.589049 
+L 178.460607 162.589049 
+L 178.460607 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 185.447283 177.459132 
+L 185.447283 162.589049 
+L 186.269245 162.589049 
+L 186.269245 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 188.52964 177.459132 
+L 188.52964 162.589049 
+L 216.065361 162.589049 
+L 216.065361 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 223.052037 177.459132 
+L 223.052037 162.589049 
+L 223.873999 162.589049 
+L 223.873999 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 226.134394 177.459132 
+L 226.134394 162.589049 
+L 253.670115 162.589049 
+L 253.670115 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 260.656791 177.459132 
+L 260.656791 162.589049 
+L 261.478753 162.589049 
+L 261.478753 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 263.739148 177.459132 
+L 263.739148 162.589049 
+L 291.274869 162.589049 
+L 291.274869 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 298.261545 177.459132 
+L 298.261545 162.589049 
+L 299.083506 162.589049 
+L 299.083506 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 301.343901 177.459132 
+L 301.343901 162.589049 
+L 328.879623 162.589049 
+L 328.879623 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 335.866299 177.459132 
+L 335.866299 162.589049 
+L 336.68826 162.589049 
+L 336.68826 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 338.948655 177.459132 
+L 338.948655 162.589049 
+L 366.484377 162.589049 
+L 366.484377 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 373.471052 177.459132 
+L 373.471052 162.589049 
+L 374.293014 162.589049 
+L 374.293014 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 376.553409 177.459132 
+L 376.553409 162.589049 
+L 404.089131 162.589049 
+L 404.089131 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 411.075806 177.459132 
+L 411.075806 162.589049 
+L 411.897768 162.589049 
+L 411.897768 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 414.158163 177.459132 
+L 414.158163 162.589049 
+L 441.693885 162.589049 
+L 441.693885 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 448.68056 177.459132 
+L 448.68056 162.589049 
+L 449.502522 162.589049 
+L 449.502522 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 451.762917 177.459132 
+L 451.762917 162.589049 
+L 479.298639 162.589049 
+L 479.298639 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 486.285314 177.459132 
+L 486.285314 162.589049 
+L 487.107276 162.589049 
+L 487.107276 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 489.367671 177.459132 
+L 489.367671 162.589049 
+L 516.903393 162.589049 
+L 516.903393 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 523.890068 177.459132 
+L 523.890068 162.589049 
+L 524.71203 162.589049 
+L 524.71203 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 526.972425 177.459132 
+L 526.972425 162.589049 
+L 554.508147 162.589049 
+L 554.508147 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 561.494822 177.459132 
+L 561.494822 162.589049 
+L 562.316784 162.589049 
+L 562.316784 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 564.577179 177.459132 
+L 564.577179 162.589049 
+L 592.1129 162.589049 
+L 592.1129 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 599.099576 177.459132 
+L 599.099576 162.589049 
+L 599.921538 162.589049 
+L 599.921538 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 602.181933 177.459132 
+L 602.181933 162.589049 
+L 629.717654 162.589049 
+L 629.717654 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 636.70433 177.459132 
+L 636.70433 162.589049 
+L 637.526292 162.589049 
+L 637.526292 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+    <path d="M 639.786687 177.459132 
+L 639.786687 162.589049 
+L 667.322408 162.589049 
+L 667.322408 177.459132 
+z
+" clip-path="url(#p7bea268345)" style="fill: #f58518; stroke: #f58518; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_8">
+    <path d="M 80.030678 199.3269 
+L 80.030678 184.456818 
+L 80.236168 184.456818 
+L 80.236168 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 83.729506 199.3269 
+L 83.729506 184.456818 
+L 83.934996 184.456818 
+L 83.934996 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 87.428334 199.3269 
+L 87.428334 184.456818 
+L 87.633824 184.456818 
+L 87.633824 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 91.127162 199.3269 
+L 91.127162 184.456818 
+L 91.332653 184.456818 
+L 91.332653 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 94.825991 199.3269 
+L 94.825991 184.456818 
+L 95.031481 184.456818 
+L 95.031481 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 98.524819 199.3269 
+L 98.524819 184.456818 
+L 98.730309 184.456818 
+L 98.730309 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 102.223647 199.3269 
+L 102.223647 184.456818 
+L 102.429138 184.456818 
+L 102.429138 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 105.922475 199.3269 
+L 105.922475 184.456818 
+L 106.127966 184.456818 
+L 106.127966 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 117.635431 199.3269 
+L 117.635431 184.456818 
+L 117.840922 184.456818 
+L 117.840922 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 121.33426 199.3269 
+L 121.33426 184.456818 
+L 121.53975 184.456818 
+L 121.53975 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 125.033088 199.3269 
+L 125.033088 184.456818 
+L 125.238578 184.456818 
+L 125.238578 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 128.731916 199.3269 
+L 128.731916 184.456818 
+L 128.937407 184.456818 
+L 128.937407 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 132.430744 199.3269 
+L 132.430744 184.456818 
+L 132.636235 184.456818 
+L 132.636235 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 136.129573 199.3269 
+L 136.129573 184.456818 
+L 136.335063 184.456818 
+L 136.335063 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 139.828401 199.3269 
+L 139.828401 184.456818 
+L 140.033891 184.456818 
+L 140.033891 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 143.527229 199.3269 
+L 143.527229 184.456818 
+L 143.73272 184.456818 
+L 143.73272 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 155.240185 199.3269 
+L 155.240185 184.456818 
+L 155.445676 184.456818 
+L 155.445676 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 158.939014 199.3269 
+L 158.939014 184.456818 
+L 159.144504 184.456818 
+L 159.144504 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 162.637842 199.3269 
+L 162.637842 184.456818 
+L 162.843332 184.456818 
+L 162.843332 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 166.33667 199.3269 
+L 166.33667 184.456818 
+L 166.542161 184.456818 
+L 166.542161 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 170.035498 199.3269 
+L 170.035498 184.456818 
+L 170.240989 184.456818 
+L 170.240989 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 173.734327 199.3269 
+L 173.734327 184.456818 
+L 173.939817 184.456818 
+L 173.939817 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 177.433155 199.3269 
+L 177.433155 184.456818 
+L 177.638645 184.456818 
+L 177.638645 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 181.131983 199.3269 
+L 181.131983 184.456818 
+L 181.337474 184.456818 
+L 181.337474 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 192.844939 199.3269 
+L 192.844939 184.456818 
+L 193.05043 184.456818 
+L 193.05043 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 196.543768 199.3269 
+L 196.543768 184.456818 
+L 196.749258 184.456818 
+L 196.749258 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 200.242596 199.3269 
+L 200.242596 184.456818 
+L 200.448086 184.456818 
+L 200.448086 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 203.941424 199.3269 
+L 203.941424 184.456818 
+L 204.146915 184.456818 
+L 204.146915 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 207.640252 199.3269 
+L 207.640252 184.456818 
+L 207.845743 184.456818 
+L 207.845743 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 211.339081 199.3269 
+L 211.339081 184.456818 
+L 211.544571 184.456818 
+L 211.544571 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 215.037909 199.3269 
+L 215.037909 184.456818 
+L 215.243399 184.456818 
+L 215.243399 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 218.736737 199.3269 
+L 218.736737 184.456818 
+L 218.942228 184.456818 
+L 218.942228 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 230.449693 199.3269 
+L 230.449693 184.456818 
+L 230.655184 184.456818 
+L 230.655184 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 234.148522 199.3269 
+L 234.148522 184.456818 
+L 234.354012 184.456818 
+L 234.354012 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 237.84735 199.3269 
+L 237.84735 184.456818 
+L 238.05284 184.456818 
+L 238.05284 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 241.546178 199.3269 
+L 241.546178 184.456818 
+L 241.751668 184.456818 
+L 241.751668 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 245.245006 199.3269 
+L 245.245006 184.456818 
+L 245.450497 184.456818 
+L 245.450497 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 248.943835 199.3269 
+L 248.943835 184.456818 
+L 249.149325 184.456818 
+L 249.149325 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 252.642663 199.3269 
+L 252.642663 184.456818 
+L 252.848153 184.456818 
+L 252.848153 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 256.341491 199.3269 
+L 256.341491 184.456818 
+L 256.546982 184.456818 
+L 256.546982 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 268.054447 199.3269 
+L 268.054447 184.456818 
+L 268.259938 184.456818 
+L 268.259938 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 271.753275 199.3269 
+L 271.753275 184.456818 
+L 271.958766 184.456818 
+L 271.958766 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 275.452104 199.3269 
+L 275.452104 184.456818 
+L 275.657594 184.456818 
+L 275.657594 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 279.150932 199.3269 
+L 279.150932 184.456818 
+L 279.356422 184.456818 
+L 279.356422 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 282.84976 199.3269 
+L 282.84976 184.456818 
+L 283.055251 184.456818 
+L 283.055251 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 286.548588 199.3269 
+L 286.548588 184.456818 
+L 286.754079 184.456818 
+L 286.754079 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 290.247417 199.3269 
+L 290.247417 184.456818 
+L 290.452907 184.456818 
+L 290.452907 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 293.946245 199.3269 
+L 293.946245 184.456818 
+L 294.151735 184.456818 
+L 294.151735 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 305.659201 199.3269 
+L 305.659201 184.456818 
+L 305.864692 184.456818 
+L 305.864692 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 309.358029 199.3269 
+L 309.358029 184.456818 
+L 309.56352 184.456818 
+L 309.56352 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 313.056858 199.3269 
+L 313.056858 184.456818 
+L 313.262348 184.456818 
+L 313.262348 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 316.755686 199.3269 
+L 316.755686 184.456818 
+L 316.961176 184.456818 
+L 316.961176 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 320.454514 199.3269 
+L 320.454514 184.456818 
+L 320.660005 184.456818 
+L 320.660005 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 324.153342 199.3269 
+L 324.153342 184.456818 
+L 324.358833 184.456818 
+L 324.358833 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 327.852171 199.3269 
+L 327.852171 184.456818 
+L 328.057661 184.456818 
+L 328.057661 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 331.550999 199.3269 
+L 331.550999 184.456818 
+L 331.756489 184.456818 
+L 331.756489 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 343.263955 199.3269 
+L 343.263955 184.456818 
+L 343.469446 184.456818 
+L 343.469446 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 346.962783 199.3269 
+L 346.962783 184.456818 
+L 347.168274 184.456818 
+L 347.168274 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 350.661612 199.3269 
+L 350.661612 184.456818 
+L 350.867102 184.456818 
+L 350.867102 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 354.36044 199.3269 
+L 354.36044 184.456818 
+L 354.56593 184.456818 
+L 354.56593 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 358.059268 199.3269 
+L 358.059268 184.456818 
+L 358.264759 184.456818 
+L 358.264759 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 361.758096 199.3269 
+L 361.758096 184.456818 
+L 361.963587 184.456818 
+L 361.963587 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 365.456925 199.3269 
+L 365.456925 184.456818 
+L 365.662415 184.456818 
+L 365.662415 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 369.155753 199.3269 
+L 369.155753 184.456818 
+L 369.361243 184.456818 
+L 369.361243 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 380.868709 199.3269 
+L 380.868709 184.456818 
+L 381.074199 184.456818 
+L 381.074199 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 384.567537 199.3269 
+L 384.567537 184.456818 
+L 384.773028 184.456818 
+L 384.773028 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 388.266366 199.3269 
+L 388.266366 184.456818 
+L 388.471856 184.456818 
+L 388.471856 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 391.965194 199.3269 
+L 391.965194 184.456818 
+L 392.170684 184.456818 
+L 392.170684 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 395.664022 199.3269 
+L 395.664022 184.456818 
+L 395.869512 184.456818 
+L 395.869512 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 399.36285 199.3269 
+L 399.36285 184.456818 
+L 399.568341 184.456818 
+L 399.568341 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 403.061679 199.3269 
+L 403.061679 184.456818 
+L 403.267169 184.456818 
+L 403.267169 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 406.760507 199.3269 
+L 406.760507 184.456818 
+L 406.965997 184.456818 
+L 406.965997 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 418.473463 199.3269 
+L 418.473463 184.456818 
+L 418.678953 184.456818 
+L 418.678953 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 422.172291 199.3269 
+L 422.172291 184.456818 
+L 422.377782 184.456818 
+L 422.377782 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 425.871119 199.3269 
+L 425.871119 184.456818 
+L 426.07661 184.456818 
+L 426.07661 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 429.569948 199.3269 
+L 429.569948 184.456818 
+L 429.775438 184.456818 
+L 429.775438 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 433.268776 199.3269 
+L 433.268776 184.456818 
+L 433.474266 184.456818 
+L 433.474266 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 436.967604 199.3269 
+L 436.967604 184.456818 
+L 437.173095 184.456818 
+L 437.173095 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 440.666432 199.3269 
+L 440.666432 184.456818 
+L 440.871923 184.456818 
+L 440.871923 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 444.365261 199.3269 
+L 444.365261 184.456818 
+L 444.570751 184.456818 
+L 444.570751 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 456.078217 199.3269 
+L 456.078217 184.456818 
+L 456.283707 184.456818 
+L 456.283707 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 459.777045 199.3269 
+L 459.777045 184.456818 
+L 459.982536 184.456818 
+L 459.982536 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 463.475873 199.3269 
+L 463.475873 184.456818 
+L 463.681364 184.456818 
+L 463.681364 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 467.174702 199.3269 
+L 467.174702 184.456818 
+L 467.380192 184.456818 
+L 467.380192 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 470.87353 199.3269 
+L 470.87353 184.456818 
+L 471.07902 184.456818 
+L 471.07902 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 474.572358 199.3269 
+L 474.572358 184.456818 
+L 474.777849 184.456818 
+L 474.777849 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 478.271186 199.3269 
+L 478.271186 184.456818 
+L 478.476677 184.456818 
+L 478.476677 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 481.970015 199.3269 
+L 481.970015 184.456818 
+L 482.175505 184.456818 
+L 482.175505 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 493.682971 199.3269 
+L 493.682971 184.456818 
+L 493.888461 184.456818 
+L 493.888461 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 497.381799 199.3269 
+L 497.381799 184.456818 
+L 497.58729 184.456818 
+L 497.58729 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 501.080627 199.3269 
+L 501.080627 184.456818 
+L 501.286118 184.456818 
+L 501.286118 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 504.779456 199.3269 
+L 504.779456 184.456818 
+L 504.984946 184.456818 
+L 504.984946 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 508.478284 199.3269 
+L 508.478284 184.456818 
+L 508.683774 184.456818 
+L 508.683774 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 512.177112 199.3269 
+L 512.177112 184.456818 
+L 512.382603 184.456818 
+L 512.382603 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 515.87594 199.3269 
+L 515.87594 184.456818 
+L 516.081431 184.456818 
+L 516.081431 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 519.574769 199.3269 
+L 519.574769 184.456818 
+L 519.780259 184.456818 
+L 519.780259 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 531.287725 199.3269 
+L 531.287725 184.456818 
+L 531.493215 184.456818 
+L 531.493215 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 534.986553 199.3269 
+L 534.986553 184.456818 
+L 535.192043 184.456818 
+L 535.192043 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 538.685381 199.3269 
+L 538.685381 184.456818 
+L 538.890872 184.456818 
+L 538.890872 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 542.384209 199.3269 
+L 542.384209 184.456818 
+L 542.5897 184.456818 
+L 542.5897 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 546.083038 199.3269 
+L 546.083038 184.456818 
+L 546.288528 184.456818 
+L 546.288528 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 549.781866 199.3269 
+L 549.781866 184.456818 
+L 549.987356 184.456818 
+L 549.987356 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 553.480694 199.3269 
+L 553.480694 184.456818 
+L 553.686185 184.456818 
+L 553.686185 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 557.179523 199.3269 
+L 557.179523 184.456818 
+L 557.385013 184.456818 
+L 557.385013 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 568.892479 199.3269 
+L 568.892479 184.456818 
+L 569.097969 184.456818 
+L 569.097969 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 572.591307 199.3269 
+L 572.591307 184.456818 
+L 572.796797 184.456818 
+L 572.796797 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 576.290135 199.3269 
+L 576.290135 184.456818 
+L 576.495626 184.456818 
+L 576.495626 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 579.988963 199.3269 
+L 579.988963 184.456818 
+L 580.194454 184.456818 
+L 580.194454 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 583.687792 199.3269 
+L 583.687792 184.456818 
+L 583.893282 184.456818 
+L 583.893282 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 587.38662 199.3269 
+L 587.38662 184.456818 
+L 587.59211 184.456818 
+L 587.59211 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 591.085448 199.3269 
+L 591.085448 184.456818 
+L 591.290939 184.456818 
+L 591.290939 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 594.784276 199.3269 
+L 594.784276 184.456818 
+L 594.989767 184.456818 
+L 594.989767 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 606.497233 199.3269 
+L 606.497233 184.456818 
+L 606.702723 184.456818 
+L 606.702723 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 610.196061 199.3269 
+L 610.196061 184.456818 
+L 610.401551 184.456818 
+L 610.401551 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 613.894889 199.3269 
+L 613.894889 184.456818 
+L 614.10038 184.456818 
+L 614.10038 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 617.593717 199.3269 
+L 617.593717 184.456818 
+L 617.799208 184.456818 
+L 617.799208 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 621.292546 199.3269 
+L 621.292546 184.456818 
+L 621.498036 184.456818 
+L 621.498036 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 624.991374 199.3269 
+L 624.991374 184.456818 
+L 625.196864 184.456818 
+L 625.196864 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 628.690202 199.3269 
+L 628.690202 184.456818 
+L 628.895693 184.456818 
+L 628.895693 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 632.38903 199.3269 
+L 632.38903 184.456818 
+L 632.594521 184.456818 
+L 632.594521 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 644.101987 199.3269 
+L 644.101987 184.456818 
+L 644.307477 184.456818 
+L 644.307477 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 647.800815 199.3269 
+L 647.800815 184.456818 
+L 648.006305 184.456818 
+L 648.006305 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 651.499643 199.3269 
+L 651.499643 184.456818 
+L 651.705133 184.456818 
+L 651.705133 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 655.198471 199.3269 
+L 655.198471 184.456818 
+L 655.403962 184.456818 
+L 655.403962 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 658.8973 199.3269 
+L 658.8973 184.456818 
+L 659.10279 184.456818 
+L 659.10279 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 662.596128 199.3269 
+L 662.596128 184.456818 
+L 662.801618 184.456818 
+L 662.801618 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 666.294956 199.3269 
+L 666.294956 184.456818 
+L 666.500447 184.456818 
+L 666.500447 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 669.993784 199.3269 
+L 669.993784 184.456818 
+L 670.199275 184.456818 
+L 670.199275 199.3269 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_9">
+    <path d="M 80.236168 221.194669 
+L 80.236168 206.324586 
+L 109.210323 206.324586 
+L 109.210323 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 117.840922 221.194669 
+L 117.840922 206.324586 
+L 146.815077 206.324586 
+L 146.815077 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 155.445676 221.194669 
+L 155.445676 206.324586 
+L 184.419831 206.324586 
+L 184.419831 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 193.05043 221.194669 
+L 193.05043 206.324586 
+L 222.024584 206.324586 
+L 222.024584 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 230.655184 221.194669 
+L 230.655184 206.324586 
+L 259.629338 206.324586 
+L 259.629338 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 268.259938 221.194669 
+L 268.259938 206.324586 
+L 297.234092 206.324586 
+L 297.234092 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 305.864692 221.194669 
+L 305.864692 206.324586 
+L 334.838846 206.324586 
+L 334.838846 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 343.469446 221.194669 
+L 343.469446 206.324586 
+L 372.4436 206.324586 
+L 372.4436 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 381.074199 221.194669 
+L 381.074199 206.324586 
+L 410.048354 206.324586 
+L 410.048354 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 418.678953 221.194669 
+L 418.678953 206.324586 
+L 447.653108 206.324586 
+L 447.653108 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 456.283707 221.194669 
+L 456.283707 206.324586 
+L 485.257862 206.324586 
+L 485.257862 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 493.888461 221.194669 
+L 493.888461 206.324586 
+L 522.862616 206.324586 
+L 522.862616 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 531.493215 221.194669 
+L 531.493215 206.324586 
+L 560.46737 206.324586 
+L 560.46737 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 569.097969 221.194669 
+L 569.097969 206.324586 
+L 598.072124 206.324586 
+L 598.072124 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 606.702723 221.194669 
+L 606.702723 206.324586 
+L 635.676878 206.324586 
+L 635.676878 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+    <path d="M 644.307477 221.194669 
+L 644.307477 206.324586 
+L 673.281632 206.324586 
+L 673.281632 221.194669 
+z
+" clip-path="url(#p7bea268345)" style="fill: #54a24b; stroke: #54a24b; stroke-width: 0.5"/>
+   </g>
+   <g id="PolyCollection_10">
+    <path d="M 104.278552 243.062438 
+L 104.278552 228.192355 
+L 104.484042 228.192355 
+L 104.484042 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 141.883306 243.062438 
+L 141.883306 228.192355 
+L 142.088796 228.192355 
+L 142.088796 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 179.48806 243.062438 
+L 179.48806 228.192355 
+L 179.69355 228.192355 
+L 179.69355 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 217.092813 243.062438 
+L 217.092813 228.192355 
+L 217.298304 228.192355 
+L 217.298304 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 254.697567 243.062438 
+L 254.697567 228.192355 
+L 254.903058 228.192355 
+L 254.903058 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 292.302321 243.062438 
+L 292.302321 228.192355 
+L 292.507812 228.192355 
+L 292.507812 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 329.907075 243.062438 
+L 329.907075 228.192355 
+L 330.112566 228.192355 
+L 330.112566 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 367.511829 243.062438 
+L 367.511829 228.192355 
+L 367.71732 228.192355 
+L 367.71732 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 405.116583 243.062438 
+L 405.116583 228.192355 
+L 405.322074 228.192355 
+L 405.322074 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 442.721337 243.062438 
+L 442.721337 228.192355 
+L 442.926828 228.192355 
+L 442.926828 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 480.326091 243.062438 
+L 480.326091 228.192355 
+L 480.531581 228.192355 
+L 480.531581 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 517.930845 243.062438 
+L 517.930845 228.192355 
+L 518.136335 228.192355 
+L 518.136335 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 555.535599 243.062438 
+L 555.535599 228.192355 
+L 555.741089 228.192355 
+L 555.741089 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 593.140353 243.062438 
+L 593.140353 228.192355 
+L 593.345843 228.192355 
+L 593.345843 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 630.745107 243.062438 
+L 630.745107 228.192355 
+L 630.950597 228.192355 
+L 630.950597 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+    <path d="M 668.349861 243.062438 
+L 668.349861 228.192355 
+L 668.555351 228.192355 
+L 668.555351 243.062438 
+z
+" clip-path="url(#p7bea268345)" style="fill: #b279a2; stroke: #b279a2; stroke-width: 0.5"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 67.70125 253.646438 
+L 67.70125 20.798437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 67.70125 253.646438 
+L 681.50125 253.646438 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_18">
+    <!-- mem_copy — stage activity across 16 jobs (bar = busy) -->
+    <g transform="translate(234.823125 14.798437) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2014" d="M 313 1978 
+L 6088 1978 
+L 6088 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6a" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(158.935547 0)"/>
+     <use xlink:href="#DejaVuSans-5f" transform="translate(256.347656 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(306.347656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(361.328125 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(422.509766 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(485.986328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(545.166016 0)"/>
+     <use xlink:href="#DejaVuSans-2014" transform="translate(576.953125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(676.953125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(708.740234 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(760.839844 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(800.048828 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(861.328125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(924.804688 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(986.328125 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1018.115234 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1079.394531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1134.375 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1173.583984 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1201.367188 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1260.546875 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1288.330078 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(1327.539062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1386.71875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1418.505859 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1479.785156 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1534.765625 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1573.628906 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1634.810547 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1686.910156 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1739.009766 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(1770.796875 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1834.419922 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1898.042969 0)"/>
+     <use xlink:href="#DejaVuSans-6a" transform="translate(1929.830078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1957.613281 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2018.794922 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2082.271484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2134.371094 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(2166.158203 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2205.171875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2268.648438 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(2329.927734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2371.041016 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(2402.828125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2486.617188 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2518.404297 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2581.880859 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2645.259766 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(2697.359375 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2756.539062 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p7bea268345">
+   <rect x="67.70125" y="20.798437" width="613.8" height="232.848"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/examples/memcpy/images/timeline_job.svg
+++ b/docs/examples/memcpy/images/timeline_job.svg
@@ -1,0 +1,3702 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="688.70125pt" height="346.642687pt" viewBox="0 0 688.70125 346.642687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M -0 346.642687 
+L 688.70125 346.642687 
+L 688.70125 0 
+L -0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 67.70125 217.358437 
+L 681.50125 217.358437 
+L 681.50125 20.798437 
+L 67.70125 20.798437 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 73.085461 217.358437 
+L 73.085461 20.798437 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m91400e4105" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m91400e4105" x="73.085461" y="217.358437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 207.690724 217.358437 
+L 207.690724 20.798437 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m91400e4105" x="207.690724" y="217.358437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 342.295987 217.358437 
+L 342.295987 20.798437 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m91400e4105" x="342.295987" y="217.358437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 476.90125 217.358437 
+L 476.90125 20.798437 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m91400e4105" x="476.90125" y="217.358437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 611.506513 217.358437 
+L 611.506513 20.798437 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m91400e4105" x="611.506513" y="217.358437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_11">
+      <defs>
+       <path id="mdb56eb61dd" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="201.466664" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- s_done out -->
+      <g transform="translate(16.92375 204.506039) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-5f" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(52.099609 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(102.099609 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(165.576172 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(226.757812 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(290.136719 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(351.660156 0)"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-75" transform="translate(444.628906 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(508.007812 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="183.158169" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- gmem1 W -->
+      <g transform="translate(19.5725 186.197544) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(415.234375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="164.849674" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- gmem1 AW -->
+      <g transform="translate(14.54 167.889049) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-41" transform="translate(415.234375 0)"/>
+       <use xlink:href="#DejaVuSans-57" transform="translate(478.142578 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="146.54118" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- copy_data rd -->
+      <g transform="translate(8.80375 149.580555) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(116.162109 0)"/>
+       <use xlink:href="#DejaVuSans-79" transform="translate(179.638672 0)"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(238.818359 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(288.818359 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(352.294922 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(413.574219 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(452.783203 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(514.0625 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(545.849609 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(585.212891 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="128.232685" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- copy_data wr -->
+      <g transform="translate(7.2 131.27206) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-70" transform="translate(116.162109 0)"/>
+       <use xlink:href="#DejaVuSans-79" transform="translate(179.638672 0)"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(238.818359 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(288.818359 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(352.294922 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(413.574219 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(452.783203 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(514.0625 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(545.849609 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(627.636719 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="109.92419" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- gmem0 R -->
+      <g transform="translate(21.92375 112.963565) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-52" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(415.234375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="91.615695" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- gmem0 AR -->
+      <g transform="translate(16.45125 94.65507) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(63.476562 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(160.888672 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(222.412109 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(319.824219 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(383.447266 0)"/>
+       <use xlink:href="#DejaVuSans-41" transform="translate(415.234375 0)"/>
+       <use xlink:href="#DejaVuSans-52" transform="translate(483.642578 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="73.307201" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- cmd read -->
+      <g transform="translate(22.87625 76.346576) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(152.392578 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(215.869141 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(247.65625 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(286.519531 0)"/>
+       <use xlink:href="#DejaVuSans-61" transform="translate(348.042969 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(409.322266 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="54.998706" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- cmd write -->
+      <g transform="translate(20.77625 58.038081) scale(0.08 -0.08)">
+       <defs>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-63"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(54.980469 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(152.392578 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(215.869141 0)"/>
+       <use xlink:href="#DejaVuSans-77" transform="translate(247.65625 0)"/>
+       <use xlink:href="#DejaVuSans-72" transform="translate(329.443359 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(370.556641 0)"/>
+       <use xlink:href="#DejaVuSans-74" transform="translate(398.339844 0)"/>
+       <use xlink:href="#DejaVuSans-65" transform="translate(437.548828 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="36.690211" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- s_cmd in -->
+      <g transform="translate(25.42875 39.729586) scale(0.08 -0.08)">
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-5f" transform="translate(52.099609 0)"/>
+       <use xlink:href="#DejaVuSans-63" transform="translate(102.099609 0)"/>
+       <use xlink:href="#DejaVuSans-6d" transform="translate(157.080078 0)"/>
+       <use xlink:href="#DejaVuSans-64" transform="translate(254.492188 0)"/>
+       <use xlink:href="#DejaVuSans-20" transform="translate(317.96875 0)"/>
+       <use xlink:href="#DejaVuSans-69" transform="translate(349.755859 0)"/>
+       <use xlink:href="#DejaVuSans-6e" transform="translate(377.539062 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 100.006513 43.647439 
+L 100.006513 29.732983 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 102.698618 43.647439 
+L 102.698618 29.732983 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 592.661776 43.647439 
+L 592.661776 29.732983 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 595.353882 43.647439 
+L 595.353882 29.732983 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 86.545987 61.955934 
+L 86.545987 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 89.238092 61.955934 
+L 89.238092 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 94.622303 61.955934 
+L 94.622303 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 100.006513 61.955934 
+L 100.006513 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 180.769671 61.955934 
+L 180.769671 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 579.20125 61.955934 
+L 579.20125 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 581.893355 61.955934 
+L 581.893355 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 587.277566 61.955934 
+L 587.277566 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 592.661776 61.955934 
+L 592.661776 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 673.424934 61.955934 
+L 673.424934 48.041478 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_3">
+    <path d="M 83.853882 80.264429 
+L 83.853882 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 86.545987 80.264429 
+L 86.545987 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 91.930197 80.264429 
+L 91.930197 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 94.622303 80.264429 
+L 94.622303 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 178.077566 80.264429 
+L 178.077566 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 576.509145 80.264429 
+L 576.509145 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 579.20125 80.264429 
+L 579.20125 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 584.585461 80.264429 
+L 584.585461 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 587.277566 80.264429 
+L 587.277566 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+    <path d="M 670.732829 80.264429 
+L 670.732829 66.349973 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #4c78a8; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_4">
+    <path d="M 199.614408 98.572923 
+L 199.614408 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 245.380197 98.572923 
+L 245.380197 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 291.145987 98.572923 
+L 291.145987 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 336.911776 98.572923 
+L 336.911776 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 382.677566 98.572923 
+L 382.677566 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 428.443355 98.572923 
+L 428.443355 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 474.209145 98.572923 
+L 474.209145 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 519.974934 98.572923 
+L 519.974934 84.658467 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_5">
+    <path d="M 67.70125 116.881418 
+L 67.70125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 70.393355 116.881418 
+L 70.393355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 202.306513 116.881418 
+L 202.306513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 204.998618 116.881418 
+L 204.998618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 207.690724 116.881418 
+L 207.690724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 210.382829 116.881418 
+L 210.382829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 213.074934 116.881418 
+L 213.074934 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 215.767039 116.881418 
+L 215.767039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 218.459145 116.881418 
+L 218.459145 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 221.15125 116.881418 
+L 221.15125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 223.843355 116.881418 
+L 223.843355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 226.535461 116.881418 
+L 226.535461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 229.227566 116.881418 
+L 229.227566 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 231.919671 116.881418 
+L 231.919671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 234.611776 116.881418 
+L 234.611776 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 237.303882 116.881418 
+L 237.303882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 239.995987 116.881418 
+L 239.995987 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 242.688092 116.881418 
+L 242.688092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 248.072303 116.881418 
+L 248.072303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 250.764408 116.881418 
+L 250.764408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 253.456513 116.881418 
+L 253.456513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 256.148618 116.881418 
+L 256.148618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 258.840724 116.881418 
+L 258.840724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 261.532829 116.881418 
+L 261.532829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 264.224934 116.881418 
+L 264.224934 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 266.917039 116.881418 
+L 266.917039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 269.609145 116.881418 
+L 269.609145 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 272.30125 116.881418 
+L 272.30125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 274.993355 116.881418 
+L 274.993355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 277.685461 116.881418 
+L 277.685461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 280.377566 116.881418 
+L 280.377566 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 283.069671 116.881418 
+L 283.069671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 285.761776 116.881418 
+L 285.761776 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 288.453882 116.881418 
+L 288.453882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 293.838092 116.881418 
+L 293.838092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 296.530197 116.881418 
+L 296.530197 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 299.222303 116.881418 
+L 299.222303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 301.914408 116.881418 
+L 301.914408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 304.606513 116.881418 
+L 304.606513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 307.298618 116.881418 
+L 307.298618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 309.990724 116.881418 
+L 309.990724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 312.682829 116.881418 
+L 312.682829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 315.374934 116.881418 
+L 315.374934 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 318.067039 116.881418 
+L 318.067039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 320.759145 116.881418 
+L 320.759145 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 323.45125 116.881418 
+L 323.45125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 326.143355 116.881418 
+L 326.143355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 328.835461 116.881418 
+L 328.835461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 331.527566 116.881418 
+L 331.527566 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 334.219671 116.881418 
+L 334.219671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 339.603882 116.881418 
+L 339.603882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 342.295987 116.881418 
+L 342.295987 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 344.988092 116.881418 
+L 344.988092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 347.680197 116.881418 
+L 347.680197 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 350.372303 116.881418 
+L 350.372303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 353.064408 116.881418 
+L 353.064408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 355.756513 116.881418 
+L 355.756513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 358.448618 116.881418 
+L 358.448618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 361.140724 116.881418 
+L 361.140724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 363.832829 116.881418 
+L 363.832829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 366.524934 116.881418 
+L 366.524934 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 369.217039 116.881418 
+L 369.217039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 371.909145 116.881418 
+L 371.909145 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 374.60125 116.881418 
+L 374.60125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 377.293355 116.881418 
+L 377.293355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 379.985461 116.881418 
+L 379.985461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 385.369671 116.881418 
+L 385.369671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 388.061776 116.881418 
+L 388.061776 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 390.753882 116.881418 
+L 390.753882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 393.445987 116.881418 
+L 393.445987 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 396.138092 116.881418 
+L 396.138092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 398.830197 116.881418 
+L 398.830197 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 401.522303 116.881418 
+L 401.522303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 404.214408 116.881418 
+L 404.214408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 406.906513 116.881418 
+L 406.906513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 409.598618 116.881418 
+L 409.598618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 412.290724 116.881418 
+L 412.290724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 414.982829 116.881418 
+L 414.982829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 417.674934 116.881418 
+L 417.674934 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 420.367039 116.881418 
+L 420.367039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 423.059145 116.881418 
+L 423.059145 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 425.75125 116.881418 
+L 425.75125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 431.135461 116.881418 
+L 431.135461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 433.827566 116.881418 
+L 433.827566 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 436.519671 116.881418 
+L 436.519671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 439.211776 116.881418 
+L 439.211776 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 441.903882 116.881418 
+L 441.903882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 444.595987 116.881418 
+L 444.595987 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 447.288092 116.881418 
+L 447.288092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 449.980197 116.881418 
+L 449.980197 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 452.672303 116.881418 
+L 452.672303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 455.364408 116.881418 
+L 455.364408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 458.056513 116.881418 
+L 458.056513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 460.748618 116.881418 
+L 460.748618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 463.440724 116.881418 
+L 463.440724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 466.132829 116.881418 
+L 466.132829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 468.824934 116.881418 
+L 468.824934 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 471.517039 116.881418 
+L 471.517039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 476.90125 116.881418 
+L 476.90125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 479.593355 116.881418 
+L 479.593355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 482.285461 116.881418 
+L 482.285461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 484.977566 116.881418 
+L 484.977566 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 487.669671 116.881418 
+L 487.669671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 490.361776 116.881418 
+L 490.361776 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 493.053882 116.881418 
+L 493.053882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 495.745987 116.881418 
+L 495.745987 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 498.438092 116.881418 
+L 498.438092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 501.130197 116.881418 
+L 501.130197 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 503.822303 116.881418 
+L 503.822303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 506.514408 116.881418 
+L 506.514408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 509.206513 116.881418 
+L 509.206513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 511.898618 116.881418 
+L 511.898618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 514.590724 116.881418 
+L 514.590724 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 517.282829 116.881418 
+L 517.282829 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 522.667039 116.881418 
+L 522.667039 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 525.359145 116.881418 
+L 525.359145 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 528.05125 116.881418 
+L 528.05125 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 530.743355 116.881418 
+L 530.743355 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 533.435461 116.881418 
+L 533.435461 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 536.127566 116.881418 
+L 536.127566 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 538.819671 116.881418 
+L 538.819671 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 541.511776 116.881418 
+L 541.511776 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 544.203882 116.881418 
+L 544.203882 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 546.895987 116.881418 
+L 546.895987 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 549.588092 116.881418 
+L 549.588092 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 552.280197 116.881418 
+L 552.280197 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 554.972303 116.881418 
+L 554.972303 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 557.664408 116.881418 
+L 557.664408 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 560.356513 116.881418 
+L 560.356513 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+    <path d="M 563.048618 116.881418 
+L 563.048618 102.966962 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #e45756; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_6">
+    <path d="M 67.70125 135.189913 
+L 67.70125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 70.393355 135.189913 
+L 70.393355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 73.085461 135.189913 
+L 73.085461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 75.777566 135.189913 
+L 75.777566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 78.469671 135.189913 
+L 78.469671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 81.161776 135.189913 
+L 81.161776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 91.930197 135.189913 
+L 91.930197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 94.622303 135.189913 
+L 94.622303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 178.077566 135.189913 
+L 178.077566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 213.074934 135.189913 
+L 213.074934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 215.767039 135.189913 
+L 215.767039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 218.459145 135.189913 
+L 218.459145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 221.15125 135.189913 
+L 221.15125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 223.843355 135.189913 
+L 223.843355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 226.535461 135.189913 
+L 226.535461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 229.227566 135.189913 
+L 229.227566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 231.919671 135.189913 
+L 231.919671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 234.611776 135.189913 
+L 234.611776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 237.303882 135.189913 
+L 237.303882 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 239.995987 135.189913 
+L 239.995987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 242.688092 135.189913 
+L 242.688092 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 245.380197 135.189913 
+L 245.380197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 248.072303 135.189913 
+L 248.072303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 250.764408 135.189913 
+L 250.764408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 256.148618 135.189913 
+L 256.148618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 258.840724 135.189913 
+L 258.840724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 261.532829 135.189913 
+L 261.532829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 264.224934 135.189913 
+L 264.224934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 266.917039 135.189913 
+L 266.917039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 269.609145 135.189913 
+L 269.609145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 272.30125 135.189913 
+L 272.30125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 274.993355 135.189913 
+L 274.993355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 277.685461 135.189913 
+L 277.685461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 280.377566 135.189913 
+L 280.377566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 283.069671 135.189913 
+L 283.069671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 285.761776 135.189913 
+L 285.761776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 288.453882 135.189913 
+L 288.453882 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 291.145987 135.189913 
+L 291.145987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 293.838092 135.189913 
+L 293.838092 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 296.530197 135.189913 
+L 296.530197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 301.914408 135.189913 
+L 301.914408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 304.606513 135.189913 
+L 304.606513 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 307.298618 135.189913 
+L 307.298618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 309.990724 135.189913 
+L 309.990724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 312.682829 135.189913 
+L 312.682829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 315.374934 135.189913 
+L 315.374934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 318.067039 135.189913 
+L 318.067039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 320.759145 135.189913 
+L 320.759145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 323.45125 135.189913 
+L 323.45125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 326.143355 135.189913 
+L 326.143355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 328.835461 135.189913 
+L 328.835461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 331.527566 135.189913 
+L 331.527566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 334.219671 135.189913 
+L 334.219671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 336.911776 135.189913 
+L 336.911776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 339.603882 135.189913 
+L 339.603882 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 342.295987 135.189913 
+L 342.295987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 347.680197 135.189913 
+L 347.680197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 350.372303 135.189913 
+L 350.372303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 353.064408 135.189913 
+L 353.064408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 355.756513 135.189913 
+L 355.756513 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 358.448618 135.189913 
+L 358.448618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 361.140724 135.189913 
+L 361.140724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 363.832829 135.189913 
+L 363.832829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 366.524934 135.189913 
+L 366.524934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 369.217039 135.189913 
+L 369.217039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 371.909145 135.189913 
+L 371.909145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 374.60125 135.189913 
+L 374.60125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 377.293355 135.189913 
+L 377.293355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 379.985461 135.189913 
+L 379.985461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 382.677566 135.189913 
+L 382.677566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 385.369671 135.189913 
+L 385.369671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 388.061776 135.189913 
+L 388.061776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 393.445987 135.189913 
+L 393.445987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 396.138092 135.189913 
+L 396.138092 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 398.830197 135.189913 
+L 398.830197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 401.522303 135.189913 
+L 401.522303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 404.214408 135.189913 
+L 404.214408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 406.906513 135.189913 
+L 406.906513 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 409.598618 135.189913 
+L 409.598618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 412.290724 135.189913 
+L 412.290724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 414.982829 135.189913 
+L 414.982829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 417.674934 135.189913 
+L 417.674934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 420.367039 135.189913 
+L 420.367039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 423.059145 135.189913 
+L 423.059145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 425.75125 135.189913 
+L 425.75125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 428.443355 135.189913 
+L 428.443355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 431.135461 135.189913 
+L 431.135461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 433.827566 135.189913 
+L 433.827566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 439.211776 135.189913 
+L 439.211776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 441.903882 135.189913 
+L 441.903882 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 444.595987 135.189913 
+L 444.595987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 447.288092 135.189913 
+L 447.288092 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 449.980197 135.189913 
+L 449.980197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 452.672303 135.189913 
+L 452.672303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 455.364408 135.189913 
+L 455.364408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 458.056513 135.189913 
+L 458.056513 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 460.748618 135.189913 
+L 460.748618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 463.440724 135.189913 
+L 463.440724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 466.132829 135.189913 
+L 466.132829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 468.824934 135.189913 
+L 468.824934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 471.517039 135.189913 
+L 471.517039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 474.209145 135.189913 
+L 474.209145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 476.90125 135.189913 
+L 476.90125 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 479.593355 135.189913 
+L 479.593355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 484.977566 135.189913 
+L 484.977566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 487.669671 135.189913 
+L 487.669671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 490.361776 135.189913 
+L 490.361776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 493.053882 135.189913 
+L 493.053882 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 495.745987 135.189913 
+L 495.745987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 498.438092 135.189913 
+L 498.438092 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 501.130197 135.189913 
+L 501.130197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 503.822303 135.189913 
+L 503.822303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 506.514408 135.189913 
+L 506.514408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 509.206513 135.189913 
+L 509.206513 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 511.898618 135.189913 
+L 511.898618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 514.590724 135.189913 
+L 514.590724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 517.282829 135.189913 
+L 517.282829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 519.974934 135.189913 
+L 519.974934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 522.667039 135.189913 
+L 522.667039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 525.359145 135.189913 
+L 525.359145 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 530.743355 135.189913 
+L 530.743355 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 533.435461 135.189913 
+L 533.435461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 536.127566 135.189913 
+L 536.127566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 538.819671 135.189913 
+L 538.819671 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 541.511776 135.189913 
+L 541.511776 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 544.203882 135.189913 
+L 544.203882 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 546.895987 135.189913 
+L 546.895987 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 549.588092 135.189913 
+L 549.588092 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 552.280197 135.189913 
+L 552.280197 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 554.972303 135.189913 
+L 554.972303 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 557.664408 135.189913 
+L 557.664408 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 560.356513 135.189913 
+L 560.356513 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 563.048618 135.189913 
+L 563.048618 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 565.740724 135.189913 
+L 565.740724 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 568.432829 135.189913 
+L 568.432829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 571.124934 135.189913 
+L 571.124934 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 573.817039 135.189913 
+L 573.817039 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 584.585461 135.189913 
+L 584.585461 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 587.277566 135.189913 
+L 587.277566 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 670.732829 135.189913 
+L 670.732829 121.275457 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_7">
+    <path d="M 67.70125 153.498408 
+L 67.70125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 70.393355 153.498408 
+L 70.393355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 73.085461 153.498408 
+L 73.085461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 75.777566 153.498408 
+L 75.777566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 78.469671 153.498408 
+L 78.469671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 81.161776 153.498408 
+L 81.161776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 83.853882 153.498408 
+L 83.853882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 175.385461 153.498408 
+L 175.385461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 178.077566 153.498408 
+L 178.077566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 186.153882 153.498408 
+L 186.153882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 215.767039 153.498408 
+L 215.767039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 218.459145 153.498408 
+L 218.459145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 221.15125 153.498408 
+L 221.15125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 223.843355 153.498408 
+L 223.843355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 226.535461 153.498408 
+L 226.535461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 229.227566 153.498408 
+L 229.227566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 231.919671 153.498408 
+L 231.919671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 234.611776 153.498408 
+L 234.611776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 237.303882 153.498408 
+L 237.303882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 239.995987 153.498408 
+L 239.995987 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 242.688092 153.498408 
+L 242.688092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 245.380197 153.498408 
+L 245.380197 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 248.072303 153.498408 
+L 248.072303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 250.764408 153.498408 
+L 250.764408 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 253.456513 153.498408 
+L 253.456513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 258.840724 153.498408 
+L 258.840724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 261.532829 153.498408 
+L 261.532829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 264.224934 153.498408 
+L 264.224934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 266.917039 153.498408 
+L 266.917039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 269.609145 153.498408 
+L 269.609145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 272.30125 153.498408 
+L 272.30125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 274.993355 153.498408 
+L 274.993355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 277.685461 153.498408 
+L 277.685461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 280.377566 153.498408 
+L 280.377566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 283.069671 153.498408 
+L 283.069671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 285.761776 153.498408 
+L 285.761776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 288.453882 153.498408 
+L 288.453882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 291.145987 153.498408 
+L 291.145987 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 293.838092 153.498408 
+L 293.838092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 296.530197 153.498408 
+L 296.530197 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 299.222303 153.498408 
+L 299.222303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 304.606513 153.498408 
+L 304.606513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 307.298618 153.498408 
+L 307.298618 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 309.990724 153.498408 
+L 309.990724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 312.682829 153.498408 
+L 312.682829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 315.374934 153.498408 
+L 315.374934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 318.067039 153.498408 
+L 318.067039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 320.759145 153.498408 
+L 320.759145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 323.45125 153.498408 
+L 323.45125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 326.143355 153.498408 
+L 326.143355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 328.835461 153.498408 
+L 328.835461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 331.527566 153.498408 
+L 331.527566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 334.219671 153.498408 
+L 334.219671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 336.911776 153.498408 
+L 336.911776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 339.603882 153.498408 
+L 339.603882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 342.295987 153.498408 
+L 342.295987 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 344.988092 153.498408 
+L 344.988092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 350.372303 153.498408 
+L 350.372303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 353.064408 153.498408 
+L 353.064408 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 355.756513 153.498408 
+L 355.756513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 358.448618 153.498408 
+L 358.448618 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 361.140724 153.498408 
+L 361.140724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 363.832829 153.498408 
+L 363.832829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 366.524934 153.498408 
+L 366.524934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 369.217039 153.498408 
+L 369.217039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 371.909145 153.498408 
+L 371.909145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 374.60125 153.498408 
+L 374.60125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 377.293355 153.498408 
+L 377.293355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 379.985461 153.498408 
+L 379.985461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 382.677566 153.498408 
+L 382.677566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 385.369671 153.498408 
+L 385.369671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 388.061776 153.498408 
+L 388.061776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 390.753882 153.498408 
+L 390.753882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 396.138092 153.498408 
+L 396.138092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 398.830197 153.498408 
+L 398.830197 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 401.522303 153.498408 
+L 401.522303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 404.214408 153.498408 
+L 404.214408 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 406.906513 153.498408 
+L 406.906513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 409.598618 153.498408 
+L 409.598618 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 412.290724 153.498408 
+L 412.290724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 414.982829 153.498408 
+L 414.982829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 417.674934 153.498408 
+L 417.674934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 420.367039 153.498408 
+L 420.367039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 423.059145 153.498408 
+L 423.059145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 425.75125 153.498408 
+L 425.75125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 428.443355 153.498408 
+L 428.443355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 431.135461 153.498408 
+L 431.135461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 433.827566 153.498408 
+L 433.827566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 436.519671 153.498408 
+L 436.519671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 441.903882 153.498408 
+L 441.903882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 444.595987 153.498408 
+L 444.595987 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 447.288092 153.498408 
+L 447.288092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 449.980197 153.498408 
+L 449.980197 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 452.672303 153.498408 
+L 452.672303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 455.364408 153.498408 
+L 455.364408 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 458.056513 153.498408 
+L 458.056513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 460.748618 153.498408 
+L 460.748618 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 463.440724 153.498408 
+L 463.440724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 466.132829 153.498408 
+L 466.132829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 468.824934 153.498408 
+L 468.824934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 471.517039 153.498408 
+L 471.517039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 474.209145 153.498408 
+L 474.209145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 476.90125 153.498408 
+L 476.90125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 479.593355 153.498408 
+L 479.593355 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 482.285461 153.498408 
+L 482.285461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 487.669671 153.498408 
+L 487.669671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 490.361776 153.498408 
+L 490.361776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 493.053882 153.498408 
+L 493.053882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 495.745987 153.498408 
+L 495.745987 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 498.438092 153.498408 
+L 498.438092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 501.130197 153.498408 
+L 501.130197 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 503.822303 153.498408 
+L 503.822303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 506.514408 153.498408 
+L 506.514408 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 509.206513 153.498408 
+L 509.206513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 511.898618 153.498408 
+L 511.898618 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 514.590724 153.498408 
+L 514.590724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 517.282829 153.498408 
+L 517.282829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 519.974934 153.498408 
+L 519.974934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 522.667039 153.498408 
+L 522.667039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 525.359145 153.498408 
+L 525.359145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 528.05125 153.498408 
+L 528.05125 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 533.435461 153.498408 
+L 533.435461 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 536.127566 153.498408 
+L 536.127566 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 538.819671 153.498408 
+L 538.819671 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 541.511776 153.498408 
+L 541.511776 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 544.203882 153.498408 
+L 544.203882 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 546.895987 153.498408 
+L 546.895987 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 549.588092 153.498408 
+L 549.588092 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 552.280197 153.498408 
+L 552.280197 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 554.972303 153.498408 
+L 554.972303 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 557.664408 153.498408 
+L 557.664408 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 560.356513 153.498408 
+L 560.356513 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 563.048618 153.498408 
+L 563.048618 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 565.740724 153.498408 
+L 565.740724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 568.432829 153.498408 
+L 568.432829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 571.124934 153.498408 
+L 571.124934 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 573.817039 153.498408 
+L 573.817039 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 576.509145 153.498408 
+L 576.509145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 668.040724 153.498408 
+L 668.040724 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 670.732829 153.498408 
+L 670.732829 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+    <path d="M 678.809145 153.498408 
+L 678.809145 139.583952 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #f58518; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_8">
+    <path d="M 70.393355 171.806902 
+L 70.393355 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 118.85125 171.806902 
+L 118.85125 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 272.30125 171.806902 
+L 272.30125 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 320.759145 171.806902 
+L 320.759145 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 369.217039 171.806902 
+L 369.217039 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 417.674934 171.806902 
+L 417.674934 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 466.132829 171.806902 
+L 466.132829 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 514.590724 171.806902 
+L 514.590724 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 563.048618 171.806902 
+L 563.048618 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 611.506513 171.806902 
+L 611.506513 157.892446 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_9">
+    <path d="M 73.085461 190.115397 
+L 73.085461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 75.777566 190.115397 
+L 75.777566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 78.469671 190.115397 
+L 78.469671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 81.161776 190.115397 
+L 81.161776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 83.853882 190.115397 
+L 83.853882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 86.545987 190.115397 
+L 86.545987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 89.238092 190.115397 
+L 89.238092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 91.930197 190.115397 
+L 91.930197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 94.622303 190.115397 
+L 94.622303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 97.314408 190.115397 
+L 97.314408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 100.006513 190.115397 
+L 100.006513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 102.698618 190.115397 
+L 102.698618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 105.390724 190.115397 
+L 105.390724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 108.082829 190.115397 
+L 108.082829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 110.774934 190.115397 
+L 110.774934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 113.467039 190.115397 
+L 113.467039 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 121.543355 190.115397 
+L 121.543355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 124.235461 190.115397 
+L 124.235461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 126.927566 190.115397 
+L 126.927566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 129.619671 190.115397 
+L 129.619671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 132.311776 190.115397 
+L 132.311776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 135.003882 190.115397 
+L 135.003882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 137.695987 190.115397 
+L 137.695987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 140.388092 190.115397 
+L 140.388092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 143.080197 190.115397 
+L 143.080197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 145.772303 190.115397 
+L 145.772303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 148.464408 190.115397 
+L 148.464408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 151.156513 190.115397 
+L 151.156513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 153.848618 190.115397 
+L 153.848618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 156.540724 190.115397 
+L 156.540724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 159.232829 190.115397 
+L 159.232829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 161.924934 190.115397 
+L 161.924934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 274.993355 190.115397 
+L 274.993355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 277.685461 190.115397 
+L 277.685461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 280.377566 190.115397 
+L 280.377566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 283.069671 190.115397 
+L 283.069671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 285.761776 190.115397 
+L 285.761776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 288.453882 190.115397 
+L 288.453882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 291.145987 190.115397 
+L 291.145987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 293.838092 190.115397 
+L 293.838092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 296.530197 190.115397 
+L 296.530197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 299.222303 190.115397 
+L 299.222303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 301.914408 190.115397 
+L 301.914408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 304.606513 190.115397 
+L 304.606513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 307.298618 190.115397 
+L 307.298618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 309.990724 190.115397 
+L 309.990724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 312.682829 190.115397 
+L 312.682829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 315.374934 190.115397 
+L 315.374934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 323.45125 190.115397 
+L 323.45125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 326.143355 190.115397 
+L 326.143355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 328.835461 190.115397 
+L 328.835461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 331.527566 190.115397 
+L 331.527566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 334.219671 190.115397 
+L 334.219671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 336.911776 190.115397 
+L 336.911776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 339.603882 190.115397 
+L 339.603882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 342.295987 190.115397 
+L 342.295987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 344.988092 190.115397 
+L 344.988092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 347.680197 190.115397 
+L 347.680197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 350.372303 190.115397 
+L 350.372303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 353.064408 190.115397 
+L 353.064408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 355.756513 190.115397 
+L 355.756513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 358.448618 190.115397 
+L 358.448618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 361.140724 190.115397 
+L 361.140724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 363.832829 190.115397 
+L 363.832829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 371.909145 190.115397 
+L 371.909145 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 374.60125 190.115397 
+L 374.60125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 377.293355 190.115397 
+L 377.293355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 379.985461 190.115397 
+L 379.985461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 382.677566 190.115397 
+L 382.677566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 385.369671 190.115397 
+L 385.369671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 388.061776 190.115397 
+L 388.061776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 390.753882 190.115397 
+L 390.753882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 393.445987 190.115397 
+L 393.445987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 396.138092 190.115397 
+L 396.138092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 398.830197 190.115397 
+L 398.830197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 401.522303 190.115397 
+L 401.522303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 404.214408 190.115397 
+L 404.214408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 406.906513 190.115397 
+L 406.906513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 409.598618 190.115397 
+L 409.598618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 412.290724 190.115397 
+L 412.290724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 420.367039 190.115397 
+L 420.367039 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 423.059145 190.115397 
+L 423.059145 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 425.75125 190.115397 
+L 425.75125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 428.443355 190.115397 
+L 428.443355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 431.135461 190.115397 
+L 431.135461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 433.827566 190.115397 
+L 433.827566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 436.519671 190.115397 
+L 436.519671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 439.211776 190.115397 
+L 439.211776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 441.903882 190.115397 
+L 441.903882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 444.595987 190.115397 
+L 444.595987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 447.288092 190.115397 
+L 447.288092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 449.980197 190.115397 
+L 449.980197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 452.672303 190.115397 
+L 452.672303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 455.364408 190.115397 
+L 455.364408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 458.056513 190.115397 
+L 458.056513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 460.748618 190.115397 
+L 460.748618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 468.824934 190.115397 
+L 468.824934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 471.517039 190.115397 
+L 471.517039 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 474.209145 190.115397 
+L 474.209145 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 476.90125 190.115397 
+L 476.90125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 479.593355 190.115397 
+L 479.593355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 482.285461 190.115397 
+L 482.285461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 484.977566 190.115397 
+L 484.977566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 487.669671 190.115397 
+L 487.669671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 490.361776 190.115397 
+L 490.361776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 493.053882 190.115397 
+L 493.053882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 495.745987 190.115397 
+L 495.745987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 498.438092 190.115397 
+L 498.438092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 501.130197 190.115397 
+L 501.130197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 503.822303 190.115397 
+L 503.822303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 506.514408 190.115397 
+L 506.514408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 509.206513 190.115397 
+L 509.206513 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 517.282829 190.115397 
+L 517.282829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 519.974934 190.115397 
+L 519.974934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 522.667039 190.115397 
+L 522.667039 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 525.359145 190.115397 
+L 525.359145 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 528.05125 190.115397 
+L 528.05125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 530.743355 190.115397 
+L 530.743355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 533.435461 190.115397 
+L 533.435461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 536.127566 190.115397 
+L 536.127566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 538.819671 190.115397 
+L 538.819671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 541.511776 190.115397 
+L 541.511776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 544.203882 190.115397 
+L 544.203882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 546.895987 190.115397 
+L 546.895987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 549.588092 190.115397 
+L 549.588092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 552.280197 190.115397 
+L 552.280197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 554.972303 190.115397 
+L 554.972303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 557.664408 190.115397 
+L 557.664408 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 565.740724 190.115397 
+L 565.740724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 568.432829 190.115397 
+L 568.432829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 571.124934 190.115397 
+L 571.124934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 573.817039 190.115397 
+L 573.817039 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 576.509145 190.115397 
+L 576.509145 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 579.20125 190.115397 
+L 579.20125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 581.893355 190.115397 
+L 581.893355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 584.585461 190.115397 
+L 584.585461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 587.277566 190.115397 
+L 587.277566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 589.969671 190.115397 
+L 589.969671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 592.661776 190.115397 
+L 592.661776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 595.353882 190.115397 
+L 595.353882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 598.045987 190.115397 
+L 598.045987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 600.738092 190.115397 
+L 600.738092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 603.430197 190.115397 
+L 603.430197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 606.122303 190.115397 
+L 606.122303 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 614.198618 190.115397 
+L 614.198618 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 616.890724 190.115397 
+L 616.890724 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 619.582829 190.115397 
+L 619.582829 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 622.274934 190.115397 
+L 622.274934 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 624.967039 190.115397 
+L 624.967039 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 627.659145 190.115397 
+L 627.659145 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 630.35125 190.115397 
+L 630.35125 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 633.043355 190.115397 
+L 633.043355 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 635.735461 190.115397 
+L 635.735461 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 638.427566 190.115397 
+L 638.427566 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 641.119671 190.115397 
+L 641.119671 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 643.811776 190.115397 
+L 643.811776 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 646.503882 190.115397 
+L 646.503882 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 649.195987 190.115397 
+L 649.195987 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 651.888092 190.115397 
+L 651.888092 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+    <path d="M 654.580197 190.115397 
+L 654.580197 176.200941 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #54a24b; stroke-width: 1.1"/>
+   </g>
+   <g id="LineCollection_10">
+    <path d="M 97.314408 208.423892 
+L 97.314408 194.509436 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b279a2; stroke-width: 1.1"/>
+    <path d="M 589.969671 208.423892 
+L 589.969671 194.509436 
+" clip-path="url(#p48cfb205ab)" style="fill: none; stroke: #b279a2; stroke-width: 1.1"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 67.70125 217.358437 
+L 67.70125 20.798437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 67.70125 217.358437 
+L 681.50125 217.358437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_11">
+    <!-- one steady-state job (reader firing 8: cycles 1454–1636, span 183) -->
+    <g transform="translate(207.434844 14.798437) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6a" d="M 603 3500 
+L 1178 3500 
+L 1178 -63 
+Q 1178 -731 923 -1031 
+Q 669 -1331 103 -1331 
+L -116 -1331 
+L -116 -844 
+L 38 -844 
+Q 366 -844 484 -692 
+Q 603 -541 603 -63 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2013" d="M 313 1978 
+L 2888 1978 
+L 2888 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6f"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(61.181641 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(124.560547 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(186.083984 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(217.871094 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(269.970703 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(309.179688 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(370.703125 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(431.982422 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(495.458984 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(552.888672 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(588.972656 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(641.072266 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(680.28125 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(741.560547 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(780.769531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(842.292969 0)"/>
+     <use xlink:href="#DejaVuSans-6a" transform="translate(874.080078 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(901.863281 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(963.044922 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1026.521484 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1058.308594 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1097.322266 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1136.185547 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1197.708984 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1258.988281 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1322.464844 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1383.988281 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1425.101562 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1456.888672 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1492.09375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1519.876953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1560.990234 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1588.773438 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1652.152344 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1715.628906 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(1747.416016 0)"/>
+     <use xlink:href="#DejaVuSans-3a" transform="translate(1811.039062 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1844.730469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1876.517578 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(1931.498047 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1990.677734 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2045.658203 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2073.441406 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2134.964844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2187.064453 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(2218.851562 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(2282.474609 0)"/>
+     <use xlink:href="#DejaVuSans-35" transform="translate(2346.097656 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(2409.720703 0)"/>
+     <use xlink:href="#DejaVuSans-2013" transform="translate(2473.34375 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(2523.34375 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2586.966797 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(2650.589844 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2714.212891 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(2777.835938 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2809.623047 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2841.410156 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2893.509766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2956.986328 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3018.265625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3081.644531 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(3113.431641 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(3177.054688 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(3240.677734 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(3304.300781 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 67.70125 309.086437 
+L 681.50125 309.086437 
+L 681.50125 243.566437 
+L 67.70125 243.566437 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_6">
+     <g id="line2d_21">
+      <path d="M 73.085461 309.086437 
+L 73.085461 243.566437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m91400e4105" x="73.085461" y="309.086437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 1450 -->
+      <g transform="translate(60.360461 323.684875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_23">
+      <path d="M 207.690724 309.086437 
+L 207.690724 243.566437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m91400e4105" x="207.690724" y="309.086437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1500 -->
+      <g transform="translate(194.965724 323.684875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_25">
+      <path d="M 342.295987 309.086437 
+L 342.295987 243.566437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m91400e4105" x="342.295987" y="309.086437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1550 -->
+      <g transform="translate(329.570987 323.684875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_27">
+      <path d="M 476.90125 309.086437 
+L 476.90125 243.566437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m91400e4105" x="476.90125" y="309.086437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 1600 -->
+      <g transform="translate(464.17625 323.684875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_29">
+      <path d="M 611.506513 309.086437 
+L 611.506513 243.566437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.4; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m91400e4105" x="611.506513" y="309.086437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 1650 -->
+      <g transform="translate(598.781513 323.684875) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(190.869141 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- clock cycle -->
+     <g transform="translate(347.246563 337.363) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(82.763672 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(143.945312 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(198.925781 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(256.835938 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(288.623047 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(343.603516 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(402.783203 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(457.763672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(485.546875 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_11">
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="309.086437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 0 -->
+      <g transform="translate(54.33875 312.885656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="282.878437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 1 -->
+      <g transform="translate(54.33875 286.677656) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#mdb56eb61dd" x="67.70125" y="256.670437" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 2 -->
+      <g transform="translate(54.33875 260.469656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- copy_data -->
+     <g transform="translate(39.49425 296.890187) rotate(-90) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-63"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(54.980469 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(179.638672 0)"/>
+      <use xlink:href="#DejaVuSans-5f" transform="translate(238.818359 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(288.818359 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(352.294922 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(413.574219 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(452.783203 0)"/>
+     </g>
+     <!-- occupancy -->
+     <g transform="translate(48.675 297.800187) rotate(-90) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-6f"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(61.181641 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(116.162109 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(171.142578 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(234.521484 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(297.998047 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(359.277344 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(422.65625 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(477.636719 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="FillBetweenPolyCollection_1">
+    <path d="M 97.314408 256.670437 
+L 97.314408 309.086437 
+L 100.006513 309.086437 
+L 100.006513 309.086437 
+L 102.698618 309.086437 
+L 102.698618 309.086437 
+L 105.390724 309.086437 
+L 105.390724 309.086437 
+L 108.082829 309.086437 
+L 108.082829 309.086437 
+L 110.774934 309.086437 
+L 110.774934 309.086437 
+L 113.467039 309.086437 
+L 113.467039 309.086437 
+L 116.159145 309.086437 
+L 116.159145 309.086437 
+L 118.85125 309.086437 
+L 118.85125 309.086437 
+L 121.543355 309.086437 
+L 121.543355 309.086437 
+L 124.235461 309.086437 
+L 124.235461 309.086437 
+L 126.927566 309.086437 
+L 126.927566 309.086437 
+L 129.619671 309.086437 
+L 129.619671 309.086437 
+L 132.311776 309.086437 
+L 132.311776 309.086437 
+L 135.003882 309.086437 
+L 135.003882 309.086437 
+L 137.695987 309.086437 
+L 137.695987 309.086437 
+L 140.388092 309.086437 
+L 140.388092 309.086437 
+L 143.080197 309.086437 
+L 143.080197 309.086437 
+L 145.772303 309.086437 
+L 145.772303 309.086437 
+L 148.464408 309.086437 
+L 148.464408 309.086437 
+L 151.156513 309.086437 
+L 151.156513 309.086437 
+L 153.848618 309.086437 
+L 153.848618 309.086437 
+L 156.540724 309.086437 
+L 156.540724 309.086437 
+L 159.232829 309.086437 
+L 159.232829 309.086437 
+L 161.924934 309.086437 
+L 161.924934 309.086437 
+L 164.617039 309.086437 
+L 164.617039 309.086437 
+L 167.309145 309.086437 
+L 167.309145 309.086437 
+L 170.00125 309.086437 
+L 170.00125 309.086437 
+L 172.693355 309.086437 
+L 172.693355 309.086437 
+L 175.385461 309.086437 
+L 175.385461 309.086437 
+L 175.385461 256.670437 
+L 175.385461 256.670437 
+L 175.385461 256.670437 
+L 172.693355 256.670437 
+L 172.693355 256.670437 
+L 170.00125 256.670437 
+L 170.00125 256.670437 
+L 167.309145 256.670437 
+L 167.309145 256.670437 
+L 164.617039 256.670437 
+L 164.617039 256.670437 
+L 161.924934 256.670437 
+L 161.924934 256.670437 
+L 159.232829 256.670437 
+L 159.232829 256.670437 
+L 156.540724 256.670437 
+L 156.540724 256.670437 
+L 153.848618 256.670437 
+L 153.848618 256.670437 
+L 151.156513 256.670437 
+L 151.156513 256.670437 
+L 148.464408 256.670437 
+L 148.464408 256.670437 
+L 145.772303 256.670437 
+L 145.772303 256.670437 
+L 143.080197 256.670437 
+L 143.080197 256.670437 
+L 140.388092 256.670437 
+L 140.388092 256.670437 
+L 137.695987 256.670437 
+L 137.695987 256.670437 
+L 135.003882 256.670437 
+L 135.003882 256.670437 
+L 132.311776 256.670437 
+L 132.311776 256.670437 
+L 129.619671 256.670437 
+L 129.619671 256.670437 
+L 126.927566 256.670437 
+L 126.927566 256.670437 
+L 124.235461 256.670437 
+L 124.235461 256.670437 
+L 121.543355 256.670437 
+L 121.543355 256.670437 
+L 118.85125 256.670437 
+L 118.85125 256.670437 
+L 116.159145 256.670437 
+L 116.159145 256.670437 
+L 113.467039 256.670437 
+L 113.467039 256.670437 
+L 110.774934 256.670437 
+L 110.774934 256.670437 
+L 108.082829 256.670437 
+L 108.082829 256.670437 
+L 105.390724 256.670437 
+L 105.390724 256.670437 
+L 102.698618 256.670437 
+L 102.698618 256.670437 
+L 100.006513 256.670437 
+L 100.006513 256.670437 
+L 97.314408 256.670437 
+z
+" clip-path="url(#pa1aa602b09)" style="fill: #f58518; fill-opacity: 0.25; stroke: #f58518; stroke-opacity: 0.25"/>
+    <path d="M 589.969671 256.670437 
+L 589.969671 309.086437 
+L 592.661776 309.086437 
+L 592.661776 309.086437 
+L 595.353882 309.086437 
+L 595.353882 309.086437 
+L 598.045987 309.086437 
+L 598.045987 309.086437 
+L 600.738092 309.086437 
+L 600.738092 309.086437 
+L 603.430197 309.086437 
+L 603.430197 309.086437 
+L 606.122303 309.086437 
+L 606.122303 309.086437 
+L 608.814408 309.086437 
+L 608.814408 309.086437 
+L 611.506513 309.086437 
+L 611.506513 309.086437 
+L 614.198618 309.086437 
+L 614.198618 309.086437 
+L 616.890724 309.086437 
+L 616.890724 309.086437 
+L 619.582829 309.086437 
+L 619.582829 309.086437 
+L 622.274934 309.086437 
+L 622.274934 309.086437 
+L 624.967039 309.086437 
+L 624.967039 309.086437 
+L 627.659145 309.086437 
+L 627.659145 309.086437 
+L 630.35125 309.086437 
+L 630.35125 309.086437 
+L 633.043355 309.086437 
+L 633.043355 309.086437 
+L 635.735461 309.086437 
+L 635.735461 309.086437 
+L 638.427566 309.086437 
+L 638.427566 309.086437 
+L 641.119671 309.086437 
+L 641.119671 309.086437 
+L 643.811776 309.086437 
+L 643.811776 309.086437 
+L 646.503882 309.086437 
+L 646.503882 309.086437 
+L 649.195987 309.086437 
+L 649.195987 309.086437 
+L 651.888092 309.086437 
+L 651.888092 309.086437 
+L 654.580197 309.086437 
+L 654.580197 309.086437 
+L 657.272303 309.086437 
+L 657.272303 309.086437 
+L 659.964408 309.086437 
+L 659.964408 309.086437 
+L 662.656513 309.086437 
+L 662.656513 309.086437 
+L 665.348618 309.086437 
+L 665.348618 309.086437 
+L 668.040724 309.086437 
+L 668.040724 309.086437 
+L 668.040724 256.670437 
+L 668.040724 256.670437 
+L 668.040724 256.670437 
+L 665.348618 256.670437 
+L 665.348618 256.670437 
+L 662.656513 256.670437 
+L 662.656513 256.670437 
+L 659.964408 256.670437 
+L 659.964408 256.670437 
+L 657.272303 256.670437 
+L 657.272303 256.670437 
+L 654.580197 256.670437 
+L 654.580197 256.670437 
+L 651.888092 256.670437 
+L 651.888092 256.670437 
+L 649.195987 256.670437 
+L 649.195987 256.670437 
+L 646.503882 256.670437 
+L 646.503882 256.670437 
+L 643.811776 256.670437 
+L 643.811776 256.670437 
+L 641.119671 256.670437 
+L 641.119671 256.670437 
+L 638.427566 256.670437 
+L 638.427566 256.670437 
+L 635.735461 256.670437 
+L 635.735461 256.670437 
+L 633.043355 256.670437 
+L 633.043355 256.670437 
+L 630.35125 256.670437 
+L 630.35125 256.670437 
+L 627.659145 256.670437 
+L 627.659145 256.670437 
+L 624.967039 256.670437 
+L 624.967039 256.670437 
+L 622.274934 256.670437 
+L 622.274934 256.670437 
+L 619.582829 256.670437 
+L 619.582829 256.670437 
+L 616.890724 256.670437 
+L 616.890724 256.670437 
+L 614.198618 256.670437 
+L 614.198618 256.670437 
+L 611.506513 256.670437 
+L 611.506513 256.670437 
+L 608.814408 256.670437 
+L 608.814408 256.670437 
+L 606.122303 256.670437 
+L 606.122303 256.670437 
+L 603.430197 256.670437 
+L 603.430197 256.670437 
+L 600.738092 256.670437 
+L 600.738092 256.670437 
+L 598.045987 256.670437 
+L 598.045987 256.670437 
+L 595.353882 256.670437 
+L 595.353882 256.670437 
+L 592.661776 256.670437 
+L 592.661776 256.670437 
+L 589.969671 256.670437 
+z
+" clip-path="url(#pa1aa602b09)" style="fill: #f58518; fill-opacity: 0.25; stroke: #f58518; stroke-opacity: 0.25"/>
+   </g>
+   <g id="line2d_34">
+    <path d="M 67.70125 282.878437 
+L 86.545987 282.878437 
+L 86.545987 309.086437 
+L 94.622303 309.086437 
+L 94.622303 282.878437 
+L 97.314408 282.878437 
+L 97.314408 256.670437 
+L 178.077566 256.670437 
+L 178.077566 282.878437 
+L 188.845987 282.878437 
+L 188.845987 309.086437 
+L 215.767039 309.086437 
+L 215.767039 282.878437 
+L 256.148618 282.878437 
+L 256.148618 309.086437 
+L 258.840724 309.086437 
+L 258.840724 282.878437 
+L 301.914408 282.878437 
+L 301.914408 309.086437 
+L 304.606513 309.086437 
+L 304.606513 282.878437 
+L 347.680197 282.878437 
+L 347.680197 309.086437 
+L 350.372303 309.086437 
+L 350.372303 282.878437 
+L 393.445987 282.878437 
+L 393.445987 309.086437 
+L 396.138092 309.086437 
+L 396.138092 282.878437 
+L 439.211776 282.878437 
+L 439.211776 309.086437 
+L 441.903882 309.086437 
+L 441.903882 282.878437 
+L 484.977566 282.878437 
+L 484.977566 309.086437 
+L 487.669671 309.086437 
+L 487.669671 282.878437 
+L 530.743355 282.878437 
+L 530.743355 309.086437 
+L 533.435461 309.086437 
+L 533.435461 282.878437 
+L 579.20125 282.878437 
+L 579.20125 309.086437 
+L 587.277566 309.086437 
+L 587.277566 282.878437 
+L 589.969671 282.878437 
+L 589.969671 256.670437 
+L 670.732829 256.670437 
+L 670.732829 282.878437 
+L 681.50125 282.878437 
+L 681.50125 309.086437 
+L 681.50125 309.086437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke: #f58518; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_35">
+    <path d="M 67.70125 256.670437 
+L 681.50125 256.670437 
+" clip-path="url(#pa1aa602b09)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #666666; stroke-width: 0.8"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 67.70125 309.086437 
+L 67.70125 243.566437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 67.70125 309.086437 
+L 681.50125 309.086437 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_22">
+    <!-- shaded = at capacity (2) → producer blocked -->
+    <g style="fill: #404040" transform="translate(70.77025 252.739237) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3d" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2192" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(115.478516 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(176.757812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(240.234375 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(301.757812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(365.234375 0)"/>
+     <use xlink:href="#DejaVuSans-3d" transform="translate(397.021484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(480.810547 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(512.597656 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(573.876953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(613.085938 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(644.873047 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(699.853516 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(761.132812 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(824.609375 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(885.888672 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(940.869141 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(968.652344 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(1007.861328 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1067.041016 0)"/>
+     <use xlink:href="#DejaVuSans-28" transform="translate(1098.828125 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(1137.841797 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(1201.464844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1240.478516 0)"/>
+     <use xlink:href="#DejaVuSans-2192" transform="translate(1272.265625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1356.054688 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1387.841797 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1451.318359 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1490.181641 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1551.363281 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1614.839844 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1678.21875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1733.199219 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1794.722656 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1835.835938 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1867.623047 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1931.099609 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1958.882812 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2020.064453 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(2075.044922 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2129.330078 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2190.853516 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p48cfb205ab">
+   <rect x="67.70125" y="20.798437" width="613.8" height="196.56"/>
+  </clipPath>
+  <clipPath id="pa1aa602b09">
+   <rect x="67.70125" y="243.566437" width="613.8" height="65.52"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/examples/memcpy/rtlsim.md
+++ b/docs/examples/memcpy/rtlsim.md
@@ -94,6 +94,11 @@ So use each rung for what it is good at:
   every edit.
 - **RTL** — the number you would quote. The `-m xsi` gate asserts **2908** exactly.
 
-Closing that ~22% gap is calibration work, and it is open: the timing model has parameters that can be
-fit against cosim, and that has not been done for this design yet. Until then, treat a pysim cycle count
-as a lower bound with the right shape, not a prediction.
+Closing that ~22% gap is calibration work. The **measurement** side of it is now built and is the
+subject of the next page: [Timing instrumentation](./timing.md) traces the internal channels and both
+`m_axi` bundles out of an RTL run and attributes the 183 cycles to named signals. The short version
+of what it finds — the gap is one cycle per word plus **two cycles per AXI burst**, and the writer,
+not the reader, is the bottleneck.
+
+Feeding those numbers back into the SimPy model is the part still open. Until that lands, treat a
+pysim cycle count as a lower bound with the right shape, not a prediction.

--- a/docs/examples/memcpy/rtlsim.md
+++ b/docs/examples/memcpy/rtlsim.md
@@ -70,35 +70,21 @@ run loops a fixed 3400 cycles with a drain tail, but the *work* finishes at 2908
 schedule, so if a change perturbs it, the assertion moves — a real behaviour change worth a human look,
 not an inequality that would absorb a regression silently.
 
-## Comparing timing to pysim
+## Which rung to trust for what
 
-The [pysim rung](./testbench.md) ran the *same graph* and reported per-job completion cycles, so the two
-are directly comparable:
+The [pysim rung](./testbench.md) ran the *same graph*, and the two agree on the **architectural**
+story: the design is pipelined, not sequential; the period is dominated by one direction
+(`max(read, write)`), not the sum; the job count and ordering match. They do **not** agree on the
+cycle count — pysim runs optimistic, because a transaction-level model does not reproduce every
+source of per-cycle contention in the generated RTL.
 
-|                         | pysim | RTL (XSI) | pysim / RTL |
-| ----------------------- | ----- | --------- | ----------- |
-| fill (first completion) | 156   | 163       | 96%         |
-| steady-state period     | 140   | 183       | 77%         |
-| total, 16 jobs          | 2256  | 2908      | 78%         |
-
-Both decompose the same way — `first + 15 × period` — and both tell the same **architectural** story:
-the design is pipelined, not sequential; the period is dominated by one direction (`max(read, write)`),
-not the sum; and the job count and ordering agree. But pysim runs **optimistic** — it under-counts the
-steady-state period by roughly a quarter, because a transaction-level model does not reproduce every
-source of per-cycle contention in the generated RTL (recall the pysim crossbar models contention the
-RTL slaves do not — the two describe slightly different systems on purpose).
-
-So use each rung for what it is good at:
+So use each for what it is good at:
 
 - **pysim** — correctness, overlap and structure, deadlock, job accounting. Fast enough to run on
   every edit.
 - **RTL** — the number you would quote. The `-m xsi` gate asserts **2908** exactly.
 
-Closing that ~22% gap is calibration work. The **measurement** side of it is now built and is the
-subject of the next page: [Timing instrumentation](./timing.md) traces the internal channels and both
-`m_axi` bundles out of an RTL run and attributes the 183 cycles to named signals. The short version
-of what it finds — the gap is one cycle per word plus **two cycles per AXI burst**, and the writer,
-not the reader, is the bottleneck.
-
-Feeding those numbers back into the SimPy model is the part still open. Until that lands, treat a
-pysim cycle count as a lower bound with the right shape, not a prediction.
+*Why* the two differ, and what to do about it, is the next page: [Timing
+instrumentation](./timing.md) traces the internal channels and both `m_axi` bundles out of an RTL
+run and attributes every cycle of the period to a named signal. Until that feeds back into the
+model, treat a pysim cycle count as a lower bound with the right shape, not a prediction.

--- a/docs/examples/memcpy/timing.md
+++ b/docs/examples/memcpy/timing.md
@@ -36,7 +36,9 @@ close to all the work.
 
 ## The per-firing table
 
-[`ExtractBurstsStep`](../../guide/timing/trace_steps.md) writes one row per **firing** of each
+Recall that free-running components (`FreeRunComp`) repeatedly call a `run_iter` function. Each
+iteration begins when its input data is available, then terminates and waits for the next. The
+[`ExtractBurstsStep`](../../guide/timing/trace_steps.md) writes one row per such **firing** of each
 component:
 
 ```json

--- a/docs/examples/memcpy/timing.md
+++ b/docs/examples/memcpy/timing.md
@@ -17,7 +17,16 @@ python examples/mem_copy/mem_copy_build.py --through extract_bursts
 ```
 
 That runs four steps beyond the [testbench codegen](./codegen_tb.md). Two of them cost nothing (they
-are pure `elaborate()`), one needs the toolchain, and the last is waveform analysis.
+are pure `elaborate()`), one needs the toolchain, and the last is waveform analysis. A fifth
+(`timing_figures`) renders the pictures on this page; `sync_docs_figures` promotes them into
+`docs/`.
+
+![Stage activity across the whole run](./images/timeline_full.svg)
+
+Every stage of the pipeline on one cycle axis, 16 jobs. Three things are visible before any
+analysis: the **183-cycle cadence**, the fact that `gmem0 R` (reads) and `gmem1 W` (writes) are busy
+*simultaneously* rather than in turn — the design really is pipelined — and that the writer's green
+band is nearly continuous while the command lanes at the top are almost entirely idle.
 
 ## The problem: XSI cannot see inside the kernel
 
@@ -130,9 +139,29 @@ uncontended:
 | `mem_r_stream` | 1–15 | 183 | **30** |
 | `mem_w_stream` | 0–15 | **183** | 0 |
 
+![Per-firing span, split into own work and waiting](./images/firing_spans.svg)
+
+Colour is the component's own work, grey is waiting on a full channel — and the bottleneck needs no
+arithmetic to spot. The writer is solid green at 183 on every firing: busy the entire period. The
+reader is 153 on firing 0, then 153 + 30 grey. And the sequencer is ~5 cycles of work against ~175
+of waiting: it finishes a command almost immediately and then sits behind everything downstream.
+
 The writer is never blocked — it is the bottleneck, 100% utilised at 183 of a 183-cycle period. The
 reader's 30 cycles are it waiting on a writer that is still draining. That is *emergent* congestion,
 not a component property, and it is exactly what must **not** be baked into a component's model.
+
+### Where the 30 cycles actually are
+
+![One job, beat by beat, with FIFO occupancy](./images/timeline_job.svg)
+
+One steady-state firing. The lower panel is the `copy_data` FIFO's occupancy, and the shaded band is
+it sitting **at capacity** — the reader blocked, unable to hand over its descriptor words, because
+the writer has not finished draining the *previous* job yet. Reading right to left across the top
+panel: the reader's `gmem0 AR` bursts only begin after that band clears.
+
+Look also at the far right of the top panel. `s_done out` fires, and `gmem1 W` **keeps going for
+another ~24 cycles afterwards**. That is the posted-write behaviour that makes `ap_done` the only
+honest place to end a firing.
 
 **Subtract the bus occupancy and a constant remains.** With `bus = nwords + 2 × (num_trans − 1)`:
 

--- a/docs/examples/memcpy/timing.md
+++ b/docs/examples/memcpy/timing.md
@@ -4,114 +4,40 @@ parent: Memory Copy
 nav_order: 7
 ---
 
-# Timing instrumentation — measuring where the cycles go
+# Timing — where the 183 cycles go
 
-The [RTL simulation](./rtlsim.md) page ends with a number: **2908 cycles** for 16 jobs, or a
-steady-state period of **183 cycles/job**. The pysim model says 140. This page is about closing that
-gap — not by fitting a fudge factor, but by *attributing* it to named signals.
+The [RTL simulation](./rtlsim.md) page ends with a number: **2908 cycles** for 16 jobs, a
+steady-state period of **183 cycles/job**, where the [pysim model](./testbench.md) said 140. This
+page closes that gap — not by fitting a fudge factor, but by *attributing* every cycle to a named
+signal.
 
-Everything here is one build command:
+To do that we need to see inside the kernel: the two internal `framed_word` FIFOs (`cmd` and
+`copy_data`) that wire the three tasks, and both `m_axi` bundles. Getting those signals out of an
+RTL run, by exact name, is general Waveflow machinery — the four
+[trace steps](../../guide/timing/trace_steps.md) — so this page uses it rather than re-explaining it:
 
 ```bash
 python examples/mem_copy/mem_copy_build.py --through extract_bursts
 ```
 
-That runs four steps beyond the [testbench codegen](./codegen_tb.md). Two of them cost nothing (they
-are pure `elaborate()`), one needs the toolchain, and the last is waveform analysis. A fifth
-(`timing_figures`) renders the pictures on this page; `sync_docs_figures` promotes them into
-`docs/`.
+That produces `mem_copy_trace.vcd` (the waveform), `mem_copy_trace.json` (the net-name manifest), and
+`mem_copy_timing.json` (a per-firing timing table). A fifth step, `timing_figures`, renders the
+pictures below; `sync_docs_figures` promotes them into the docs.
+
+## The run at a glance
 
 ![Stage activity across the whole run](./images/timeline_full.svg)
 
-Every stage of the pipeline on one cycle axis, 16 jobs. Three things are visible before any
-analysis: the **183-cycle cadence**, the fact that `gmem0 R` (reads) and `gmem1 W` (writes) are busy
-*simultaneously* rather than in turn — the design really is pipelined — and that the writer's green
-band is nearly continuous while the command lanes at the top are almost entirely idle.
+Every stage of the pipeline on one cycle axis, 16 jobs. Three things are visible before any analysis:
+the **183-cycle cadence**; that `gmem0 R` (reads) and `gmem1 W` (writes) are busy *simultaneously*
+rather than in turn, so the design really is pipelined; and that the writer's green band is nearly
+continuous while the command lanes at the top are almost entirely idle. The writer is doing something
+close to all the work.
 
-## The problem: XSI cannot see inside the kernel
+## The per-firing table
 
-`xsi_get_port_number` resolves **top-level ports only**. The interesting signals in `mem_copy` are
-not ports — they are the two internal `framed_word` FIFOs (`cmd` and `copy_data`) that wire the
-three tasks together. Through XSI's value API they are unreachable.
-
-The way in is `$dumpvars`, from a small Verilog module elaborated *alongside* the DUT.
-
-## Step 1 — `AddVcdTopStep`: the dumper
-
-Writes `xsi/vcd_dumper_<top>.v`:
-
-```verilog
-module vcd_dumper_mem_copy;
-    initial begin
-        $dumpfile("mem_copy_trace.vcd");
-        $dumpvars(1, mem_copy);
-    end
-endmodule
-```
-
-Two details carry all the weight.
-
-**It is a second top, not a wrapper.** `run.bat … trace` elaborates `work.mem_copy
-work.vcd_dumper_mem_copy`. The DUT is untouched, so every BFM port number and every cycle count is
-identical to an untraced run — the trace *observes*, it does not perturb.
-
-**The level is 1, not 0.** Level 1 dumps this scope's own signals and does not descend into
-children. That sounds like it would miss the internal FIFOs, and it does not: **Vitis lifts
-inter-task dataflow channel wires up into the top scope**, beside the task instances. So a level-1
-dump already reaches
-
-```
-cmd_dout / cmd_empty_n / cmd_full_n          the channel itself
-mem_seq_..._U0_cmd_din / _cmd_write          the producer's side
-mem_r_stream_..._U0_cmd_read                 the consumer's side
-<task>_U0_ap_done                            each task's firing boundary
-```
-
-with **no hierarchical path to resolve**. Level 0 would dump the entire subtree for no extra reach.
-The cost stays bounded: 258 signals for `mem_copy`, 363 for `interleaver_canon`.
-
-The module is named after the top because one `xsi/` directory can serve several tops
-(`examples/interleaver/xsi` builds three), and a dumper naming a scope that is not part of *this*
-elaboration is a hard error.
-
-## Step 2 — `TraceManifestStep`: what the nets are called
-
-Writes `results/mem_copy_trace.json`, mapping the Python graph onto RTL net names. Derived entirely
-from `elaborate()` — no RTL is read, nothing is simulated.
-
-Why a manifest instead of matching names in the waveform? Because substring matching is not merely
-fragile here, it is **wrong**. An interleaver trace contains both
-
-```
-ywords_fifo_cap[2:0]                       the channel's counter
-il_store_..._U0_ywords_fifo_cap[31:0]      the instance's own copy
-```
-
-Different widths, different meanings, and a matcher takes whichever it sees first. The names are
-already known — codegen chose them — so the manifest binds *exactly*, and a net that has gone
-missing fails loudly instead of silently extracting nothing.
-
-Only the `_U0` instance suffix is Vitis's choice; channel names are the C++ stream variables, port
-names are the boundary names, `m_axi` nets are named after the bundle.
-
-## Step 3 — `RtlSimStep`: run it, tracing
-
-A thin wrapper over `xsi/run.bat`, passing its third argument `trace`.
-
-**This step asserts nothing.** It runs and produces `xsi/mem_copy_trace.vcd`. The exact cycle count
-stays with the `-m xsi` gate, which calls `run.bat` directly — routing a green gate through new code
-is how a gate quietly stops meaning what it meant.
-
-{: .warning }
-> **Re-running the built `.exe` does not regenerate the VCD.** Only the full `run.bat` path does,
-> because the dump comes from the elaborated snapshot. A sweep that re-ran the binary per data point
-> once silently re-measured the *previous* trace and reported an identical period at five different
-> job sizes. `RtlSimStep` deletes the VCD first and fails if it does not reappear.
-
-## Step 4 — `ExtractBurstsStep`: the timing table
-
-Binds the manifest to the waveform and writes `results/mem_copy_timing.json` — one row per
-**firing** of each component:
+[`ExtractBurstsStep`](../../guide/timing/trace_steps.md) writes one row per **firing** of each
+component:
 
 ```json
 {"component": "mem_w_stream_framed_done_task", "index": 8,
@@ -119,16 +45,13 @@ Binds the manifest to the waveform and writes `results/mem_copy_timing.json` —
  "nwords": 128, "num_trans": 8, "blocked": 0}
 ```
 
-- `span` — first input handshake → `ap_done`
-- `nwords` / `num_trans` — `m_axi` beats and bursts inside the firing, *measured* off the trace
-- `blocked` — cycles this component's output channel sat at capacity
+`span` is the firing's true occupancy — first input handshake to `ap_done`, *not* its last output
+beat, because the writer's `m_axi` stores are posted and keep draining after `s_done`
+([why that matters](../../guide/timing/trace_pitfalls.md#2-a-firing-ends-at-ap_done-not-the-last-output-beat)).
+`blocked` is cycles its output channel sat at capacity, read from the FIFO occupancy counters rather
+than a write enable ([why](../../guide/timing/trace_pitfalls.md#3-read-backpressure-from-occupancy-not-the-write-enable)).
 
-That is deliberately the shape a calibration consumes: `span` regressed over `{nwords, num_trans}`.
-It is also everything the figures need.
-
-## Reading the result
-
-Two facts fall straight out of the table.
+Two facts fall straight out of it.
 
 **`blocked == 0` isolates the rows you may calibrate on.** Only the reader's *first* firing is
 uncontended:
@@ -143,80 +66,61 @@ uncontended:
 
 Colour is the component's own work, grey is waiting on a full channel — and the bottleneck needs no
 arithmetic to spot. The writer is solid green at 183 on every firing: busy the entire period. The
-reader is 153 on firing 0, then 153 + 30 grey. And the sequencer is ~5 cycles of work against ~175
-of waiting: it finishes a command almost immediately and then sits behind everything downstream.
+reader is 153 on firing 0, then 153 + 30 grey. And the sequencer is ~5 cycles of work against ~175 of
+waiting — it finishes a command almost immediately and then sits behind everything downstream.
 
-The writer is never blocked — it is the bottleneck, 100% utilised at 183 of a 183-cycle period. The
-reader's 30 cycles are it waiting on a writer that is still draining. That is *emergent* congestion,
-not a component property, and it is exactly what must **not** be baked into a component's model.
+So the writer is the bottleneck, 100% utilised at 183 of a 183-cycle period. The reader's 30 cycles
+are it waiting on a writer that is still draining — *emergent* congestion, not a component property,
+and exactly what must **not** be baked into a component's model.
 
-### Where the 30 cycles actually are
+## Where the 30 cycles actually are
 
 ![One job, beat by beat, with FIFO occupancy](./images/timeline_job.svg)
 
 One steady-state firing. The lower panel is the `copy_data` FIFO's occupancy, and the shaded band is
-it sitting **at capacity** — the reader blocked, unable to hand over its descriptor words, because
-the writer has not finished draining the *previous* job yet. Reading right to left across the top
-panel: the reader's `gmem0 AR` bursts only begin after that band clears.
+it at **capacity** — the reader blocked, unable to hand over its descriptor words, because the writer
+has not finished draining the *previous* job. The reader's `gmem0 AR` bursts (top panel) only begin
+after that band clears.
 
-Look also at the far right of the top panel. `s_done out` fires, and `gmem1 W` **keeps going for
-another ~24 cycles afterwards**. That is the posted-write behaviour that makes `ap_done` the only
-honest place to end a firing.
+Look also at the far right: `s_done out` fires, and `gmem1 W` **keeps going for another ~24 cycles**.
+That is the posted-write drain — the reason a firing must end at `ap_done` and not at `s_done`.
 
-**Subtract the bus occupancy and a constant remains.** With `bus = nwords + 2 × (num_trans − 1)`:
+## The law
 
-| component | `span − bus` |
-| --- | --- |
-| `mem_w_stream` | **41** |
-| `mem_r_stream` | **11** |
-
-Same bus law, different per-component constants — which is the two-level calibration split made
-visible: the burst term is a *platform* property of the `m_axi` adapter, the constant is the
-component's own control cost.
-
-## Three traps this instrumentation exists to avoid
-
-**Sample mid clock-low, not on the rising edge.** A VCD records a change caused by an edge *at* that
-edge's timestamp, so sampling there reads the value the edge produced. For a two-wire handshake that
-is not a clean one-cycle shift — it both invents and destroys coincidences. On this trace it read
-AXI-MM `AW` as 16 accepted addresses instead of 128. `waveflow.utils.vcd.clock_sample_times` steps
-back a quarter period; beats are still *labelled* by the true edge time.
-
-**A firing ends at `ap_done`, not at the last output beat.** An `m_axi` store is *posted* — it
-retires when the adapter accepts the word, not when the beat is on the bus. `mem_copy`'s writer
-emits `s_done` at cycle 1642, its last W beat lands at 1666 and its B response at 1667. Anchoring on
-the output beat measures 155 where the firing is 183, and *inverts which stage looks like the
-bottleneck*.
-
-A free-running top has no control interface, but each `hls::task` instance inside it is an ordinary
-`ap_ctrl_hs` block with `ap_start`/`ap_continue` tied to `1'b1` — so `ap_done` still pulses once per
-firing, and HLS holds it until the firing's outstanding writes have responded.
-
-**Read backpressure from the FIFO's occupancy, not its write enable.** HLS *gates* the write enable:
-a task blocked on a full channel stalls its pipeline without ever asserting `write`, so a
-`write & !full_n` metric reports zero backpressure while the producer is stuck. `blocked` compares
-`<ch>_num_data_valid` against `<ch>_fifo_cap` instead. This is what located the 30 cycles.
-
-## What this is for
-
-The measured law for `mem_copy`'s writer, across `n_words` from 32 to 512:
+Sweeping `n_words` from 32 to 512 (a 16× range), the writer's firing span is exactly:
 
 ```
 span = 41 + n + 2 × (ceil(n/16) − 1)
 ```
 
 One cycle per word, **two cycles per AXI burst boundary** (HLS's `max_burst_length` is 16), plus a
-fixed control cost. The burst term belongs on `BusTiming` (the memory slave); the 41 belongs to the
-component.
+fixed control cost — the two-cycle term read straight off the gaps between W bursts in the trace. The
+same structure appears as a two-level split in the table itself: subtract the bus occupancy
+`nwords + 2 × (num_trans − 1)` and a **constant** remains per component:
 
-Feeding those back into the SimPy model — and giving the internal channels their real depth of 2 —
-reproduces the RTL across that whole 16× range to **1.1%**, with the 30 cycles of congestion
-emerging rather than being fitted. Implementing that in the framework, and automating the fit, is
-the next arc: see `plans/memcpy_timing_calibration.md`.
+| component | `span − bus` |
+| --- | --- |
+| `mem_w_stream` | **41** |
+| `mem_r_stream` | **11** |
+
+Same bus law, different per-component constants. The burst term is a *platform* property of the
+`m_axi` adapter — it belongs on a [`BusTiming`](../../guide/timing/aximm.md) model shared by every
+accelerator; the constant is the component's own control cost.
+
+## Why this is a model, not a fit
+
+The two constants were measured on **uncontended** firings only (`blocked == 0`). Feed them back into
+the SimPy model, give the internal channels their real depth of 2, and the 30 cycles of congestion
+**emerge** rather than being fitted — reproducing the RTL across the whole 16× range to **1.1%**,
+versus 27% for a single-point fit. That is the payoff of getting the measurement window right: a
+component model calibrated in isolation that still predicts the contended system.
+
+Implementing that split in the framework — `BusTiming` on the memory slave, the fixed latency on the
+component, channel depth from the same declaration codegen uses — and automating the fit, is the next
+arc. See [`plans/memcpy_timing_calibration.md`](https://github.com/sdrangan/waveflow/tree/main/plans/memcpy_timing_calibration.md).
 
 ## See also
 
+- [Tracing a kernel run](../../guide/timing/trace_steps.md) — the four steps, in general
+- [Trace pitfalls](../../guide/timing/trace_pitfalls.md) — the three traps this relied on avoiding
 - [RTL simulation](./rtlsim.md) — the run this instruments
-- [Testbench codegen](./codegen_tb.md) — the harness the trace observes
-- `waveflow/utils/trace.py` — `load_trace`, `BoundTrace`, `Firing`
-- `waveflow/build/trace_steps.py` — the four steps

--- a/docs/examples/memcpy/timing.md
+++ b/docs/examples/memcpy/timing.md
@@ -1,0 +1,193 @@
+---
+title: Timing instrumentation
+parent: Memory Copy
+nav_order: 7
+---
+
+# Timing instrumentation — measuring where the cycles go
+
+The [RTL simulation](./rtlsim.md) page ends with a number: **2908 cycles** for 16 jobs, or a
+steady-state period of **183 cycles/job**. The pysim model says 140. This page is about closing that
+gap — not by fitting a fudge factor, but by *attributing* it to named signals.
+
+Everything here is one build command:
+
+```bash
+python examples/mem_copy/mem_copy_build.py --through extract_bursts
+```
+
+That runs four steps beyond the [testbench codegen](./codegen_tb.md). Two of them cost nothing (they
+are pure `elaborate()`), one needs the toolchain, and the last is waveform analysis.
+
+## The problem: XSI cannot see inside the kernel
+
+`xsi_get_port_number` resolves **top-level ports only**. The interesting signals in `mem_copy` are
+not ports — they are the two internal `framed_word` FIFOs (`cmd` and `copy_data`) that wire the
+three tasks together. Through XSI's value API they are unreachable.
+
+The way in is `$dumpvars`, from a small Verilog module elaborated *alongside* the DUT.
+
+## Step 1 — `AddVcdTopStep`: the dumper
+
+Writes `xsi/vcd_dumper_<top>.v`:
+
+```verilog
+module vcd_dumper_mem_copy;
+    initial begin
+        $dumpfile("mem_copy_trace.vcd");
+        $dumpvars(1, mem_copy);
+    end
+endmodule
+```
+
+Two details carry all the weight.
+
+**It is a second top, not a wrapper.** `run.bat … trace` elaborates `work.mem_copy
+work.vcd_dumper_mem_copy`. The DUT is untouched, so every BFM port number and every cycle count is
+identical to an untraced run — the trace *observes*, it does not perturb.
+
+**The level is 1, not 0.** Level 1 dumps this scope's own signals and does not descend into
+children. That sounds like it would miss the internal FIFOs, and it does not: **Vitis lifts
+inter-task dataflow channel wires up into the top scope**, beside the task instances. So a level-1
+dump already reaches
+
+```
+cmd_dout / cmd_empty_n / cmd_full_n          the channel itself
+mem_seq_..._U0_cmd_din / _cmd_write          the producer's side
+mem_r_stream_..._U0_cmd_read                 the consumer's side
+<task>_U0_ap_done                            each task's firing boundary
+```
+
+with **no hierarchical path to resolve**. Level 0 would dump the entire subtree for no extra reach.
+The cost stays bounded: 258 signals for `mem_copy`, 363 for `interleaver_canon`.
+
+The module is named after the top because one `xsi/` directory can serve several tops
+(`examples/interleaver/xsi` builds three), and a dumper naming a scope that is not part of *this*
+elaboration is a hard error.
+
+## Step 2 — `TraceManifestStep`: what the nets are called
+
+Writes `results/mem_copy_trace.json`, mapping the Python graph onto RTL net names. Derived entirely
+from `elaborate()` — no RTL is read, nothing is simulated.
+
+Why a manifest instead of matching names in the waveform? Because substring matching is not merely
+fragile here, it is **wrong**. An interleaver trace contains both
+
+```
+ywords_fifo_cap[2:0]                       the channel's counter
+il_store_..._U0_ywords_fifo_cap[31:0]      the instance's own copy
+```
+
+Different widths, different meanings, and a matcher takes whichever it sees first. The names are
+already known — codegen chose them — so the manifest binds *exactly*, and a net that has gone
+missing fails loudly instead of silently extracting nothing.
+
+Only the `_U0` instance suffix is Vitis's choice; channel names are the C++ stream variables, port
+names are the boundary names, `m_axi` nets are named after the bundle.
+
+## Step 3 — `RtlSimStep`: run it, tracing
+
+A thin wrapper over `xsi/run.bat`, passing its third argument `trace`.
+
+**This step asserts nothing.** It runs and produces `xsi/mem_copy_trace.vcd`. The exact cycle count
+stays with the `-m xsi` gate, which calls `run.bat` directly — routing a green gate through new code
+is how a gate quietly stops meaning what it meant.
+
+{: .warning }
+> **Re-running the built `.exe` does not regenerate the VCD.** Only the full `run.bat` path does,
+> because the dump comes from the elaborated snapshot. A sweep that re-ran the binary per data point
+> once silently re-measured the *previous* trace and reported an identical period at five different
+> job sizes. `RtlSimStep` deletes the VCD first and fails if it does not reappear.
+
+## Step 4 — `ExtractBurstsStep`: the timing table
+
+Binds the manifest to the waveform and writes `results/mem_copy_timing.json` — one row per
+**firing** of each component:
+
+```json
+{"component": "mem_w_stream_framed_done_task", "index": 8,
+ "start": 1488, "end": 1670, "span": 183,
+ "nwords": 128, "num_trans": 8, "blocked": 0}
+```
+
+- `span` — first input handshake → `ap_done`
+- `nwords` / `num_trans` — `m_axi` beats and bursts inside the firing, *measured* off the trace
+- `blocked` — cycles this component's output channel sat at capacity
+
+That is deliberately the shape a calibration consumes: `span` regressed over `{nwords, num_trans}`.
+It is also everything the figures need.
+
+## Reading the result
+
+Two facts fall straight out of the table.
+
+**`blocked == 0` isolates the rows you may calibrate on.** Only the reader's *first* firing is
+uncontended:
+
+| component | firing | span | blocked |
+| --- | --- | --- | --- |
+| `mem_r_stream` | 0 | **153** | 0 |
+| `mem_r_stream` | 1–15 | 183 | **30** |
+| `mem_w_stream` | 0–15 | **183** | 0 |
+
+The writer is never blocked — it is the bottleneck, 100% utilised at 183 of a 183-cycle period. The
+reader's 30 cycles are it waiting on a writer that is still draining. That is *emergent* congestion,
+not a component property, and it is exactly what must **not** be baked into a component's model.
+
+**Subtract the bus occupancy and a constant remains.** With `bus = nwords + 2 × (num_trans − 1)`:
+
+| component | `span − bus` |
+| --- | --- |
+| `mem_w_stream` | **41** |
+| `mem_r_stream` | **11** |
+
+Same bus law, different per-component constants — which is the two-level calibration split made
+visible: the burst term is a *platform* property of the `m_axi` adapter, the constant is the
+component's own control cost.
+
+## Three traps this instrumentation exists to avoid
+
+**Sample mid clock-low, not on the rising edge.** A VCD records a change caused by an edge *at* that
+edge's timestamp, so sampling there reads the value the edge produced. For a two-wire handshake that
+is not a clean one-cycle shift — it both invents and destroys coincidences. On this trace it read
+AXI-MM `AW` as 16 accepted addresses instead of 128. `waveflow.utils.vcd.clock_sample_times` steps
+back a quarter period; beats are still *labelled* by the true edge time.
+
+**A firing ends at `ap_done`, not at the last output beat.** An `m_axi` store is *posted* — it
+retires when the adapter accepts the word, not when the beat is on the bus. `mem_copy`'s writer
+emits `s_done` at cycle 1642, its last W beat lands at 1666 and its B response at 1667. Anchoring on
+the output beat measures 155 where the firing is 183, and *inverts which stage looks like the
+bottleneck*.
+
+A free-running top has no control interface, but each `hls::task` instance inside it is an ordinary
+`ap_ctrl_hs` block with `ap_start`/`ap_continue` tied to `1'b1` — so `ap_done` still pulses once per
+firing, and HLS holds it until the firing's outstanding writes have responded.
+
+**Read backpressure from the FIFO's occupancy, not its write enable.** HLS *gates* the write enable:
+a task blocked on a full channel stalls its pipeline without ever asserting `write`, so a
+`write & !full_n` metric reports zero backpressure while the producer is stuck. `blocked` compares
+`<ch>_num_data_valid` against `<ch>_fifo_cap` instead. This is what located the 30 cycles.
+
+## What this is for
+
+The measured law for `mem_copy`'s writer, across `n_words` from 32 to 512:
+
+```
+span = 41 + n + 2 × (ceil(n/16) − 1)
+```
+
+One cycle per word, **two cycles per AXI burst boundary** (HLS's `max_burst_length` is 16), plus a
+fixed control cost. The burst term belongs on `BusTiming` (the memory slave); the 41 belongs to the
+component.
+
+Feeding those back into the SimPy model — and giving the internal channels their real depth of 2 —
+reproduces the RTL across that whole 16× range to **1.1%**, with the 30 cycles of congestion
+emerging rather than being fitted. Implementing that in the framework, and automating the fit, is
+the next arc: see `plans/memcpy_timing_calibration.md`.
+
+## See also
+
+- [RTL simulation](./rtlsim.md) — the run this instruments
+- [Testbench codegen](./codegen_tb.md) — the harness the trace observes
+- `waveflow/utils/trace.py` — `load_trace`, `BoundTrace`, `Firing`
+- `waveflow/build/trace_steps.py` — the four steps

--- a/docs/guide/timing/index.md
+++ b/docs/guide/timing/index.md
@@ -14,3 +14,9 @@ Waveflow provides some basic package for python processing of timing diagrams re
 - Extracting information from timing diagrams
 - Python-based analysis for AXI protocols including AXI-Lite, AXI-Streaming, and AXI memory-mapped
 
+For a free-running (`ap_ctrl_none`) `hls::task` kernel, [Tracing a kernel run](./trace_steps.md)
+covers the four build steps that dump a VCD of its internal channels and bind the signals by exact
+name; [Trace pitfalls](./trace_pitfalls.md) collects the three subtle ways such a measurement goes
+silently wrong (sampling phase, `ap_done` anchoring, occupancy vs write-enable). The
+[memcpy timing](../../examples/memcpy/timing.md) example applies the whole flow to one kernel.
+

--- a/docs/guide/timing/trace_pitfalls.md
+++ b/docs/guide/timing/trace_pitfalls.md
@@ -1,0 +1,105 @@
+---
+title: Trace pitfalls
+parent: Timing Analysis Tools
+nav_order: 8
+has_children: false
+---
+
+# Trace pitfalls — three ways a measurement goes silently wrong
+
+A trace measurement rarely fails loudly. It returns a number, the number looks plausible, and it is
+wrong. Each pitfall below produced a confident, incorrect conclusion before it was caught — and each
+is baked into the Waveflow trace tooling so you inherit the fix. They are worth understanding anyway,
+because the moment you step outside the provided accessors they return.
+
+## 1. Sample mid clock-low, not on the rising edge
+
+A VCD records a signal change caused by a clock edge **at that edge's timestamp**. So if you sample a
+synchronous signal *at* the rising edge, you read the value the edge just produced — the *post*-edge
+value — not the value the flops captured.
+
+For a single registered signal that is only a one-cycle shift. For a **two-wire handshake**
+(`VALID & READY`) it is worse: the two wires can move at the same timestamp in opposite directions,
+so sampling on the edge both **invents** coincidences (both high post-edge that were not both high
+during the cycle) and **destroys** them (a handshake that completed, erased because one wire dropped
+on the edge). On a real `mem_copy` trace this read AXI-MM `AW` as **16** accepted addresses instead
+of **128** — an 8× undercount — and made the writer look like the faster stage when it is the
+bottleneck.
+
+The fix is to sample **a quarter period before** each rising edge — the middle of the clock-low
+phase, where every synchronous signal is stable at the value the next edge will capture. Half a
+period lands on the *falling* edge, another transition boundary, and degrades again.
+
+```python
+from waveflow.utils.vcd import extract_clock_times, clock_sample_times, resample_signal
+
+edges = extract_clock_times(clk_sig)          # the rising edges
+grid = clock_sample_times(edges)              # a quarter period earlier
+value = resample_signal(sig, grid)
+```
+
+`extract_axis_bursts`, `extract_aximm_bursts`, `extract_fifo_bursts` and every `BoundTrace` accessor
+already do this. Beats are still **labelled** by the true edge time, so `tstart` and cycle indices
+are unchanged — only the *reading* moves.
+
+## 2. A firing ends at `ap_done`, not the last output beat
+
+It is tempting to time a component from its first input beat to its last output beat. That is wrong
+whenever the component issues `m_axi` **writes**, because an `m_axi` store is **posted**: it retires
+when the adapter *accepts* the word, not when the beat reaches the bus. The component's own code has
+moved on; the write burst is still draining behind it.
+
+On `mem_copy`'s writer, three plausible window-ends give three different stories:
+
+| window ends at | firing span | conclusion it supports |
+| --- | --- | --- |
+| `s_done` (last stream output) | 155 | "the reader is the bottleneck; the writer idles" |
+| last `B` response | 180 | "a few cycles of restart latency" |
+| **`ap_done`** | **183** | **the writer is 100% utilised — the bottleneck** |
+
+Only the last is right. `ap_done` is unambiguous because **HLS holds it until the firing's
+outstanding writes have responded** — it is the one signal that means "this firing is actually done".
+
+The subtlety: a free-running top is `ap_ctrl_none` and has **no** control interface. But each
+`hls::task` instance *inside* it is an ordinary `ap_ctrl_hs` block with `ap_start`/`ap_continue`
+tied to `1'b1` (you can see the `assign …_ap_start = 1'b1;` in the generated top), so `ap_done` still
+pulses once per firing — and Vitis lifts the pin into the top scope where a level-1 dump sees it.
+
+`BoundTrace.component_firings()` anchors on it; `Firing.span` is first-input → `ap_done`.
+
+{: .note }
+> A consequence worth holding separately from timing: because the store is posted, a response emitted
+> *inside* the firing (like `mem_copy`'s `CopyResp`) can go out **before** the data it reports has
+> actually landed in memory. If a downstream consumer must not read the destination until the write
+> is durable, the guarantee has to ride the **task boundary** (`ap_done`), not a stream write inside
+> the body.
+
+## 3. Read backpressure from occupancy, not the write enable
+
+To measure whether a producer is being throttled, the obvious signal is its write handshake —
+"cycles where it wanted to write but the channel was full". **That signal does not exist.** HLS
+*gates* the write enable: a task blocked on a full channel stalls its whole pipeline **without ever
+asserting `write`**. So a `write & !full_n` metric reports **zero** backpressure precisely when the
+producer is most stuck.
+
+The reliable signal is the FIFO's own **occupancy counter**. A channel at capacity is a producer
+that cannot push:
+
+```python
+blocked = bt.channel_blocked("copy_data", firing.start, firing.end)
+```
+
+which compares `<ch>_num_data_valid` against `<ch>_fifo_cap` (both named in the manifest, both dumped
+at level 1). This is what located `mem_copy`'s 30 cycles/job of blocking — invisible on every write
+handshake in the design.
+
+## Why these matter for calibration
+
+All three share a theme: **a component's true occupancy is not what its stream ports say.** It keeps
+working after its last output (2), it stalls without signalling it (3), and even reading the ports
+correctly requires the right sampling phase (1). A timing model calibrated on the wrong window folds
+contention and posted-write drain into the component's own cost — and then composition stops
+predicting anything, because the contention was supposed to *emerge* from the interconnect, not be
+baked into the block. Getting the window right is what lets you calibrate on uncontended firings and
+have congestion fall out on its own. The [memcpy timing](../../examples/memcpy/timing.md) page walks
+that through end to end.

--- a/docs/guide/timing/trace_steps.md
+++ b/docs/guide/timing/trace_steps.md
@@ -1,0 +1,173 @@
+---
+title: Tracing a kernel run
+parent: Timing Analysis Tools
+nav_order: 7
+has_children: false
+---
+
+# Tracing a kernel run — the four trace steps
+
+To analyse a kernel's timing you need a **VCD of its internal signals**, and then a way to know
+which net is which. Waveflow builds both as ordinary [BuildDag](../build/index.md) steps, so
+instrumenting a run is one command rather than a procedure:
+
+```bash
+python <example>_build.py --through extract_bursts
+```
+
+```
+CodegenTbStep → AddVcdTopStep + TraceManifestStep → RtlSimStep → ExtractBurstsStep
+                (the dumper)     (the net names)     (the VCD)    (the timing table)
+```
+
+All four live in [`waveflow/build/trace_steps.py`](https://github.com/sdrangan/waveflow/tree/main/waveflow/build/trace_steps.py)
+and are **general infrastructure** — the only example-specific input is the component class, passed
+as a constructor argument. Any free-running (`ap_ctrl_none`) `hls::task` top produced by
+`composite_top_spec` works unchanged.
+
+> **Two ways to get a VCD.** [Extracting VCD Files](./vcd.md) (`xsim_vcd`) re-runs a **cosim** and
+> injects `log_vcd` into the generated Tcl — the right tool for a control-driven (`ap_ctrl_hs`)
+> kernel driven by `cosim_design`. The steps on *this* page are for the **free-running BFM/XSI**
+> flow, where the kernel has no cosim wrapper and is driven cycle-by-cycle by a
+> [BFM harness](../build/bfm.md). Same output format (a VCD the [parser](./parsing.md) reads); two
+> different flows to produce it.
+
+## The problem the dumper solves
+
+The XSI value API (`xsi_get_port_number`) resolves **top-level ports only**. The interesting signals
+in a composite kernel are usually *not* ports — they are the internal FIFOs wiring the tasks
+together. Through XSI they are unreachable, and the BFM run writes a `.wdb`, not a VCD.
+
+The way in is Verilog's `$dumpvars`, from a small module elaborated **alongside** the DUT.
+
+## `AddVcdTopStep` — the dumper
+
+Writes `xsi/vcd_dumper_<top>.v`:
+
+```verilog
+module vcd_dumper_<top>;
+    initial begin
+        $dumpfile("<top>_trace.vcd");
+        $dumpvars(1, <top>);
+    end
+endmodule
+```
+
+Two decisions carry the weight.
+
+**It is a second top, not a wrapper.** `run.bat … trace` elaborates `work.<top>
+work.vcd_dumper_<top>`. The DUT itself is untouched, so every BFM port number and every cycle count
+is identical to an untraced run — the dumper *observes*, it does not perturb. (A pass-through wrapper
+would also work, but means mirroring the whole port list by hand — tedium that fails for reasons
+unrelated to what you are measuring.)
+
+**The level is 1, not 0.** `$dumpvars(1, …)` dumps this scope's own signals and does **not** descend
+into children. That sounds like it would miss the internal FIFOs — and it does not, because **Vitis
+lifts inter-task dataflow channel wires up into the top scope**, beside the task instances. So a
+level-1 dump already reaches, with **no hierarchical path to resolve**:
+
+```
+<ch>_dout / <ch>_empty_n / <ch>_full_n     the channel itself
+<producer>_U0_<ch>_din / _<ch>_write        the producer's side
+<consumer>_U0_<ch>_read                     the consumer's side
+<task>_U0_ap_done                           each task's firing boundary
+```
+
+Level 0 would dump the entire subtree for no extra reach. The cost stays bounded — a level-1 dump is
+258 signals for `mem_copy`, 363 for `interleaver_canon`, not the thousands a full-tree dump gives.
+
+The module is named after the top because one `xsi/` directory can serve several tops
+(`examples/interleaver/xsi` builds three), and a dumper naming a scope that is not part of *this*
+elaboration is a hard error. The `trace` argument that selects it lives in the **master**
+`run.bat` ([`waveflow/build/xsi/run.bat`](https://github.com/sdrangan/waveflow/tree/main/waveflow/build/xsi/run.bat)),
+which `XsiHarnessStep` copies into each example — editing the copied `run.bat` would be undone on the
+next codegen.
+
+## `TraceManifestStep` — what the nets are called
+
+Writes `results/<top>_trace.json`, mapping the Python graph onto RTL net names. Derived entirely from
+`elaborate()` — no RTL is read, nothing is simulated, so it is cheap and runs alongside the C++
+codegen rather than after synthesis.
+
+Why a manifest, instead of matching names in the waveform later? Because substring matching is not
+merely fragile, it is **wrong**. An interleaver trace contains both
+
+```
+ywords_fifo_cap[2:0]                    the channel's own counter
+il_store_..._U0_ywords_fifo_cap[31:0]   an instance's internal copy
+```
+
+— different widths, different meanings, and a matcher takes whichever it sees first. The names are
+already known here, because **codegen chose them**: channel names are the C++ stream variables, port
+names are the boundary names, `m_axi` nets are named after the bundle. Only the `_U0` instance suffix
+is Vitis's. So the manifest binds *exactly*, and a net that has gone missing (a renamed channel, a
+new Vitis release) **fails loudly** instead of silently extracting nothing.
+
+The manifest is the artifact the loader ([`waveflow/utils/trace.py`](https://github.com/sdrangan/waveflow/tree/main/waveflow/utils/trace.py),
+`load_trace` → `BoundTrace`) resolves against a VCD.
+
+## `RtlSimStep` — run it, tracing
+
+A thin wrapper over `xsi/run.bat`, passing its third argument `trace`. It **asserts nothing**: it
+runs and produces `xsi/<top>_trace.vcd`. Correctness — the exact cycle count — stays with the
+`-m xsi` gate, which calls `run.bat` directly. Two callers of one script is deliberate; routing a
+green gate through new code is how a gate quietly stops meaning what it meant.
+
+{: .warning }
+> **Re-running the built `.exe` does not regenerate the VCD.** Only the full `run.bat` path does,
+> because the dump comes from the *elaborated snapshot*. A driver that re-ran the binary per data
+> point once silently re-measured the **previous** trace and reported an identical result at five
+> different inputs. `RtlSimStep` deletes the VCD first and fails if it does not reappear — copy that
+> discipline in any hand-rolled sweep.
+
+It is toolchain-gated (needs Vitis-synthesized RTL plus Vivado `xsim` and a MinGW `g++`), and takes
+a `prepare` hook to materialize the scenario the BFM reads — the scenario is an *input* to the run,
+so a step that did not write it would measure whatever was left behind.
+
+## `ExtractBurstsStep` — the timing table
+
+Binds the manifest to the waveform and writes `results/<top>_timing.json` — one row per **firing** of
+each component:
+
+```json
+{"component": "...", "index": 8,
+ "start": 1488, "end": 1670, "span": 183,
+ "nwords": 128, "num_trans": 8, "blocked": 0}
+```
+
+- `span` — first input handshake → `ap_done` (see [Trace pitfalls](./trace_pitfalls.md) for why this
+  anchor and not the last output beat)
+- `nwords` / `num_trans` — `m_axi` beats and bursts inside the firing, **measured** off the trace,
+  not assumed
+- `blocked` — cycles this component's output channel sat at capacity (from the FIFO's occupancy
+  counters, the only reliable backpressure signal — again, [Trace pitfalls](./trace_pitfalls.md))
+
+The shape is deliberate: `span` regressed over `{nwords, num_trans}` is exactly what a
+[`BusTiming`](./aximm.md) model consumes, and `blocked == 0` isolates the firings that may be
+calibrated on. So the calibration path consumes this artifact unchanged rather than needing a second
+extractor.
+
+## `BoundTrace` — reading a trace in Python
+
+For interactive analysis you rarely need the steps; `load_trace` does the binding directly:
+
+```python
+from waveflow.utils.trace import load_trace
+
+bt = load_trace("results/mem_copy_trace.json", "xsi/mem_copy_trace.vcd")
+
+bt.component("mem_r_stream_framed_task")          # what streams it touches
+bt.component_firings("mem_r_stream_framed_task")  # per-firing windows (ap_done anchored)
+bt.component_bursts("mem_r_stream_framed_task")   # beats in/out per channel
+bt.aximm_bursts("gmem1")                          # (write, read, clk_period) for a bundle
+bt.channel_blocked("copy_data", lo, hi)           # backpressure cycles in a window
+```
+
+Every accessor takes the RTL instance name or the task-body name, and binds by exact net.
+
+## See also
+
+- [Trace pitfalls](./trace_pitfalls.md) — the three ways a trace measurement goes silently wrong
+- [Parsing VCD Files](./parsing.md) — the `VcdParser` these build on
+- [AXI4-MM](./aximm.md) / [AXI4-Stream](./axistream.md) — the burst extractors
+- [memcpy timing](../../examples/memcpy/timing.md) — the whole flow applied to one kernel

--- a/examples/mem_copy/mem_copy_build.py
+++ b/examples/mem_copy/mem_copy_build.py
@@ -31,14 +31,21 @@ from pathlib import Path
 
 from waveflow.build.build import BuildConfig, BuildDag, BuildStep, SourceStep
 from waveflow.build.cli import run_dag_cli
-from waveflow.build.trace_steps import AddVcdTopStep, TraceManifestStep
+from waveflow.build.trace_steps import (
+    AddVcdTopStep,
+    ExtractBurstsStep,
+    RtlSimStep,
+    TraceManifestStep,
+)
 from waveflow.toolchain import toolchain
 
 try:
-    from examples.mem_copy.mem_copy import DEFAULT_MEM_DW, XSI_JOBS, generate_dut, generate_tb
+    from examples.mem_copy.mem_copy import (DEFAULT_MEM_DW, XSI_JOBS, generate_dut, generate_tb,
+                                            write_mem_copy_xsi_bundles)
     from examples.mem_copy.mem_copy_sim import MemCopySim
 except ModuleNotFoundError:  # run as a script from the example directory
-    from mem_copy import DEFAULT_MEM_DW, XSI_JOBS, generate_dut, generate_tb  # type: ignore[no-redef]
+    from mem_copy import (DEFAULT_MEM_DW, XSI_JOBS, generate_dut,  # type: ignore[no-redef]
+                          generate_tb, write_mem_copy_xsi_bundles)
     from mem_copy_sim import MemCopySim  # type: ignore[no-redef]
 
 HERE = Path(__file__).resolve().parent
@@ -189,6 +196,13 @@ def build_mem_copy_dag() -> BuildDag:
                               source_artifact="mem_copy_source",
                               output_path="results/mem_copy_trace.json"))
     dag.add(CSynthStep(name="csynth"))
+    # The timing rung.  `rtlsim` runs but never asserts -- the exact cycle count stays with the
+    # `-m xsi` gate; this one exists to produce a waveform.  `extract_bursts` then turns the
+    # waveform plus the manifest into a per-firing timing table.
+    dag.add(RtlSimStep(name="rtlsim", top="mem_copy", tb="mem_copy_bfm_tb", xsi_dir="xsi",
+                       prepare=write_mem_copy_xsi_bundles))
+    dag.add(ExtractBurstsStep(name="extract_bursts",
+                              output_path="results/mem_copy_timing.json"))
     return dag
 
 

--- a/examples/mem_copy/mem_copy_build.py
+++ b/examples/mem_copy/mem_copy_build.py
@@ -48,6 +48,12 @@ except ModuleNotFoundError:  # run as a script from the example directory
                           generate_tb, write_mem_copy_xsi_bundles)
     from mem_copy_sim import MemCopySim  # type: ignore[no-redef]
 
+try:
+    from examples.mem_copy.mem_copy_figures import SyncDocsFiguresStep, TimingFiguresStep
+except ModuleNotFoundError:  # run as a script from the example directory
+    from mem_copy_figures import (SyncDocsFiguresStep,  # type: ignore[no-redef]
+                                  TimingFiguresStep)
+
 HERE = Path(__file__).resolve().parent
 
 
@@ -203,6 +209,11 @@ def build_mem_copy_dag() -> BuildDag:
                        prepare=write_mem_copy_xsi_bundles))
     dag.add(ExtractBurstsStep(name="extract_bursts",
                               output_path="results/mem_copy_timing.json"))
+    # Figures are on-demand: `--through timing_figures` renders into results/ (gitignored), and
+    # `--through sync_docs_figures` promotes them into docs/ as committed assets, so a docs figure
+    # only changes when you mean it to and the change is a reviewable diff.
+    dag.add(TimingFiguresStep(name="timing_figures"))
+    dag.add(SyncDocsFiguresStep(name="sync_docs_figures"))
     return dag
 
 

--- a/examples/mem_copy/mem_copy_figures.py
+++ b/examples/mem_copy/mem_copy_figures.py
@@ -1,0 +1,347 @@
+"""Committed-figure workflow for the ``mem_copy`` timing instrumentation.
+
+Three figures, in the order the story is told on
+``docs/examples/memcpy/timing.md``:
+
+* **timeline_full.svg** — the whole run: every observation point on one cycle axis.
+  The 183-cycle cadence and the read/write overlap are visible at a glance.
+* **timeline_job.svg** — one steady-state job, beat by beat, with the ``copy_data``
+  FIFO occupancy underneath.  This is where the 30 cycles of backpressure become a
+  thing you can *see*: the channel pinned at capacity while the writer drains.
+* **firing_spans.svg** — per-firing spans per component.  The writer is uniform at
+  183 (100% utilised, the bottleneck); the reader is 153 on its one uncontended
+  firing and 183 on every later one.
+
+The first two need the waveform (per-beat detail); the third is rendered from
+``results/mem_copy_timing.json`` alone, so it regenerates with no toolchain at all.
+
+Generated SVGs land in ``results/`` (gitignored); :class:`SyncDocsFiguresStep`
+promotes them — on demand, via an explicit manifest — into
+``docs/examples/memcpy/images/`` as committed assets, so a docs figure only changes
+when you intend it to and the change is a reviewable ``git diff``.
+
+Run it with::
+
+    python mem_copy_build.py --through sync_docs_figures
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+
+import matplotlib
+
+matplotlib.use("svg")
+# Deterministic SVG: a stable hashsalt fixes the element ids matplotlib would otherwise randomize,
+# so a re-render only diffs when the figure truly changed.
+matplotlib.rcParams["svg.hashsalt"] = "mem_copy_figures"
+import matplotlib.pyplot as plt  # noqa: E402
+
+from waveflow.build.build import BuildConfig, BuildStep  # noqa: E402
+
+FIGURE_MANIFEST = [
+    {"name": "timeline_full", "source": "results/timeline_full.svg",
+     "dest": "docs/examples/memcpy/images/timeline_full.svg"},
+    {"name": "timeline_job", "source": "results/timeline_job.svg",
+     "dest": "docs/examples/memcpy/images/timeline_job.svg"},
+    {"name": "firing_spans", "source": "results/firing_spans.svg",
+     "dest": "docs/examples/memcpy/images/firing_spans.svg"},
+]
+
+#: One colour per stage of the pipeline, reused across all three figures so a reader can carry the
+#: mapping from one to the next.
+C_SEQ, C_READ, C_COPY, C_WRITE, C_DONE = (
+    "#4C78A8", "#E45756", "#F58518", "#54A24B", "#B279A2")
+
+
+def _save_svg(fig, path: Path) -> None:
+    """Write a deterministic SVG (no embedded timestamp)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, format="svg", bbox_inches="tight", metadata={"Date": None})
+    plt.close(fig)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Reading the trace
+# ---------------------------------------------------------------------------
+
+def _observations(bt):
+    """The lanes both timeline figures draw, top to bottom: commands in, through the two internal
+    framed FIFOs and both memory ports, to the response out.
+
+    Ordered so the figure reads as dataflow -- a beat entering at the top exits at the bottom."""
+    ch = {c["id"]: c for c in bt.manifest["channels"]}
+    hs = bt._handshakes
+
+    def chan(cid, side):
+        c = ch[cid]
+        return (hs(c[side]["write"], c[side]["full_n"]) if side == "write"
+                else hs(c[side]["empty_n"], c[side]["read"]))
+
+    def port(pid, v, r):
+        return hs(bt.port(pid)["signals"][v], bt.port(pid)["signals"][r])
+
+    return [
+        ("s_cmd in",      port("s_cmd", "tvalid", "tready"),        C_SEQ),
+        ("cmd write",     chan("cmd", "write"),                     C_SEQ),
+        ("cmd read",      chan("cmd", "read"),                      C_SEQ),
+        ("gmem0 AR",      port("gmem0", "ARVALID", "ARREADY"),      C_READ),
+        ("gmem0 R",       port("gmem0", "RVALID", "RREADY"),        C_READ),
+        ("copy_data wr",  chan("copy_data", "write"),               C_COPY),
+        ("copy_data rd",  chan("copy_data", "read"),                C_COPY),
+        ("gmem1 AW",      port("gmem1", "AWVALID", "AWREADY"),      C_WRITE),
+        ("gmem1 W",       port("gmem1", "WVALID", "WREADY"),        C_WRITE),
+        ("s_done out",    port("s_done", "tvalid", "tready"),       C_DONE),
+    ]
+
+
+def _occupancy(bt, channel="copy_data"):
+    """(level, capacity) series for a channel's FIFO, or (None, 0) if not exposed."""
+    d = bt.channel(channel).get("depth", {})
+    lvl, cap = d.get("level"), d.get("cap")
+    if not lvl or not cap or lvl not in bt.resolved or cap not in bt.resolved:
+        return None, 0
+    from waveflow.utils.vcd import resample_signal
+
+    def _s(bare):
+        n = bt.resolved[bare]
+        bt.parser.sig_info[n].get_values()
+        return np.asarray(resample_signal(bt.parser.sig_info[n], bt._grid()))
+
+    level = _s(lvl)
+    return level, int(_s(cap).max())
+
+
+# ---------------------------------------------------------------------------
+# Figures
+# ---------------------------------------------------------------------------
+
+def _runs(ev: np.ndarray, gap: int = 3) -> list[tuple[int, int]]:
+    """Collapse handshake cycles into contiguous activity runs ``(start, width)``.
+
+    At full-run scale a per-beat figure is 2000+ SVG paths (a 1.4 MB asset) of hairlines nobody can
+    resolve anyway.  Runs carry the same information at that zoom -- when each stage was busy -- for
+    a fraction of the size.  The per-beat view is the job figure's job."""
+    if not len(ev):
+        return []
+    ev = np.asarray(ev)
+    breaks = np.nonzero(np.diff(ev) > gap)[0]
+    starts = np.concatenate(([ev[0]], ev[breaks + 1]))
+    ends = np.concatenate((ev[breaks], [ev[-1]]))
+    return [(int(s), max(int(e - s), 1)) for s, e in zip(starts, ends)]
+
+
+def render_timeline_full(bt, out: Path, n_cycles: int | None = None) -> None:
+    """Every stage's activity across the run, one lane per observation point."""
+    lanes = _observations(bt)
+    hi = n_cycles or int(max((e[-1] for _, e, _ in lanes if len(e)), default=1)) + 40
+
+    fig, ax = plt.subplots(figsize=(11, 4.2))
+    for row, (label, ev, colour) in enumerate(lanes):
+        y = len(lanes) - 1 - row
+        runs = _runs(ev)
+        if runs:
+            # edgecolor == facecolor with a real linewidth: a 1-cycle run is well under a pixel
+            # across a 2900-cycle axis, and with no stroke it antialiases to a grey smear instead of
+            # the lane's colour.
+            ax.broken_barh(runs, (y - 0.34, 0.68), facecolors=colour,
+                           edgecolors=colour, linewidth=0.5)
+    ax.set_yticks(range(len(lanes)))
+    ax.set_yticklabels([lbl for lbl, _, _ in lanes][::-1], fontsize=8)
+    ax.set_xlim(0, hi)
+    ax.set_xlabel("clock cycle")
+    ax.set_title("mem_copy — stage activity across 16 jobs (bar = busy)", fontsize=10)
+    ax.set_axisbelow(True)          # else the grid draws over the bars and reads as extra events
+    ax.grid(axis="x", alpha=0.25, linewidth=0.4)
+    for s in ("top", "right"):
+        ax.spines[s].set_visible(False)
+    _save_svg(fig, out)
+
+
+def render_timeline_job(bt, out: Path, job: int = 8) -> None:
+    """One steady-state firing, beat by beat, with the copy_data FIFO occupancy underneath.
+
+    The occupancy panel is the point of the figure: `copy_data` sits at capacity for ~30 cycles at
+    the start of the firing, which is the reader blocked on a writer that has not drained yet.  A
+    write-enable-based metric shows nothing there -- HLS gates the enable -- so the counter is the
+    only place that congestion is visible.
+    """
+    firings = bt.component_firings("mem_r_stream_framed_task")
+    f = firings[min(job, len(firings) - 1)]
+    lo, hi = f.start - 6, f.end + 40
+
+    lanes = _observations(bt)
+    level, cap = _occupancy(bt)
+
+    fig, (ax, ax2) = plt.subplots(
+        2, 1, figsize=(11, 5.2), sharex=True, gridspec_kw={"height_ratios": [3, 1]})
+
+    for row, (label, ev, colour) in enumerate(lanes):
+        y = len(lanes) - 1 - row
+        e = ev[(ev >= lo) & (ev <= hi)]
+        if len(e):
+            ax.vlines(e, y - 0.38, y + 0.38, color=colour, linewidth=1.1)
+    ax.set_yticks(range(len(lanes)))
+    ax.set_yticklabels([lbl for lbl, _, _ in lanes][::-1], fontsize=8)
+    ax.set_title(f"one steady-state job (reader firing {f.index}: "
+                 f"cycles {f.start}–{f.end}, span {f.span})", fontsize=10)
+    ax.set_axisbelow(True)          # else the grid draws over the bars and reads as extra events
+    ax.grid(axis="x", alpha=0.25, linewidth=0.4)
+    for s in ("top", "right"):
+        ax.spines[s].set_visible(False)
+
+    if level is not None and cap:
+        x = np.arange(lo, hi + 1)
+        ax2.step(x, level[lo:hi + 1], where="post", color=C_COPY, linewidth=1.0)
+        ax2.axhline(cap, color="0.4", linestyle="--", linewidth=0.8)
+        blocked = np.asarray(level[lo:hi + 1]) >= cap
+        ax2.fill_between(x, 0, cap, where=blocked, color=C_COPY, alpha=0.25, step="post")
+        ax2.set_ylim(0, cap + 0.5)
+        ax2.set_ylabel("copy_data\noccupancy", fontsize=8)
+        ax2.text(0.005, 0.86, f"shaded = at capacity ({cap}) → producer blocked",
+                 transform=ax2.transAxes, fontsize=7.5, color="0.25")
+    ax2.set_xlim(lo, hi)
+    ax2.set_xlabel("clock cycle")
+    ax2.set_axisbelow(True)
+    ax2.grid(axis="x", alpha=0.25, linewidth=0.4)
+    for s in ("top", "right"):
+        ax2.spines[s].set_visible(False)
+    _save_svg(fig, out)
+
+
+def render_firing_spans(events: dict, out: Path) -> None:
+    """Per-firing span for each component -- rendered from the timing table alone, no waveform.
+
+    Shows the bottleneck without any arithmetic: the writer is a flat 183 on every firing, so it is
+    busy for the entire period; the reader is 153 on the one firing nothing blocked it, and 183
+    afterwards -- the 30-cycle difference is congestion, not its own cost.
+    """
+    by_comp: dict[str, list[dict]] = {}
+    for f in events["firings"]:
+        by_comp.setdefault(f["component"], []).append(f)
+
+    order = ["mem_seq_framed_task", "mem_r_stream_framed_task", "mem_w_stream_framed_done_task"]
+    comps = [c for c in order if c in by_comp] + [c for c in by_comp if c not in order]
+    colours = {"mem_seq_framed_task": C_SEQ, "mem_r_stream_framed_task": C_READ,
+               "mem_w_stream_framed_done_task": C_WRITE}
+
+    fig, ax = plt.subplots(figsize=(11, 3.6))
+    width = 0.8 / max(len(comps), 1)
+    for i, comp in enumerate(comps):
+        rows = sorted(by_comp[comp], key=lambda r: r["index"])
+        xs = np.arange(len(rows)) + i * width - 0.4 + width / 2
+        own = [r["span"] - r["blocked"] for r in rows]
+        blocked = [r["blocked"] for r in rows]
+        ax.bar(xs, own, width=width, color=colours.get(comp, "0.5"),
+               label=comp.replace("_framed_task", "").replace("_framed_done_task", ""))
+        # Stacked in grey rather than hatched: the blocked part is not this component's work, and a
+        # translucent hatch over a coloured bar reads as a third colour rather than as "waiting".
+        ax.bar(xs, blocked, width=width, bottom=own, color="0.78",
+               edgecolor=colours.get(comp, "0.5"), linewidth=0.4,
+               label="blocked (waiting on a full channel)" if i == 0 else None)
+
+    ax.set_xticks(np.arange(len(next(iter(by_comp.values())))))
+    ax.set_xlabel("firing (job index)")
+    ax.set_ylabel("span (cycles)")
+    ax.set_title("per-firing span — colour is the component's own work, grey is waiting",
+                 fontsize=10)
+    ax.legend(fontsize=8, frameon=False, ncol=4, loc="upper center",
+              bbox_to_anchor=(0.5, -0.22))
+    ax.grid(axis="y", alpha=0.25, linewidth=0.4)
+    for s in ("top", "right"):
+        ax.spines[s].set_visible(False)
+    _save_svg(fig, out)
+
+
+# ---------------------------------------------------------------------------
+# Build steps
+# ---------------------------------------------------------------------------
+
+@dataclass(kw_only=True)
+class TimingFiguresStep(BuildStep):
+    """Render the three timing figures into ``results/``.
+
+    Consumes the manifest and the waveform (per-beat detail the summary table does not carry) plus
+    the extracted table (which ``firing_spans`` alone is enough for).
+    """
+
+    description: str = "Render the mem_copy timing figures from the traced run."
+    params: ClassVar[dict] = {}
+
+    manifest_artifact: str = "trace_manifest"
+    vcd_artifact: str = "trace_vcd"
+    events_artifact: str = "timing_events"
+    zoom_job: int = 8
+
+    @property
+    def consumes(self) -> list:  # type: ignore[override]
+        return [self.manifest_artifact, self.vcd_artifact, self.events_artifact]
+
+    @property
+    def produces(self) -> dict:  # type: ignore[override]
+        return {f"{e['name']}_svg": Path(e["source"]) for e in FIGURE_MANIFEST}
+
+    def run(self, config: BuildConfig, **artifacts) -> dict[str, Any]:
+        from waveflow.utils.trace import load_trace
+
+        root = Path(config.root_dir) if config.root_dir is not None else Path.cwd()
+        bt = load_trace(artifacts[self.manifest_artifact], artifacts[self.vcd_artifact])
+        events = json.loads(Path(artifacts[self.events_artifact]).read_text(encoding="utf-8"))
+
+        out = {}
+        render_timeline_full(bt, root / "results" / "timeline_full.svg")
+        out["timeline_full_svg"] = root / "results" / "timeline_full.svg"
+        render_timeline_job(bt, root / "results" / "timeline_job.svg", job=self.zoom_job)
+        out["timeline_job_svg"] = root / "results" / "timeline_job.svg"
+        render_firing_spans(events, root / "results" / "firing_spans.svg")
+        out["firing_spans_svg"] = root / "results" / "firing_spans.svg"
+        return out
+
+
+@dataclass(kw_only=True)
+class SyncDocsFiguresStep(BuildStep):
+    """Promote the generated SVGs into the committed docs assets, on demand.
+
+    Copies each manifest entry and writes a ``sync_status.json`` provenance record (per figure:
+    source path, content hash) next to the committed assets — the cheap staleness signal a docs lint
+    can check without re-running Vitis.  Mirrors the shared_mem / regmap workflow.
+    """
+
+    description: str = "Copy the timing figures into docs/images and record provenance."
+    params: ClassVar[dict] = {}
+
+    @property
+    def consumes(self) -> list:  # type: ignore[override]
+        return [f"{e['name']}_svg" for e in FIGURE_MANIFEST]
+
+    @property
+    def produces(self) -> dict:  # type: ignore[override]
+        return {"docs_figures_sync": Path("docs/examples/memcpy/images/sync_status.json")}
+
+    def run(self, config: BuildConfig, **_) -> dict[str, Any]:
+        # docs/ lives at the repo root; the example dir is examples/mem_copy.
+        repo_root = Path(config.root_dir).parents[1]
+        records = []
+        for entry in FIGURE_MANIFEST:
+            src = Path(config.root_dir) / entry["source"]
+            dst = repo_root / entry["dest"]
+            if not src.exists():
+                raise RuntimeError(f"Manifest source missing: {src} "
+                                   f"(run --through timing_figures first)")
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(src.read_bytes())
+            records.append({"name": entry["name"], "source": entry["source"],
+                            "dest": entry["dest"], "source_sha256": _sha256(src)})
+        sync_path = repo_root / "docs" / "examples" / "memcpy" / "images" / "sync_status.json"
+        sync_path.parent.mkdir(parents=True, exist_ok=True)
+        sync_path.write_text(json.dumps({"figures": records}, indent=2) + "\n", encoding="utf-8")
+        return {"docs_figures_sync": sync_path}

--- a/examples/mem_copy/xsi/run.bat
+++ b/examples/mem_copy/xsi/run.bat
@@ -4,10 +4,15 @@ rem generated free-running mem-stream kernel.  Adapted from the interleaver sand
 rem   run.bat mem_r_stream mem_r_bfm_tb
 rem   run.bat mem_w_stream mem_w_bfm_tb
 rem
-rem Pass a third argument `trace` to also elaborate vcd_dumper.v as a SECOND top, whose $dumpvars
-rem writes <top>_trace.vcd.  That leaves the XSI top -- and every BFM port number -- untouched, so
-rem the run is identical apart from the dump; the gate cycle counts are unchanged either way.
+rem Pass a third argument `trace` to also elaborate vcd_dumper_<top>.v as a SECOND top, whose
+rem $dumpvars writes <top>_trace.vcd.  The XSI top -- and so every BFM port number -- is untouched,
+rem so the cycle counts are identical either way; only the dump is added.  The dumper is per-top
+rem because one xsi/ directory can serve several (examples/interleaver/xsi builds three), and a
+rem dumper naming a scope that is not part of THIS elaboration is a hard error.
 rem   run.bat mem_copy mem_copy_bfm_tb trace
+rem
+rem Note: re-running the built .exe does NOT regenerate the VCD -- only this script does, because
+rem the dump comes from the elaborated snapshot.  See waveflow.build.trace_steps.RtlSimStep.
 cd /d "%~dp0"
 set VIV=C:\Xilinx\2025.1\Vivado
 set MINGW=%VIV%\tps\mingw\6.2.0\win64.o\nt

--- a/tests/build/test_trace_steps.py
+++ b/tests/build/test_trace_steps.py
@@ -13,7 +13,12 @@ import pytest
 from pathlib import Path
 
 from waveflow.build.build import BuildConfig
-from waveflow.build.trace_steps import AddVcdTopStep, TraceManifestStep
+from waveflow.build.trace_steps import (
+    AddVcdTopStep,
+    ExtractBurstsStep,
+    RtlSimStep,
+    TraceManifestStep,
+)
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -130,3 +135,97 @@ class TestAddVcdTop:
             encoding="utf-8")
         committed = (REPO / xsi_dir / f"vcd_dumper_{top}.v").read_text(encoding="utf-8")
         assert generated == committed
+
+
+class TestRtlSimStepWiring:
+    """Structural only -- actually running it needs Vitis RTL plus Vivado xsim."""
+
+    @pytest.fixture
+    def step(self):
+        return RtlSimStep(name="rtlsim", top="mem_copy", tb="mem_copy_bfm_tb", xsi_dir="xsi")
+
+    def test_declares_the_vcd_it_produces(self, step):
+        assert step.produces["trace_vcd"] == Path("xsi/mem_copy_trace.vcd")
+
+    def test_consumes_rtl_and_the_dumper(self, step):
+        """It needs synthesized RTL *and* the second top, or run.bat cannot trace."""
+        assert set(step.consumes) == {"report_dir", "vcd_dumper"}
+
+    def test_asserts_nothing_about_cycle_counts(self, step):
+        """Correctness stays with the -m xsi gate; this step only produces a waveform.  Routing a
+        green gate through new code is how a gate quietly stops meaning what it meant."""
+        src = Path(RtlSimStep.run.__code__.co_filename).read_text(encoding="utf-8")
+        body = src.split("class RtlSimStep")[1].split("class ExtractBurstsStep")[0]
+        assert "2908" not in body and "want_cycles" not in body
+
+
+class TestExtractBurstsWiring:
+    @pytest.fixture
+    def step(self):
+        return ExtractBurstsStep(name="extract_bursts", output_path="results/t.json")
+
+    def test_consumes_manifest_and_vcd(self, step):
+        assert set(step.consumes) == {"trace_manifest", "trace_vcd"}
+
+    def test_produces_the_timing_table(self, step):
+        assert step.produces["timing_events"] == Path("results/t.json")
+
+    def test_records_the_burst_length_it_assumed(self, step):
+        """`num_trans` is measured, not derived -- recording max_burst_len lets a consumer CHECK
+        it against ceil(nwords/max_burst_len) instead of assuming."""
+        assert step.max_burst_len == 16
+
+
+@pytest.mark.xsi
+class TestExtractedTableAgainstTheRealTrace:
+    """The artifact is the calibration input, so these pin its invariants, not just its shape."""
+
+    @pytest.fixture
+    def events(self):
+        p = REPO / "examples/mem_copy/results/mem_copy_timing.json"
+        if not p.exists():
+            pytest.skip(f"no extracted timing at {p} -- "
+                        f"python examples/mem_copy/mem_copy_build.py --through extract_bursts")
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    def test_one_row_per_firing_per_component(self, events):
+        from collections import Counter
+        per = Counter(f["component"] for f in events["firings"])
+        assert set(per.values()) == {16}, f"16 jobs, so 16 firings each: {per}"
+
+    def test_blocked_isolates_the_calibratable_rows(self, events):
+        """`blocked == 0` is the "safe to calibrate on" filter, computed rather than assumed.
+
+        Only the reader's FIRST firing is uncontended; every later one absorbs 30 cycles waiting on
+        a writer that is still draining.  The writer is never blocked -- it is the bottleneck."""
+        r = [f for f in events["firings"] if f["component"] == "mem_r_stream_framed_task"]
+        w = [f for f in events["firings"] if f["component"] == "mem_w_stream_framed_done_task"]
+
+        assert r[0]["blocked"] == 0 and r[0]["span"] == 153
+        assert {f["blocked"] for f in r[1:]} == {30}
+        assert {f["span"] for f in r[1:]} == {183}
+        assert {f["blocked"] for f in w} == {0}
+        assert {f["span"] for f in w} == {183}
+
+    def test_the_bus_term_is_shared_and_the_fixed_term_is_per_component(self, events):
+        """The whole point of the two-level split: subtract the bus occupancy
+        (`nwords + 2*(bursts-1)`) and what remains is a CONSTANT per component -- the writer's
+        control cost is 41, the reader's 11.  Same bus law, different component constants."""
+        fixed = {}
+        for f in events["firings"]:
+            if f["blocked"] or not f["nwords"]:
+                continue                      # contended rows and non-m_axi stages are not samples
+            bus = f["nwords"] + 2 * (f["num_trans"] - 1)
+            fixed.setdefault(f["component"], set()).add(f["span"] - bus)
+
+        assert fixed["mem_w_stream_framed_done_task"] == {41}
+        assert fixed["mem_r_stream_framed_task"] == {11}
+
+    def test_num_trans_matches_the_recorded_burst_length(self, events):
+        """128 words at max_burst_len=16 is 8 bursts -- measured off AW/AR, so this cross-checks
+        the trace against the assumption rather than restating it."""
+        import math
+        mb = events["max_burst_len"]
+        for f in events["firings"]:
+            if f["nwords"]:
+                assert f["num_trans"] == math.ceil(f["nwords"] / mb), f

--- a/tests/examples/test_mem_copy_figures.py
+++ b/tests/examples/test_mem_copy_figures.py
@@ -1,0 +1,54 @@
+"""tests/examples/test_mem_copy_figures.py -- the committed timing figures are actually there.
+
+Rendering needs a traced RTL run, so it is not tested here.  What *is* worth a cheap gate is that
+every figure the docs page embeds exists as a committed asset: a missing SVG is a broken image on
+docs/examples/memcpy/timing.md, and nothing else would catch it until someone opened the page.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _manifest():
+    import sys
+    sys.path.insert(0, str(REPO / "examples" / "mem_copy"))
+    from mem_copy_figures import FIGURE_MANIFEST
+    return FIGURE_MANIFEST
+
+
+def test_every_manifest_figure_is_committed():
+    for entry in _manifest():
+        dst = REPO / entry["dest"]
+        assert dst.exists(), (
+            f"{entry['name']}: {entry['dest']} is missing. Regenerate with "
+            f"`python examples/mem_copy/mem_copy_build.py --through sync_docs_figures`.")
+        assert dst.stat().st_size > 0
+
+
+def test_sync_status_records_every_figure():
+    """The provenance record is the staleness signal a docs lint would read; it has to be complete.
+
+    Not committed -- the repo's global ``*.json`` ignore covers it, matching how shared_mem and
+    regmap do it (they commit the SVGs only) -- so this checks it when a local sync has produced
+    one and skips otherwise."""
+    path = REPO / "docs/examples/memcpy/images/sync_status.json"
+    if not path.exists():
+        pytest.skip("no local sync_status.json (it is a build output, not a committed asset)")
+    status = json.loads(path.read_text(encoding="utf-8"))
+    assert {f["name"] for f in status["figures"]} == {e["name"] for e in _manifest()}
+    for f in status["figures"]:
+        assert len(f["source_sha256"]) == 64
+
+
+def test_timing_page_embeds_them():
+    """A committed asset nothing references is dead weight; a reference with no asset is a broken
+    image.  Pin both directions."""
+    page = (REPO / "docs/examples/memcpy/timing.md").read_text(encoding="utf-8")
+    for entry in _manifest():
+        name = Path(entry["dest"]).name
+        assert f"./images/{name}" in page, f"timing.md does not embed {name}"

--- a/tests/utils/test_trace.py
+++ b/tests/utils/test_trace.py
@@ -20,6 +20,8 @@ from waveflow.simulation.simulation import Simulation
 from waveflow.utils.trace import TraceBindError, load_trace
 
 VEC = {"tdata", "din", "dout", "ARADDR", "AWADDR", "RDATA", "WDATA", "ARLEN", "AWLEN"}
+#: The FIFO occupancy counters -- narrow vectors, not 1-bit flags.
+COUNTER = {"level", "cap"}
 
 
 def _widths(manifest: dict) -> dict[str, int]:
@@ -30,8 +32,9 @@ def _widths(manifest: dict) -> dict[str, int]:
     for p in manifest["boundary"]:
         out.update({s: (64 if k in VEC else 1) for k, s in p["signals"].items()})
     for c in manifest["channels"]:
-        for side in ("write", "read"):
-            out.update({s: (65 if k in VEC else 1) for k, s in c.get(side, {}).items()})
+        for side in ("write", "read", "depth"):
+            for k, s in c.get(side, {}).items():
+                out[s] = 65 if k in VEC else (3 if k in COUNTER else 1)
     return out
 
 

--- a/waveflow/build/composite_gen.py
+++ b/waveflow/build/composite_gen.py
@@ -324,6 +324,11 @@ def _channel_trace(ch: IntChannel, tasks: tuple[TaskInst, ...]) -> dict:
     entry["read"] = {"dout": f"{ch.name}_dout",
                      "read": f"{cons}_{ch.name}_read",
                      "empty_n": f"{ch.name}_empty_n"}
+    # The FIFO's own occupancy counters.  These are the only RELIABLE way to see backpressure: HLS
+    # gates the write enable, so a task blocked on a full channel stalls its pipeline WITHOUT ever
+    # asserting `write` -- a `write & !full_n` metric reads zero even while the producer is stuck.
+    # Comparing `level` against `cap` is what actually located mem_copy's 30 cycles/job of blocking.
+    entry["depth"] = {"level": f"{ch.name}_num_data_valid", "cap": f"{ch.name}_fifo_cap"}
     return entry
 
 

--- a/waveflow/build/trace_steps.py
+++ b/waveflow/build/trace_steps.py
@@ -1,21 +1,28 @@
-"""BuildStep that emits a component's trace manifest.
+"""BuildSteps for the timing-trace rung: name the nets, run the RTL, extract the timing.
+
+The chain, all four of which are DAG steps:
+
+    CodegenTbStep -> AddVcdTopStep + TraceManifestStep -> RtlSimStep -> ExtractBurstsStep
+                     (the dumper)   (the net names)      (the VCD)     (the timing table)
+
+The first two are pure ``elaborate()`` and cost nothing; the third needs Vitis + Vivado; the fourth
+is pure waveform analysis.  ``ExtractBurstsStep``'s output is deliberately shaped as a *calibration
+table* -- one row per firing with ``{nwords, num_trans, span}`` -- because that is both what the
+figures need and what a ``CalibModel`` regresses over.  See ``plans/memcpy_timing_calibration.md``.
 
 The manifest maps the Python graph onto the RTL net names a waveform will carry (see
-:meth:`~waveflow.build.composite_gen.TopSpec.trace_manifest`).  It is a pure function of
-``elaborate()`` -- no Vitis, no RTL, no simulation -- so it belongs on the same rung as the C++
-codegen steps rather than downstream of csynth, and it is cheap enough to regenerate whenever the
-design source changes.
-
-Kept in its own module for the same reason :mod:`waveflow.build.cosim_steps` is: it is one small
-concern with one consumer (:mod:`waveflow.utils.trace`), and burying it in the C++ codegen module
-would suggest it emits C++.
+:meth:`~waveflow.build.composite_gen.TopSpec.trace_manifest`).  Kept in its own module for the same
+reason :mod:`waveflow.build.cosim_steps` is: one small concern with one consumer
+(:mod:`waveflow.utils.trace`), and burying it in the C++ codegen module would suggest it emits C++.
 """
 from __future__ import annotations
 
 import json
+import math
+import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, Callable, ClassVar
 
 from waveflow.build.build import BuildConfig, BuildStep
 from waveflow.build.composite_gen import DEFAULT_MEM_DW, composite_top_spec
@@ -155,3 +162,190 @@ class TraceManifestStep(BuildStep):
         out_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n",
                             encoding="utf-8")
         return {"trace_manifest": out_path}
+
+
+@dataclass(kw_only=True)
+class RtlSimStep(BuildStep):
+    """Run the RTL through XSI **with tracing on**, producing ``<top>_trace.vcd``.
+
+    A thin wrapper over the example's ``xsi/run.bat``, which already does the whole flow
+    (``xvlog`` -> ``xelab -dll`` -> ``g++`` the BFM main -> execute).  Its third argument ``trace``
+    additionally elaborates the :class:`AddVcdTopStep` dumper as a second top, leaving the DUT and
+    every BFM port number untouched -- the cycle counts are identical either way.
+
+    **This step asserts nothing.**  It runs and produces an artifact; correctness stays with the
+    ``-m xsi`` gate in ``tests/examples/test_xsi_bfm.py``, which calls ``run.bat`` directly and
+    checks the exact cycle count.  Two callers of one script is deliberate: routing a green gate
+    through new code is how a gate quietly stops meaning what it meant.
+
+    Toolchain-gated: needs Vitis-synthesized RTL on disk plus Vivado ``xsim`` and a MinGW ``g++``.
+
+    Construction parameters
+    -----------------------
+    top, tb : str
+        Kernel top and BFM testbench basename, exactly as ``run.bat`` takes them.
+    xsi_dir : str
+        Directory holding ``run.bat`` (repo-relative).
+    prepare : callable | None
+        Called with the resolved ``xsi_dir`` before the run, to materialize the scenario bundles the
+        BFM reads (for mem_copy, ``write_mem_copy_xsi_bundles``).  The scenario is an *input* to the
+        run, so a step that did not write it would measure whatever was left behind.
+    """
+
+    description: str = "Run the RTL under XSI with $dumpvars tracing enabled."
+    params: ClassVar[dict] = {}
+
+    top: str
+    tb: str
+    xsi_dir: str = "xsi"
+    rtl_artifact: str = "report_dir"
+    dumper_artifact: str = "vcd_dumper"
+    prepare: Callable[[Path], None] | None = None
+
+    @property
+    def consumes(self) -> list:  # type: ignore[override]
+        return [self.rtl_artifact, self.dumper_artifact]
+
+    @property
+    def produces(self) -> dict:  # type: ignore[override]
+        return {"trace_vcd": Path(self.xsi_dir) / f"{self.top}_trace.vcd"}
+
+    def run(self, config: BuildConfig, **artifacts) -> dict[str, Any]:
+        root = Path(config.root_dir) if config.root_dir is not None else Path.cwd()
+        xsi = root / self.xsi_dir
+        vcd = xsi / f"{self.top}_trace.vcd"
+
+        if self.prepare is not None:
+            self.prepare(xsi)
+
+        # Delete first, then require it to reappear.  Re-running the built .exe does NOT regenerate
+        # the VCD -- only the full run.bat path, which re-elaborates, does -- so without this guard
+        # a failed or skipped run leaves the PREVIOUS trace on disk and everything downstream is
+        # silently measured from the wrong run.  Not hypothetical: it yielded an identical period
+        # at five different job sizes before it was caught.
+        vcd.unlink(missing_ok=True)
+
+        r = subprocess.run(["cmd", "/c", ".\\run.bat", self.top, self.tb, "trace"],
+                           cwd=str(xsi), capture_output=True, text=True, timeout=1800)
+        out = (r.stdout or "") + (r.stderr or "")
+        if "XSI_EXITCODE=0" not in out:
+            raise RuntimeError(f"{self.top}: XSI run did not complete cleanly:\n{out[-3000:]}")
+        if not vcd.exists():
+            raise RuntimeError(
+                f"{self.top}: run.bat completed but wrote no {vcd.name}. Is vcd_dumper_{self.top}.v "
+                f"present in {xsi} (AddVcdTopStep), and did run.bat get the `trace` argument?")
+        return {"trace_vcd": vcd}
+
+
+@dataclass(kw_only=True)
+class ExtractBurstsStep(BuildStep):
+    """Turn a traced run into a **timing table**: one row per component firing.
+
+    Binds the :class:`TraceManifestStep` manifest to the :class:`RtlSimStep` waveform and writes
+    what the figures and the calibration both need:
+
+    * ``firings`` -- per firing: ``span`` (first input handshake -> ``ap_done``), the regression
+      features ``nwords`` (m_axi beats moved) and ``num_trans`` (burst count), and ``blocked``
+      (cycles its output channel sat at capacity).
+    * ``channels`` -- per internal channel, packet and beat counts on both ends.
+    * ``boundary`` -- per port / bundle, burst and beat counts.
+
+    ``span`` is anchored on ``ap_done``, not on the last output beat, because an ``m_axi`` store is
+    posted: a component keeps working after its final stream beat.  On mem_copy's writer that is
+    155 vs 183 -- a 15% under-count that inverts which stage looks like the bottleneck.  See
+    :class:`waveflow.utils.trace.Firing`.
+
+    Pure waveform analysis: no toolchain, no simulation.
+    """
+
+    description: str = "Extract a per-firing timing table from a traced RTL run."
+    params: ClassVar[dict] = {}
+
+    manifest_artifact: str = "trace_manifest"
+    vcd_artifact: str = "trace_vcd"
+    output_path: str = "results/timing_events.json"
+    #: Words per AXI burst -- HLS's ``max_read_burst_length`` / ``max_write_burst_length``.
+    #: Recorded so a consumer can CHECK ``num_trans`` against ``ceil(nwords / max_burst_len)``
+    #: rather than assume it.
+    max_burst_len: int = 16
+
+    @property
+    def consumes(self) -> list:  # type: ignore[override]
+        return [self.manifest_artifact, self.vcd_artifact]
+
+    @property
+    def produces(self) -> dict:  # type: ignore[override]
+        return {"timing_events": Path(self.output_path)}
+
+    def _firing_rows(self, bt) -> list[dict]:
+        rows: list[dict] = []
+        for task in bt.manifest["tasks"]:
+            view = bt.component(task["inst"])
+            try:
+                firings = bt.component_firings(task["inst"])
+            except ValueError:
+                continue                      # a source with no observable input has no window
+            out_ch = [c for c in view.outputs if bt.channel(c)["kind"] != "sob"]
+            maxi = [bt.port(p) for p in view.boundary if bt.port(p)["kind"] == "maxi"]
+
+            for f in firings:
+                nwords = num_trans = 0
+                for p in maxi:
+                    s = p["signals"]
+                    for beat_v, beat_r, addr_v, addr_r in (
+                            ("RVALID", "RREADY", "ARVALID", "ARREADY"),
+                            ("WVALID", "WREADY", "AWVALID", "AWREADY")):
+                        if beat_v not in s or addr_v not in s:
+                            continue
+                        beats = bt._handshakes(s[beat_v], s[beat_r])
+                        addrs = bt._handshakes(s[addr_v], s[addr_r])
+                        nwords += int(((beats >= f.start) & (beats <= f.end)).sum())
+                        num_trans += int(((addrs >= f.start) & (addrs <= f.end)).sum())
+                rows.append({
+                    "component": task["id"], "inst": task["inst"], "index": f.index,
+                    "start": f.start, "end": f.end, "span": f.span,
+                    "nwords": nwords, "num_trans": num_trans,
+                    "blocked": sum(bt.channel_blocked(c, f.start, f.end) for c in out_ch),
+                })
+        return rows
+
+    def run(self, config: BuildConfig, **artifacts) -> dict[str, Any]:
+        from waveflow.utils.trace import load_trace
+
+        bt = load_trace(artifacts[self.manifest_artifact], artifacts[self.vcd_artifact])
+        man = bt.manifest
+
+        channels = []
+        for c in man["channels"]:
+            row = {"id": c["id"], "kind": c["kind"], "width": c["width"],
+                   "producer": c["producer"], "consumer": c["consumer"]}
+            if c["kind"] != "sob":
+                for side in ("write", "read"):
+                    pk, _ = bt.channel_bursts(c["id"], side=side)
+                    row[side] = {"packets": len(pk),
+                                 "beats": int(sum(len(p["data"]) for p in pk))}
+            channels.append(row)
+
+        boundary = []
+        for p in man["boundary"]:
+            if p["kind"] == "maxi":
+                wb, rb, _ = bt.aximm_bursts(p["id"])
+                boundary.append({
+                    "id": p["id"], "kind": "maxi", "directions": p["directions"],
+                    "write": {"bursts": len(wb),
+                              "beats": int(sum(len(b["data"]) for b in wb))},
+                    "read": {"bursts": len(rb),
+                             "beats": int(sum(len(b["data"]) for b in rb))}})
+            else:
+                bursts, _ = bt.port_bursts(p["id"])
+                boundary.append({"id": p["id"], "kind": p["kind"], "bursts": len(bursts),
+                                 "beats": int(sum(len(b["data"]) for b in bursts))})
+
+        events = {"version": 1, "top": man["top"], "max_burst_len": self.max_burst_len,
+                  "firings": self._firing_rows(bt), "channels": channels, "boundary": boundary}
+
+        root = Path(config.root_dir) if config.root_dir is not None else Path.cwd()
+        out_path = root / self.output_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(events, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return {"timing_events": out_path}

--- a/waveflow/build/xsi/run.bat
+++ b/waveflow/build/xsi/run.bat
@@ -1,8 +1,18 @@
 @echo off
-rem run.bat <top> <tb_basename> — XSI flow (xvlog -> xelab -dll -> g++ BFM -> run) for a generated
-rem free-running mem-stream kernel.  Adapted from the interleaver sandbox xsi_task/run.bat.
+rem run.bat <top> <tb_basename> [trace] — XSI flow (xvlog -> xelab -dll -> g++ BFM -> run) for a
+rem generated free-running mem-stream kernel.  Adapted from the interleaver sandbox xsi_task/run.bat.
 rem   run.bat mem_r_stream mem_r_bfm_tb
 rem   run.bat mem_w_stream mem_w_bfm_tb
+rem
+rem Pass a third argument `trace` to also elaborate vcd_dumper_<top>.v as a SECOND top, whose
+rem $dumpvars writes <top>_trace.vcd.  The XSI top -- and so every BFM port number -- is untouched,
+rem so the cycle counts are identical either way; only the dump is added.  The dumper is per-top
+rem because one xsi/ directory can serve several (examples/interleaver/xsi builds three), and a
+rem dumper naming a scope that is not part of THIS elaboration is a hard error.
+rem   run.bat mem_copy mem_copy_bfm_tb trace
+rem
+rem Note: re-running the built .exe does NOT regenerate the VCD -- only this script does, because
+rem the dump comes from the elaborated snapshot.  See waveflow.build.trace_steps.RtlSimStep.
 cd /d "%~dp0"
 set VIV=C:\Xilinx\2025.1\Vivado
 set MINGW=%VIV%\tps\mingw\6.2.0\win64.o\nt
@@ -12,8 +22,17 @@ set PATH=%~dp0xsim.dir\%TOP%;%MINGW%\bin;%VIV%\lib\win64.o;%VIV%\bin;%PATH%
 echo --- xvlog RTL (%TOP%) ---
 call %VIV%\bin\xvlog -f rtl_%TOP%.f
 echo xvlog errorlevel=%ERRORLEVEL%
-echo --- xelab -dll ---
-call %VIV%\bin\xelab work.%TOP% -dll -s %TOP% -debug typical
+rem The two xelab lines are spelled out rather than built in a variable: setting one inside an
+rem if/else block needs delayed expansion, which is a classic cmd trap.
+if /I "%3"=="trace" (
+  echo --- xvlog vcd_dumper_%TOP% ---
+  call %VIV%\bin\xvlog vcd_dumper_%TOP%.v
+  echo --- xelab -dll [+ vcd_dumper_%TOP%] ---
+  call %VIV%\bin\xelab work.%TOP% work.vcd_dumper_%TOP% -dll -s %TOP% -debug typical
+) else (
+  echo --- xelab -dll ---
+  call %VIV%\bin\xelab work.%TOP% -dll -s %TOP% -debug typical
+)
 echo xelab errorlevel=%ERRORLEVEL%
 echo --- g++ BFM tb (%TB%) ---
 call %MINGW%\bin\g++.exe -I%VIV%\data\xsim\include -O3 -c -o xsi_loader.o xsi_loader.cpp

--- a/waveflow/utils/trace.py
+++ b/waveflow/utils/trace.py
@@ -31,7 +31,8 @@ from waveflow.utils.vcd import (
 #: Signals that may legitimately be absent, so a missing one is a fact about the design rather than
 #: a broken binding.  ``tlast``: a plain ``hls::stream<ap_uint<W> >`` boundary port has no TLAST
 #: wire (mem_copy's ``s_cmd``).  The AXI burst signals: absent on an AXI4-Lite bundle.
-_OPTIONAL = frozenset({"tlast", "AWLEN", "WLAST", "ARLEN", "RLAST", "BVALID", "BREADY"})
+_OPTIONAL = frozenset({"tlast", "AWLEN", "WLAST", "ARLEN", "RLAST", "BVALID", "BREADY",
+                       "level", "cap"})
 
 
 @dataclass(frozen=True)
@@ -208,6 +209,11 @@ class BoundTrace:
         A firing starts at its first input handshake -- on any channel it consumes -- after the
         previous firing completed.  That excludes time the component spent waiting to be *given*
         work, so a firing's span is its own cost plus whatever it stalled on mid-firing.
+
+        If a firing has **no** fresh arrival (its input was already buffered when it began, which
+        happens whenever an upstream driver runs ahead), the start falls back to the cycle after the
+        previous ``ap_done``.  The firing is still returned: it happened, and dropping it would make
+        the row count disagree with ``task_done_cycles`` and silently lose a sample.
         """
         view = self.component(inst)
         done = np.asarray(self.task_done_cycles(inst))
@@ -231,10 +237,36 @@ class BoundTrace:
         prev = -1
         for j, end in enumerate(done):
             after = arrivals[(arrivals > prev) & (arrivals <= end)]
-            if len(after):
-                firings.append(Firing(index=j, start=int(after[0]), end=int(end)))
+            start = int(after[0]) if len(after) else min(prev + 1, int(end))
+            firings.append(Firing(index=j, start=start, end=int(end)))
             prev = int(end)
         return tuple(firings)
+
+    def channel_blocked(self, name: str, lo: int, hi: int) -> int:
+        """Cycles in ``[lo, hi]`` where channel *name* sat at capacity — i.e. its producer was
+        blocked.
+
+        Read from the FIFO's own occupancy counters, not from the write handshake.  HLS gates the
+        write enable, so a producer stalled on a full channel never asserts ``write`` and a
+        ``write & !full_n`` metric reports zero backpressure while the producer is stuck.  Returns
+        ``0`` if the design exposes no counters for this channel.
+        """
+        ch = self.channel(name)
+        d = ch.get("depth", {})
+        lvl, cap = d.get("level"), d.get("cap")
+        if not lvl or not cap or lvl not in self.resolved or cap not in self.resolved:
+            return 0
+
+        def _s(bare):
+            n = self.resolved[bare]
+            self.parser.sig_info[n].get_values()
+            return np.asarray(resample_signal(self.parser.sig_info[n], self._grid()))
+
+        level, capacity = _s(lvl), _s(cap)
+        top = int(capacity.max()) if capacity.size else 0
+        if top <= 0:
+            return 0
+        return int((level[lo:hi + 1] >= top).sum())
 
     def component_bursts(self, inst: str) -> dict[str, dict]:
         """Every channel beat arriving at and leaving one component.
@@ -350,7 +382,7 @@ def load_trace(manifest: dict | str | Path, vcd_path: str | Path) -> BoundTrace:
         for key, sig in p["signals"].items():
             _resolve(key, sig, f"boundary {p['id']}")
     for c in manifest["channels"]:
-        for side in ("write", "read"):
+        for side in ("write", "read", "depth"):
             for key, sig in c.get(side, {}).items():
                 _resolve(key, sig, f"channel {c['id']}.{side}")
 


### PR DESCRIPTION
Builds on #111 (the trace foundation, already on `main`). Completes the timing-instrumentation DAG so measuring a kernel's timing is one command, adds the figures, and splits the docs into reusable guide + example narrative.

```
CodegenTbStep → AddVcdTopStep + TraceManifestStep → RtlSimStep → ExtractBurstsStep
                (the dumper)     (the net names)     (the VCD)    (the timing table)
```

```bash
python examples/mem_copy/mem_copy_build.py --through extract_bursts   # table
python examples/mem_copy/mem_copy_build.py --through sync_docs_figures # + figures
```

## What's here

- **`RtlSimStep`** — thin wrapper over `run.bat … trace`. Asserts nothing; the exact cycle count stays with the `-m xsi` gate. Deletes the VCD first and requires it to reappear (re-running the `.exe` does *not* regenerate it — a trap that fed one sweep the previous trace five times).
- **`ExtractBurstsStep`** — a per-firing **timing table** (`span`, `nwords`, `num_trans`, `blocked`), shaped so a `BusTiming` calibration consumes it unchanged. `blocked` (from FIFO occupancy) automatically isolates the calibratable rows.
- **Figures** — `TimingFiguresStep` + `SyncDocsFiguresStep`, three committed SVGs following the shared_mem/regmap workflow: stage-activity timeline, one-job zoom with FIFO occupancy, per-firing span split into work vs waiting.
- **Docs, split** — general infra → `docs/guide/timing/trace_steps.md` (the four steps) + `trace_pitfalls.md` (the three traps: sampling phase, `ap_done` anchoring, occupancy-vs-write-enable). The mem_copy page is rewritten as a narrative that *uses* the infra and links to the guide.

## Fixes found while wiring

- `run.bat` is generated by `XsiHarnessStep`; the `trace` branch moved to the master `waveflow/build/xsi/run.bat` so it survives regeneration.
- The manifest now names each channel's FIFO occupancy counters — the only reliable backpressure signal (HLS gates the write enable).
- `component_firings` no longer drops a firing whose input was pre-buffered (was 47 rows for 48 firings).

## Verification

- `-m xsi` gates unchanged (158 / 176 / 2908 / 3469); `RtlSimStep`/`ExtractBursts` verified end-to-end through the DAG.
- New xsi-marked tests pin the table invariants: 16 firings/component, `blocked==0` isolates the reader's firing 0, and the two-level split (bus term shared, fixed term 41/11 per component).
- Full `not vitis and not xsi` suite at the same 6 pre-existing baseline failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)