### PR TITLE
calib: TimingModel — per-component timing-residual fitting engine

### DIFF
--- a/plans/timing_model.md
+++ b/plans/timing_model.md
@@ -1,0 +1,270 @@
+# TimingModel — per-component timing calibration on top of CalibModel
+
+**Status: design sketch.** The measurement half is shipped (PRs #111/#112: trace steps,
+per-firing timing table, `ap_done` windows, `blocked` column). This plan is the *fitting* half —
+the orchestration that turns those measurements into a per-component delay the pysim `run_iter` can
+apply. See `plans/memcpy_timing_calibration.md` for the measured law this has to reproduce.
+
+## The gap this fills
+
+`waveflow/calib/calib.py` already has the model machinery and says so in its own docstring —
+"it doesn't have any infrastructure for collecting data":
+
+- `CalibModel` / `LinCalibModel` — `fit` / `predict` / `score`, the state_dict artifact I/O, the
+  seed fallback (`load_or_default`). `LinCalibModel(fit_intercept=False, transform=…)` **is** the
+  mem_copy law shape: through-origin physical rates, with `clk_period` folded into the features so
+  the fit is clock-independent.
+- `CalibDataFrame` — the append-only datapoint corpus (csv, timestamps).
+
+What is missing is the glue **between a traced run and those models**: pull this component's rows
+from the timing table, decide which are valid, join RTL vs pysim into a residual, fit, and expose a
+`predict` the component calls. That glue is `TimingModel`. It **composes** `CalibModel`, it does not
+replace or subclass it.
+
+## What the session proved (constraints the design must honour)
+
+1. **Fit the RESIDUAL, not the absolute span.** `predict` returns the delay pysim is *missing*
+   (`RTL_span − pysim_span + current_dly`, see below). Fitting absolute re-derives the `nwords` term
+   pysim already models and destroys the property that makes it a model: contention *emerging* from
+   the bounded channel rather than being baked in.
+2. **Validity = `blocked == 0`, already computed.** `ExtractBurstsStep` emits `blocked` per firing
+   (from FIFO occupancy, the only reliable backpressure signal). `get_data_from_vcd` is therefore
+   "load `<top>_timing.json`, select this component, keep `blocked == 0`" — not stall-detection from
+   scratch.
+3. **The span window is `ap_done`, not the last output beat** — posted `m_axi` writes keep draining
+   after `s_done`. Already handled by `component_firings`; the table's `span` is correct.
+4. **`predict` degrades to a seed when unfitted** — a component with a `TimingModel` but no data yet
+   must still simulate (optimistically). `CalibModel.load_or_default` already does this.
+
+## `predict` returns the RESIDUAL (decided)
+
+`predict` returns **only the additional delay pysim did not already account for**, applied as an
+explicit `self.timeout` in `run_iter`:
+
+```python
+x = yield self.mem_if.read(nwords)      # pysim ALREADY charges the bus/mem read time here
+y = process(x)
+dly = self.tm.predict({...})            # only what pysim is still MISSING
+yield self.timeout(dly)
+```
+
+This dissolves the bus-vs-component question at the API level: the target is defined *operationally*
+as "RTL minus whatever pysim already computed." Whether the residual is bus or control is then a
+question of **how good the rest of the pysim model is**, not an API fork — improve `BusTiming` and
+the residual shrinks; leave it and the residual carries the difference. So the class is always
+residual-only; the two-level split becomes "where you spend effort improving pysim," recorded per
+[[project-two-level-calibration]].
+
+### The residual must subtract the CURRENT prediction (self-correcting fit)
+
+The subtlety that makes this converge from any starting point: the residual is **not** simply
+`RTL_span − pysim_span`, because the pysim span *already includes whatever the model predicted on
+that run*. Concretely — model currently predicts `dly = 5`, pysim total = 80, RTL = 100. The model
+should have added 20 more, i.e. the true delay is `25`, not `20`:
+
+```
+pysim_span = pysim_intrinsic + current_dly          # what the run produced
+want:  RTL_span = pysim_intrinsic + true_dly
+so:    true_dly = RTL_span − pysim_intrinsic
+                = RTL_span − (pysim_span − current_dly)
+                = RTL_span − pysim_span + current_dly     # the fit target
+```
+
+**Therefore the pysim datapoint must record `current_dly`** — the prediction that was live during
+that run — alongside its span. The fit target is `RTL_span − pysim_span + current_dly`. Two
+consequences, both good:
+
+- No special "baseline run with the model disabled" is needed. *Any* run is a valid datapoint as
+  long as it recorded what the model contributed.
+- Calibration is **online / iterative**: run pysim with the current model → measure → re-fit →
+  converge. A seed of 0 (or the hand-fit constant) is just the first iterate.
+
+## Multiple targets (API now, one for now)
+
+`predict` returns a **list** of delays, length `num_targets` (default 1); `num_targets > 1` raises
+`NotImplementedError` for now. This carries the API so components can eventually inject a delay
+*between* internal processing stages:
+
+```python
+dlys = self.tm.predict({...})       # length num_targets
+yield self.timeout(dlys[0]); yield self.proc0(...)
+yield self.timeout(dlys[1]); yield self.proc1(...)
+yield self.timeout(dlys[2]); yield self.proc2(...)
+```
+
+Each target is its **own** `CalibModel` (composition — the per-target rule the base already
+enforces; a single vector regression over correlated targets would be wrong, which is the only thing
+to avoid, *not* multi-target itself). So multi-target = N composed models, which the class supports
+naturally.
+
+**Why it's gated at 1 for now:** calibrating N per-stage delays needs per-stage *measurement* — the
+`ap_done`/port boundaries only bound the whole firing, so splitting it across internal stages
+requires intra-component visibility. That is exactly the deferred **Tier-2 tracing** (hierarchical
+paths + `.v` scan). So `num_targets > 1` unblocks when Tier-2 lands; until then a component is one
+firing, one residual.
+
+## Deferred subtlety (flag, don't solve)
+
+A scalar delay is not the whole story: **where** in `run_iter` it is injected matters. Leading vs
+trailing placement gave the same *period* but different *fill* (first-completion latency), because a
+writer's residual is a posted-write drain (trailing) while a reader's is control setup (leading). So
+the model is really `(delay, placement)`; `placement` affects latency-accuracy even when it does not
+affect throughput. Default to one placement now; carry it as a field so it is not a silent
+assumption. (With `num_targets > 1` the placements are implicit in the `timeout`/`proc` interleave,
+which is the more general form.)
+
+## Storage: per-run folders, not one shared csv
+
+A single append-only `rtl.csv` means a read-modify-write on every run, and it throws away per-run
+detail — exactly what you want back when a fit is bad and you need to inspect one point (the full
+burst sequence, the raw firing rows). So make **each run its own folder the source of truth**, and
+let `fit()` glob them:
+
+```
+calib_dir/
+  params.json                 # fitted state_dict(s) — the ONLY deploy artifact (DAG-tracked)
+  runs/
+    <run_id>/                 # one folder per (design, scenario) run — append-only at folder level
+      rtl_firings.csv         # this component's firings from the VCD table (incl. blocked)
+      pysim_firings.csv       # this component's firings incl. current_dly
+      bursts.json (optional)  # full per-beat detail, for when a fit looks wrong — debug only
+```
+
+Why this beats a shared csv:
+
+- **No RMW, concurrency-safe.** Each run writes a fresh folder; nothing edits a shared file, so
+  parallel/repeated runs cannot corrupt the corpus.
+- **The debug trail is free.** `bursts.json` (or whatever a subclass drops) lives beside the summary
+  rows, so a bad fit is inspectable without re-running.
+- **`fit()` is a glob + concat + join**, reading `runs/*/`. The two per-source frames become a
+  *derived cache*, not stored state.
+
+This layout, the discovery, and the glob/concat are **common** (base `TimingModel`) — the row schema
+is the shared `ExtractBurstsStep` shape. Only the *optional extra* artifact a run drops (`bursts.json`)
+might vary per subclass, and it is not on the fit path. So it is less machinery than a
+concurrency-safe shared-csv RMW, not more — no per-subclass storage code needed.
+
+`run_id` should be derived from the scenario (e.g. `n_words`, job count) so a re-run of the same
+point overwrites rather than duplicates — deterministic, DAG-friendly.
+
+## Shape
+
+```
+TimingModel  (per FreeRunComp — orchestration; COMPOSES CalibModel)
+  calib_dir/                             # per-run folders (see above); params.json the deploy artifact
+  models: list[CalibModel]               # length num_targets (default 1); each per-target
+  features: list[str]                    # e.g. ["nwords", "num_trans"]
+  num_targets: int = 1                   # predict() returns a list this long; >1 raises for now
+  placement: "leading" | "trailing"      # where run_iter injects the delay (single-target case)
+
+  # collection (the genuinely new glue)
+  collect_rtl(events, run_id)            # this component's blocked==0 firings -> runs/<id>/rtl_firings.csv
+  collect_pysim(component, run_id)       # this component's spans + current_dly -> runs/<id>/pysim_firings.csv
+  # fit
+  fit()                                  # glob runs/*/, join rtl+pysim on `features`;
+                                         #   target = rtl_span - pysim_span + current_dly;
+                                         #   per-target CalibModel.fit; save params.json
+  # deploy
+  predict(row) -> list[float]            # additional delay(s) in CYCLES; * clk.period at the call site
+                                         #   load_or_default so an unfitted model returns the seed
+  # lifecycle
+  reset(runs=True, params=False)         # wipe the corpus (runs/) and/or the fitted params, to
+                                         #   recalibrate from scratch; back to the seed
+```
+
+`reset` exists because the corpus is append-only across runs, so a stale or bad-scenario datapoint
+otherwise lingers forever. `reset(runs=True)` clears `runs/` (start collecting fresh);
+`reset(params=True)` deletes `params.json` (fall back to the seed on next `predict`). Default clears
+runs only — the common "re-sweep from scratch" — and leaves a fitted model deployable until the next
+fit replaces it.
+
+### Component side (the user's sketch, refined)
+
+```python
+class MemWStream(FreeRunComp):
+    def __post_init__(self):
+        super().__post_init__()
+        self.tm = StreamTimingModel(
+            calib_dir=<example>/calib/mem_w_stream,
+            features=["nwords", "num_trans"],
+            placement="trailing",           # posted-write drain
+            seed={...})                     # fixed cost until calibrated
+        self.add_timing_model(self.tm)      # register on the component (tree-discoverable)
+
+    def _run_iter_inband(self):
+        ... read descriptor, buffer fwd, write data ...
+        dly = self.tm.predict({"nwords": nw, "num_trans": ceil(nw/16)})
+        yield self.timeout(dly * self.clk.period)   # trailing: after the write, before next firing
+        ... emit response ...
+```
+
+`add_timing_model` mirrors `add_dyn_param` / `discover_dyn_params`: a walk over the built tree finds
+every registered `TimingModel`, which is what lets a build step know "trace these components and,
+after the RTL run, collect into their calib_dirs."
+
+### `StreamTimingModel(TimingModel)`
+
+Declares the per-target models a mem-stream component needs. A pure-write component (MemWStream) has
+one target (`write_residual`); a component that both reads and writes could declare two. Each is a
+`LinCalibModel(fit_intercept=False, transform=fold_clk)` over `features`.
+
+## DAG integration
+
+Extends the timing rung already on `main`:
+
+```
+... -> ExtractBurstsStep -> CollectTimingStep -> FitTimingStep
+                            (per registered TM:   (per registered TM:
+                             write runs/<id>/      glob runs/*, join,
+                             rtl+pysim firings)    fit, save params.json)
+```
+
+- **`CollectTimingStep`** consumes `timing_events` (RTL) + the pysim run's spans; for each registered
+  `TimingModel` on the design, writes a `runs/<run_id>/` folder (per above). One folder per scenario,
+  so a sweep across `n_words` (once the TB's baked `h.run(3400)` + 24640-word arena are parameterized
+  — the prerequisite from the calibration plan) grows the corpus without touching prior runs.
+- **`FitTimingStep`** calls `tm.fit()` for each; writes `params.json`. DAG-tracked artifact, so a
+  changed corpus re-fits and a design that consumes the params re-runs.
+
+The presence of a registered `TimingModel` is the signal for both steps — a component with none is
+simply not collected or fitted, and simulates from whatever its `run_iter` already does.
+
+## Reuse ledger (what is new vs already shipped)
+
+| piece                                      | status                                                                                                                                                                                                                                                                                  |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| fit / predict / score / state_dict / seed  | **exists** — `CalibModel` / `LinCalibModel`                                                                                                                                                                                                                                  |
+| datapoint corpus (csv, timestamps)         | **exists** — `CalibDataFrame`                                                                                                                                                                                                                                                  |
+| per-firing RTL table +`blocked` validity | **exists** — `ExtractBurstsStep` (#112)                                                                                                                                                                                                                                        |
+| `ap_done` span windows                   | **exists** — `component_firings` (#111)                                                                                                                                                                                                                                        |
+| pysim per-firing spans                     | **partial** — `transfer_spans` is a per-component convention in `mem_stream.py` (MemRStream/MemWStream each set it up), *not* on `FreeRunComp`. Lift it to the base (or have `add_timing_model` install the hook) so any calibrated component records spans uniformly. |
+| `TimingModel` (compose + collect + join) | **new** — small                                                                                                                                                                                                                                                                  |
+| `get_data_from_vcd` (select + filter)    | **new** — small, reads the #112 table                                                                                                                                                                                                                                            |
+| `add_timing_model` / tree discovery      | **new** — mirrors `discover_dyn_params`                                                                                                                                                                                                                                        |
+| `CollectTimingStep` / `FitTimingStep`  | **new**                                                                                                                                                                                                                                                                           |
+| per-run folder storage + glob/concat       | **new** — small, common (base), no per-subclass code                                                                                                                                                                                                                             |
+| improve `BusTiming` to shrink the residual | **later** — not a fork; residual carries whatever pysim's bus model misses until then                                                                                                                                                                                            |
+
+## Order of work
+
+1. `TimingModel` + `StreamTimingModel`, `num_targets=1`. `predict` returns `[dly]` from a seed;
+   `collect_rtl` / `collect_pysim` (recording `current_dly`) / `fit` (target
+   `rtl_span − pysim_span + current_dly`) over the per-run folders + `LinCalibModel`. Lift
+   `transfer_spans` to `FreeRunComp` (or install via `add_timing_model`) so the pysim side is uniform.
+2. Wire one component (MemWStream) — `add_timing_model`, the `run_iter` timeout, the two build steps.
+   Gate: pysim period matches RTL to the ~1% the hand-analysis already hit, at n_words=128, from a
+   0-seed after one collect+fit iteration.
+3. Parameterize the TB run-bound + arena; sweep n_words; confirm the fit extrapolates (the real test
+   — a single size cannot calibrate the slope).
+4. Improve pysim's `BusTiming` so the residual becomes the pure per-component control cost (the
+   two-level split); revisit when a second m_axi master shares a bus.
+5. `num_targets > 1` — gated on Tier-2 intra-component tracing (per-stage measurement).
+
+## Related
+
+- `plans/memcpy_timing_calibration.md` — the measured law and the sweep result this reproduces
+- [[project-memcpy-timing-instrumentation]] — the measurement arc (merged)
+- [[reference-calib-statedict-artifacts]] — the state_dict + DAG-artifact + seed pattern reused here
+- [[project-two-level-calibration]] — why the bus/component split matters (residual carries it until
+  `BusTiming` improves)
+- `waveflow/calib/calib.py` — `CalibModel`, `LinCalibModel`, `CalibDataFrame`

--- a/plans/timing_model.md
+++ b/plans/timing_model.md
@@ -113,70 +113,83 @@ affect throughput. Default to one placement now; carry it as a field so it is no
 assumption. (With `num_targets > 1` the placements are implicit in the `timeout`/`proc` interleave,
 which is the more general form.)
 
-## Storage: per-run folders, not one shared csv
+## Storage: independent rtl / pysim trees, joined on features
 
-A single append-only `rtl.csv` means a read-modify-write on every run, and it throws away per-run
-detail — exactly what you want back when a fit is bad and you need to inspect one point (the full
-burst sequence, the raw firing rows). So make **each run its own folder the source of truth**, and
-let `fit()` glob them:
+RTL and pysim are collected at **different cadence** — RTL is Vitis-expensive (a sweep of a handful
+of sizes), pysim is every-edit-cheap (run it 50×). So they are *not* 1:1 and must not be coupled in
+one run folder. The merge key is the **feature point** (`nwords`, `num_trans`), not the run id: an
+RTL run at n=128 and a pysim run at n=128 correspond even collected months apart.
 
 ```
 calib_dir/
-  params.json                 # fitted state_dict(s) — the ONLY deploy artifact (DAG-tracked)
-  runs/
-    <run_id>/                 # one folder per (design, scenario) run — append-only at folder level
-      rtl_firings.csv         # this component's firings from the VCD table (incl. blocked)
-      pysim_firings.csv       # this component's firings incl. current_dly
-      bursts.json (optional)  # full per-beat detail, for when a fit looks wrong — debug only
+  rtl/<run_id>/firings.csv     # collected whenever an RTL trace runs (spans in cycles)
+  pysim/<run_id>/firings.csv   # collected whenever pysim runs — any cadence (spans + current_dly)
+  params.json                  # fitted state_dict — the ONLY deploy artifact (DAG-tracked)
+  corpus.csv                   # derived: the merged residual frame (a cache, inspectable)
 ```
 
-Why this beats a shared csv:
+- **Independent collection.** `collect_rtl` / `collect_pysim` drop into their own trees; no 1:1
+  assumption. Each `<run_id>` folder is the source of truth (re-running a scenario overwrites it —
+  no shared-csv read-modify-write, concurrency-safe), and holds the full per-firing rows as the
+  debug trail when a fit looks wrong.
+- **Join on features, report the gaps.** `gen_data_frame` aggregates each side per feature point and
+  inner-joins on `features`. A point on only one side cannot yield a residual and is recorded on
+  `.coverage` (`{matched, rtl_only, pysim_only}`), so a thin fit is a *visible* coverage gap, not a
+  silent one.
 
-- **No RMW, concurrency-safe.** Each run writes a fresh folder; nothing edits a shared file, so
-  parallel/repeated runs cannot corrupt the corpus.
-- **The debug trail is free.** `bursts.json` (or whatever a subclass drops) lives beside the summary
-  rows, so a bad fit is inspectable without re-running.
-- **`fit()` is a glob + concat + join**, reading `runs/*/`. The two per-source frames become a
-  *derived cache*, not stored state.
+The three-layer read is:
 
-This layout, the discovery, and the glob/concat are **common** (base `TimingModel`) — the row schema
-is the shared `ExtractBurstsStep` shape. Only the *optional extra* artifact a run drops (`bursts.json`)
-might vary per subclass, and it is not on the fit path. So it is less machinery than a
-concurrency-safe shared-csv RMW, not more — no per-subclass storage code needed.
+```
+is_record_valid(firing, run_dir) -> bool     # per firing, RTL side only; default blocked==0; overridable
+        ⊂
+get_params(run_dir) -> dict | None           # per run: filter (rtl) → aggregate → one point row
+        ⊂
+gen_data_frame() -> DataFrame                # all runs both sides: inner-join on features → residual
+```
 
-`run_id` should be derived from the scenario (e.g. `n_words`, job count) so a re-run of the same
-point overwrites rather than duplicates — deterministic, DAG-friendly.
+`get_params` is the per-model "how to read a run" hook; `is_record_valid` the per-model validity
+test (a subclass can scan the run's AXI trace for stalls the FIFO counters miss). Both have sensible
+defaults, so a plain `StreamTimingModel` needs neither.
+
+## Units: cycles internal, convert at the boundary
+
+Everything stored and fitted is in **cycles**, so `params.json` is clock-independent — the same
+fitted law drives a re-synth at a different clock, only the boundary conversion changes. The two
+sides differ: **RTL is natively cycles** (VCD cycle indices), **pysim is time**. So `collect_pysim`
+divides its spans by `clk.period` on the way in, and `predict` multiplies back on the way out. With
+`clk=None` the data is assumed already in cycles (tests, pure analysis). The component does no
+arithmetic — `predict` returns a time it hands straight to `timeout`, and it records raw times that
+`collect_pysim` converts. The rare genuinely-time-valued term (a DRAM latency in ns) is the override:
+carry `clk.period` as a *feature* via the `LinCalibModel.transform`.
 
 ## Shape
 
 ```
 TimingModel  (per FreeRunComp — orchestration; COMPOSES CalibModel)
-  calib_dir/                             # per-run folders (see above); params.json the deploy artifact
-  models: list[CalibModel]               # length num_targets (default 1); each per-target
-  features: list[str]                    # e.g. ["nwords", "num_trans"]
+  component, calib_dir, features
   num_targets: int = 1                   # predict() returns a list this long; >1 raises for now
-  placement: "leading" | "trailing"      # where run_iter injects the delay (single-target case)
+  placement: "leading" | "trailing"      # advisory: where run_iter injects the delay
+  seed: dict | None                      # state_dict used before any fit (0 delay by default)
+  clk: Any = None                        # .period; converts pysim time<->cycles. None = already cycles
+  coverage: dict                         # set by gen_data_frame: matched / rtl_only / pysim_only
 
-  # collection (the genuinely new glue)
-  collect_rtl(events, run_id)            # this component's blocked==0 firings -> runs/<id>/rtl_firings.csv
-  collect_pysim(component, run_id)       # this component's spans + current_dly -> runs/<id>/pysim_firings.csv
-  # fit
-  fit()                                  # glob runs/*/, join rtl+pysim on `features`;
-                                         #   target = rtl_span - pysim_span + current_dly;
-                                         #   per-target CalibModel.fit; save params.json
-  # deploy
-  predict(row) -> list[float]            # additional delay(s) in CYCLES; * clk.period at the call site
-                                         #   load_or_default so an unfitted model returns the seed
+  # collection (independent trees)
+  collect_rtl(events, run_id)            # this component's firings -> rtl/<id>/firings.csv
+  collect_pysim(firings, run_id)         # spans + current_dly (time -> cycles) -> pysim/<id>/firings.csv
+  # read (three layers)
+  is_record_valid(firing, run_dir)       # per-firing validity (RTL side); default blocked==0
+  get_params(run_dir) -> dict | None     # one run -> its aggregated point
+  gen_data_frame() -> DataFrame          # join on features -> features…|span_rtl|span_pysim|current_dly|residual
+  # fit / deploy
+  fit()                                  # gen_data_frame -> LinCalibModel.fit(target=residual) -> params.json
+  predict(row) -> list[float]            # additional delay(s); TIME if clk set, else cycles; seed if unfitted
   # lifecycle
-  reset(runs=True, params=False)         # wipe the corpus (runs/) and/or the fitted params, to
-                                         #   recalibrate from scratch; back to the seed
+  reset(corpus=True, params=False)       # wipe rtl/+pysim/+corpus.csv and/or params.json
 ```
 
-`reset` exists because the corpus is append-only across runs, so a stale or bad-scenario datapoint
-otherwise lingers forever. `reset(runs=True)` clears `runs/` (start collecting fresh);
-`reset(params=True)` deletes `params.json` (fall back to the seed on next `predict`). Default clears
-runs only — the common "re-sweep from scratch" — and leaves a fitted model deployable until the next
-fit replaces it.
+`reset(corpus=True)` (default) clears the `rtl/`+`pysim/` trees and `corpus.csv` — the common
+"re-sweep from scratch" — and leaves a fitted model deployable. `reset(params=True)` deletes
+`params.json` so the next `predict` falls back to the seed.
 
 ### Component side (the user's sketch, refined)
 
@@ -215,14 +228,15 @@ Extends the timing rung already on `main`:
 ```
 ... -> ExtractBurstsStep -> CollectTimingStep -> FitTimingStep
                             (per registered TM:   (per registered TM:
-                             write runs/<id>/      glob runs/*, join,
-                             rtl+pysim firings)    fit, save params.json)
+                             collect_rtl +         gen_data_frame join,
+                             collect_pysim)        fit, save params.json)
 ```
 
 - **`CollectTimingStep`** consumes `timing_events` (RTL) + the pysim run's spans; for each registered
-  `TimingModel` on the design, writes a `runs/<run_id>/` folder (per above). One folder per scenario,
-  so a sweep across `n_words` (once the TB's baked `h.run(3400)` + 24640-word arena are parameterized
-  — the prerequisite from the calibration plan) grows the corpus without touching prior runs.
+  `TimingModel` on the design, calls `collect_rtl` / `collect_pysim` (independent trees, keyed by a
+  scenario-derived `run_id`). A sweep across `n_words` (once the TB's baked `h.run(3400)` +
+  24640-word arena are parameterized — the prerequisite from the calibration plan) grows the corpus
+  without touching prior runs.
 - **`FitTimingStep`** calls `tm.fit()` for each; writes `params.json`. DAG-tracked artifact, so a
   changed corpus re-fits and a design that consumes the params re-runs.
 

--- a/tests/calib/test_timing_model.py
+++ b/tests/calib/test_timing_model.py
@@ -1,8 +1,8 @@
 """tests/calib/test_timing_model.py — the residual-fitting orchestration.
 
 The model machinery (LinCalibModel) is covered in test_calib.py; this file is about the layer
-TimingModel adds: collecting per-run firings, filtering on `blocked`, joining RTL vs pysim into the
-*current-prediction-corrected* residual, and the lifecycle (seed fallback, reset, num_targets guard).
+TimingModel adds: independent rtl/pysim collection, per-firing validity, the merged residual frame
+(with the current-prediction correction), cycle/time conversion, coverage, and the lifecycle.
 """
 from __future__ import annotations
 
@@ -31,23 +31,34 @@ def _pysim_firings(*, nwords=128, n=16, span=147, current_dly=0.0, max_burst=16)
             for _ in range(n)]
 
 
+class _Clk:
+    def __init__(self, period):
+        self.period = period
+
+
 @pytest.fixture
 def tm(tmp_path):
     return StreamTimingModel(component="mem_w_stream_framed_done_task", calib_dir=tmp_path / "cal")
 
 
+def _seed_two_sizes(m, component="c"):
+    """Collect two sizes whose true residual is 2*num_trans (nwords contributes 0)."""
+    for nw in (128, 512):
+        nt = nw // 16
+        m.collect_rtl(_rtl_events(component=component, nwords=nw, span=1000 + nw + 2 * nt),
+                      run_id=f"n{nw}")
+        m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw, current_dly=0.0), run_id=f"n{nw}")
+
+
 class TestConstruction:
     def test_stream_defaults_the_basis(self, tmp_path):
-        m = StreamTimingModel(component="c", calib_dir=tmp_path)
-        assert m.features == ["nwords", "num_trans"]
+        assert StreamTimingModel(component="c", calib_dir=tmp_path).features == ["nwords", "num_trans"]
 
     def test_base_requires_features(self, tmp_path):
         with pytest.raises(ValueError, match="features"):
             TimingModel(component="c", calib_dir=tmp_path)
 
     def test_unfitted_predicts_the_seed(self, tmp_path):
-        """A fresh model with the default (zero) seed adds no delay — a component with a TimingModel
-        but no calibration still simulates."""
         m = StreamTimingModel(component="c", calib_dir=tmp_path)
         assert m.predict({"nwords": 128, "num_trans": 8}) == [0.0]
 
@@ -57,143 +68,190 @@ class TestConstruction:
         assert m.predict({"nwords": 128, "num_trans": 8}) == [22.0 + 2.0 * 8]
 
 
-class TestCollectAndFit:
+class TestResidualAndFit:
     def test_residual_subtracts_pysim_and_adds_current_dly(self, tm):
-        """The crux: target = rtl - pysim + current_dly.  With current_dly recorded, the fit is
-        self-correcting from any prior model state."""
-        # RTL 183, pysim 150 measured WHILE the model was already adding 5 -> true residual 38.
+        """The crux: residual = rtl - pysim + current_dly, so the fit is self-correcting."""
         tm.collect_rtl(_rtl_events(span=183), run_id="n128")
         tm.collect_pysim(_pysim_firings(span=150, current_dly=5.0), run_id="n128")
-        corpus = tm.build_corpus()
-        assert len(corpus) == 1
-        assert corpus.df[tm._model.target].iloc[0] == pytest.approx(183 - 150 + 5)
+        df = tm.gen_data_frame()
+        assert len(df) == 1
+        assert df["residual"].iloc[0] == pytest.approx(183 - 150 + 5)
 
     def test_blocked_firings_are_dropped(self, tm):
-        """Only blocked==0 firings are the component's own cost."""
         ev = _rtl_events(span=183, n_firings=16)
         for f in ev["firings"][1:]:            # firing 0 clean, rest contended
-            f["blocked"] = 30
-            f["span"] = 213
+            f["blocked"], f["span"] = 30, 213
         tm.collect_rtl(ev, run_id="n128")
         tm.collect_pysim(_pysim_firings(span=150), run_id="n128")
-        corpus = tm.build_corpus()
-        # median RTL span over the ONE valid firing = 183, not the contended 213.
-        assert corpus.df[tm._model.target].iloc[0] == pytest.approx(183 - 150 + 0)
+        # median over the ONE valid RTL firing = 183, not the contended 213.
+        assert tm.gen_data_frame()["residual"].iloc[0] == pytest.approx(183 - 150)
 
     def test_fit_recovers_a_linear_law_across_sizes(self, tmp_path):
-        """Two sizes, residual = 22 + 2*num_trans (nwords contributes 0): the fit must recover it,
-        which a single size could not."""
         m = StreamTimingModel(component="c", calib_dir=tmp_path)
-        for nw in (128, 512):
-            nt = nw // 16
-            m.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * nt),
-                          run_id=f"n{nw}")
-            m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw, current_dly=0.0),
-                            run_id=f"n{nw}")
+        _seed_two_sizes(m)
         m.fit()
-        # residual(nw) = 2*num_trans -> predict at an UNSEEN size extrapolates.
-        pred = m.predict({"nwords": 256, "num_trans": 16})[0]
-        assert pred == pytest.approx(2 * 16, abs=1e-6)
+        assert m.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(2 * 16, abs=1e-6)
 
     def test_fit_writes_params_json(self, tm):
         tm.collect_rtl(_rtl_events(), run_id="n128")
         tm.collect_pysim(_pysim_firings(), run_id="n128")
+        tm.collect_rtl(_rtl_events(nwords=512, span=615), run_id="n512")
+        tm.collect_pysim(_pysim_firings(nwords=512, span=531), run_id="n512")
         tm.fit()
         params = json.loads((tm.calib_dir / "params.json").read_text())
         assert "intercept" in params and set(tm.features) <= set(params)
 
-    def test_fitted_model_reloads_from_params(self, tmp_path):
-        """A deployed model predicts from params.json alone — no corpus, no sklearn refit."""
+    def test_deployed_model_reloads_from_params(self, tmp_path):
         a = StreamTimingModel(component="c", calib_dir=tmp_path)
-        for nw in (128, 512):
-            a.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
-                          run_id=f"n{nw}")
-            a.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw), run_id=f"n{nw}")
+        _seed_two_sizes(a)
         a.fit()
         want = a.predict({"nwords": 256, "num_trans": 16})[0]
-
         b = StreamTimingModel(component="c", calib_dir=tmp_path)   # fresh, only reads params.json
         assert b.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(want)
 
-    def test_empty_corpus_fit_raises(self, tm):
-        """A fit with nothing joined must fail, not silently leave a seed model looking fitted."""
+    def test_empty_join_fit_raises(self, tm):
         tm.collect_rtl(_rtl_events(), run_id="n128")   # RTL only, no pysim
         with pytest.raises(RuntimeError, match="no residual datapoints"):
             tm.fit()
 
     def test_predict_never_negative(self, tmp_path):
-        """A residual model that extrapolates below zero must clamp — a negative timeout is meaningless."""
         m = StreamTimingModel(component="c", calib_dir=tmp_path,
                               seed={"nwords": 0.0, "num_trans": 0.0, "intercept": -5.0})
         assert m.predict({"nwords": 0, "num_trans": 0}) == [0.0]
 
-
-class TestPerRunStorage:
-    def test_each_run_is_its_own_folder(self, tm):
-        tm.collect_rtl(_rtl_events(), run_id="n128")
-        tm.collect_rtl(_rtl_events(nwords=256, span=327), run_id="n256")
-        assert (tm.runs_dir / "n128" / "rtl_firings.csv").exists()
-        assert (tm.runs_dir / "n256" / "rtl_firings.csv").exists()
-
-    def test_rerunning_a_scenario_overwrites_not_duplicates(self, tm):
+    def test_corpus_csv_is_written_and_inspectable(self, tm):
         tm.collect_rtl(_rtl_events(span=183), run_id="n128")
-        tm.collect_rtl(_rtl_events(span=999), run_id="n128")   # same run_id
-        tm.collect_pysim(_pysim_firings(), run_id="n128")
-        corpus = tm.build_corpus()
-        assert corpus.df[tm._model.target].iloc[0] == pytest.approx(999 - 147 + 0)
+        tm.collect_pysim(_pysim_firings(span=147, current_dly=0.0), run_id="n128")
+        tm.gen_data_frame()
+        import pandas as pd
+        corpus = pd.read_csv(tm.corpus_path)
+        assert list(corpus.columns) == ["nwords", "num_trans", "span_rtl", "span_pysim",
+                                        "current_dly", "residual"]
+        assert corpus["residual"].iloc[0] == pytest.approx(36)
 
-    def test_fit_globs_all_runs(self, tmp_path):
-        m = StreamTimingModel(component="c", calib_dir=tmp_path)
-        m.collect_rtl(_rtl_events(component="c", nwords=128, span=1128 + 2 * 8), run_id="a")
-        m.collect_pysim(_pysim_firings(nwords=128, span=1128), run_id="a")
-        m.collect_rtl(_rtl_events(component="c", nwords=512, span=1512 + 2 * 32), run_id="b")
-        m.collect_pysim(_pysim_firings(nwords=512, span=1512), run_id="b")
-        assert len(m.build_corpus()) == 2      # both runs joined
+
+class TestIndependentCadenceAndCoverage:
+    def test_rtl_and_pysim_collect_into_separate_trees(self, tm):
+        tm.collect_rtl(_rtl_events(), run_id="n128")
+        tm.collect_pysim(_pysim_firings(), run_id="whenever")   # different run id, fine
+        assert (tm.calib_dir / "rtl" / "n128" / "firings.csv").exists()
+        assert (tm.calib_dir / "pysim" / "whenever" / "firings.csv").exists()
+
+    def test_join_is_on_features_not_run_id(self, tm):
+        """RTL and pysim at n=128 correspond even under different run ids."""
+        tm.collect_rtl(_rtl_events(nwords=128, span=183), run_id="rtl_sweep_a")
+        tm.collect_pysim(_pysim_firings(nwords=128, span=147), run_id="pysim_nightly_42")
+        df = tm.gen_data_frame()
+        assert len(df) == 1 and df["residual"].iloc[0] == pytest.approx(36)
+
+    def test_coverage_reports_unmatched_points(self, tm):
+        """pysim ran more sizes than RTL — the extra points are reported, not silently dropped."""
+        tm.collect_rtl(_rtl_events(nwords=128, span=183), run_id="a")
+        tm.collect_pysim(_pysim_firings(nwords=128, span=147), run_id="a")
+        tm.collect_pysim(_pysim_firings(nwords=256, span=291), run_id="b")   # no RTL counterpart
+        df = tm.gen_data_frame()
+        assert len(df) == 1                                # only the matched point fits
+        assert tm.coverage["matched"] == [(128.0, 8.0)]
+        assert tm.coverage["pysim_only"] == [(256.0, 16.0)]
+        assert tm.coverage["rtl_only"] == []
+
+    def test_rerunning_a_scenario_overwrites(self, tm):
+        tm.collect_rtl(_rtl_events(span=183), run_id="n128")
+        tm.collect_rtl(_rtl_events(span=999), run_id="n128")   # same run_id -> replace
+        tm.collect_pysim(_pysim_firings(), run_id="n128")
+        assert tm.gen_data_frame()["residual"].iloc[0] == pytest.approx(999 - 147)
+
+
+class TestCycleTimeConversion:
+    def test_pysim_time_is_converted_to_cycles_on_collect(self, tmp_path):
+        """clk set: pysim spans arrive in TIME and are divided to cycles; residual is in cycles."""
+        clk = _Clk(period=10.0)                # 10 ns/cycle
+        m = StreamTimingModel(component="c", calib_dir=tmp_path, clk=clk)
+        m.collect_rtl(_rtl_events(component="c", nwords=128, span=183), run_id="n128")  # cycles
+        m.collect_pysim([{"nwords": 128, "num_trans": 8, "span": 1470.0, "current_dly": 0.0}],
+                        run_id="n128")          # 1470 ns = 147 cycles
+        df = m.gen_data_frame()
+        assert df["span_pysim"].iloc[0] == pytest.approx(147)
+        assert df["residual"].iloc[0] == pytest.approx(183 - 147)
+
+    def test_predict_returns_time_when_clk_set(self, tmp_path):
+        clk = _Clk(period=10.0)
+        m = StreamTimingModel(component="c", calib_dir=tmp_path, clk=clk,
+                              seed={"nwords": 0.0, "num_trans": 0.0, "intercept": 5.0})
+        # 5 cycles * 10 ns = 50 ns
+        assert m.predict({"nwords": 128, "num_trans": 8}) == [50.0]
+
+    def test_params_are_clock_independent(self, tmp_path):
+        """The fitted state_dict is cycles — the SAME params drive different clocks, only the
+        boundary conversion differs.  This is the payoff of cycles-internal."""
+        a = StreamTimingModel(component="c", calib_dir=tmp_path / "a", clk=_Clk(10.0))
+        for nw in (128, 512):
+            a.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
+                          run_id=f"n{nw}")
+            a.collect_pysim([{"nwords": nw, "num_trans": nw // 16,
+                              "span": (1000 + nw) * 10.0, "current_dly": 0.0}], run_id=f"n{nw}")
+        a.fit()
+        params = json.loads((a.calib_dir / "params.json").read_text())
+
+        # Same params, a slower clock: predict scales with the period, params do not.
+        b = StreamTimingModel(component="c", calib_dir=tmp_path / "a", clk=_Clk(20.0))
+        assert b.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(2 * 16 * 20.0)
+        assert json.loads((b.calib_dir / "params.json").read_text()) == params
+
+
+class TestValidityHook:
+    def test_is_record_valid_is_overridable(self, tmp_path):
+        """A model can supply its own validity test (e.g. an AXI stall scan)."""
+        class OnlyEven(StreamTimingModel):
+            def is_record_valid(self, firing, run_dir):
+                return int(firing["index"]) % 2 == 0     # keep even firings only
+
+        m = OnlyEven(component="c", calib_dir=tmp_path)
+        ev = _rtl_events(component="c", n_firings=4, span=100)
+        for i, f in enumerate(ev["firings"]):
+            f["span"] = 100 + i                            # spans 100,101,102,103
+        m.collect_rtl(ev, run_id="n128")
+        m.collect_pysim(_pysim_firings(nwords=128, span=0.0), run_id="n128")
+        # median of even-index spans (100, 102) = 101.
+        assert m.gen_data_frame()["span_rtl"].iloc[0] == pytest.approx(101)
 
 
 class TestReset:
-    def test_reset_wipes_runs_by_default(self, tm):
+    def test_reset_wipes_the_corpus_by_default(self, tm):
         tm.collect_rtl(_rtl_events(), run_id="n128")
-        assert tm.runs_dir.exists()
+        tm.collect_pysim(_pysim_firings(), run_id="n128")
+        tm.gen_data_frame()
         tm.reset()
-        assert not tm.runs_dir.exists()
-
-    def test_reset_params_falls_back_to_seed(self, tmp_path):
-        m = StreamTimingModel(component="c", calib_dir=tmp_path)
-        for nw in (128, 512):
-            m.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
-                          run_id=f"n{nw}")
-            m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw), run_id=f"n{nw}")
-        m.fit()
-        assert m.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(32)
-
-        m.reset(runs=False, params=True)
-        assert not (m.calib_dir / "params.json").exists()
-        assert m.predict({"nwords": 256, "num_trans": 16})[0] == 0.0   # back to the zero seed
+        assert not (tm.calib_dir / "rtl").exists()
+        assert not (tm.calib_dir / "pysim").exists()
+        assert not tm.corpus_path.exists()
 
     def test_reset_default_keeps_params(self, tmp_path):
         m = StreamTimingModel(component="c", calib_dir=tmp_path)
-        for nw in (128, 512):
-            m.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
-                          run_id=f"n{nw}")
-            m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw), run_id=f"n{nw}")
+        _seed_two_sizes(m)
         m.fit()
-        m.reset()                              # runs only
+        m.reset()
         assert (m.calib_dir / "params.json").exists()
+
+    def test_reset_params_falls_back_to_seed(self, tmp_path):
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        _seed_two_sizes(m)
+        m.fit()
+        assert m.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(32)
+        m.reset(corpus=False, params=True)
+        assert not (m.calib_dir / "params.json").exists()
+        assert m.predict({"nwords": 256, "num_trans": 16})[0] == 0.0
 
 
 class TestMultiTargetGuard:
     def test_construction_is_allowed(self, tmp_path):
-        """The API is carried — you can declare num_targets > 1..."""
-        m = StreamTimingModel(component="c", calib_dir=tmp_path, num_targets=3)
-        assert m.num_targets == 3
+        assert StreamTimingModel(component="c", calib_dir=tmp_path, num_targets=3).num_targets == 3
 
     def test_every_operation_raises(self, tmp_path):
-        """...but nothing works until per-stage measurement (Tier-2) exists."""
         m = StreamTimingModel(component="c", calib_dir=tmp_path, num_targets=3)
         with pytest.raises(NotImplementedError, match="per-stage"):
             m.predict({"nwords": 128, "num_trans": 8})
         with pytest.raises(NotImplementedError):
             m.collect_rtl(_rtl_events(), run_id="x")
         with pytest.raises(NotImplementedError):
-            m.fit()
+            m.gen_data_frame()

--- a/tests/calib/test_timing_model.py
+++ b/tests/calib/test_timing_model.py
@@ -1,0 +1,199 @@
+"""tests/calib/test_timing_model.py — the residual-fitting orchestration.
+
+The model machinery (LinCalibModel) is covered in test_calib.py; this file is about the layer
+TimingModel adds: collecting per-run firings, filtering on `blocked`, joining RTL vs pysim into the
+*current-prediction-corrected* residual, and the lifecycle (seed fallback, reset, num_targets guard).
+"""
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from waveflow.calib.timing_model import StreamTimingModel, TimingModel
+
+
+def _rtl_events(component="mem_w_stream_framed_done_task", *, nwords=128, n_firings=16,
+                span=183, blocked=0, max_burst=16):
+    """An ExtractBurstsStep-shaped events dict: n_firings of one component, all identical."""
+    num_trans = math.ceil(nwords / max_burst)
+    return {"version": 1, "top": "mem_copy", "max_burst_len": max_burst,
+            "firings": [{"component": component, "inst": f"{component}_U0", "index": i,
+                         "start": 0, "end": span - 1, "span": span,
+                         "nwords": nwords, "num_trans": num_trans, "blocked": blocked}
+                        for i in range(n_firings)]}
+
+
+def _pysim_firings(*, nwords=128, n=16, span=147, current_dly=0.0, max_burst=16):
+    num_trans = math.ceil(nwords / max_burst)
+    return [{"nwords": nwords, "num_trans": num_trans, "span": span, "current_dly": current_dly}
+            for _ in range(n)]
+
+
+@pytest.fixture
+def tm(tmp_path):
+    return StreamTimingModel(component="mem_w_stream_framed_done_task", calib_dir=tmp_path / "cal")
+
+
+class TestConstruction:
+    def test_stream_defaults_the_basis(self, tmp_path):
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        assert m.features == ["nwords", "num_trans"]
+
+    def test_base_requires_features(self, tmp_path):
+        with pytest.raises(ValueError, match="features"):
+            TimingModel(component="c", calib_dir=tmp_path)
+
+    def test_unfitted_predicts_the_seed(self, tmp_path):
+        """A fresh model with the default (zero) seed adds no delay — a component with a TimingModel
+        but no calibration still simulates."""
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        assert m.predict({"nwords": 128, "num_trans": 8}) == [0.0]
+
+    def test_nonzero_seed_is_used_before_fit(self, tmp_path):
+        m = StreamTimingModel(component="c", calib_dir=tmp_path,
+                              seed={"nwords": 0.0, "num_trans": 2.0, "intercept": 22.0})
+        assert m.predict({"nwords": 128, "num_trans": 8}) == [22.0 + 2.0 * 8]
+
+
+class TestCollectAndFit:
+    def test_residual_subtracts_pysim_and_adds_current_dly(self, tm):
+        """The crux: target = rtl - pysim + current_dly.  With current_dly recorded, the fit is
+        self-correcting from any prior model state."""
+        # RTL 183, pysim 150 measured WHILE the model was already adding 5 -> true residual 38.
+        tm.collect_rtl(_rtl_events(span=183), run_id="n128")
+        tm.collect_pysim(_pysim_firings(span=150, current_dly=5.0), run_id="n128")
+        corpus = tm.build_corpus()
+        assert len(corpus) == 1
+        assert corpus.df[tm._model.target].iloc[0] == pytest.approx(183 - 150 + 5)
+
+    def test_blocked_firings_are_dropped(self, tm):
+        """Only blocked==0 firings are the component's own cost."""
+        ev = _rtl_events(span=183, n_firings=16)
+        for f in ev["firings"][1:]:            # firing 0 clean, rest contended
+            f["blocked"] = 30
+            f["span"] = 213
+        tm.collect_rtl(ev, run_id="n128")
+        tm.collect_pysim(_pysim_firings(span=150), run_id="n128")
+        corpus = tm.build_corpus()
+        # median RTL span over the ONE valid firing = 183, not the contended 213.
+        assert corpus.df[tm._model.target].iloc[0] == pytest.approx(183 - 150 + 0)
+
+    def test_fit_recovers_a_linear_law_across_sizes(self, tmp_path):
+        """Two sizes, residual = 22 + 2*num_trans (nwords contributes 0): the fit must recover it,
+        which a single size could not."""
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        for nw in (128, 512):
+            nt = nw // 16
+            m.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * nt),
+                          run_id=f"n{nw}")
+            m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw, current_dly=0.0),
+                            run_id=f"n{nw}")
+        m.fit()
+        # residual(nw) = 2*num_trans -> predict at an UNSEEN size extrapolates.
+        pred = m.predict({"nwords": 256, "num_trans": 16})[0]
+        assert pred == pytest.approx(2 * 16, abs=1e-6)
+
+    def test_fit_writes_params_json(self, tm):
+        tm.collect_rtl(_rtl_events(), run_id="n128")
+        tm.collect_pysim(_pysim_firings(), run_id="n128")
+        tm.fit()
+        params = json.loads((tm.calib_dir / "params.json").read_text())
+        assert "intercept" in params and set(tm.features) <= set(params)
+
+    def test_fitted_model_reloads_from_params(self, tmp_path):
+        """A deployed model predicts from params.json alone — no corpus, no sklearn refit."""
+        a = StreamTimingModel(component="c", calib_dir=tmp_path)
+        for nw in (128, 512):
+            a.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
+                          run_id=f"n{nw}")
+            a.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw), run_id=f"n{nw}")
+        a.fit()
+        want = a.predict({"nwords": 256, "num_trans": 16})[0]
+
+        b = StreamTimingModel(component="c", calib_dir=tmp_path)   # fresh, only reads params.json
+        assert b.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(want)
+
+    def test_empty_corpus_fit_raises(self, tm):
+        """A fit with nothing joined must fail, not silently leave a seed model looking fitted."""
+        tm.collect_rtl(_rtl_events(), run_id="n128")   # RTL only, no pysim
+        with pytest.raises(RuntimeError, match="no residual datapoints"):
+            tm.fit()
+
+    def test_predict_never_negative(self, tmp_path):
+        """A residual model that extrapolates below zero must clamp — a negative timeout is meaningless."""
+        m = StreamTimingModel(component="c", calib_dir=tmp_path,
+                              seed={"nwords": 0.0, "num_trans": 0.0, "intercept": -5.0})
+        assert m.predict({"nwords": 0, "num_trans": 0}) == [0.0]
+
+
+class TestPerRunStorage:
+    def test_each_run_is_its_own_folder(self, tm):
+        tm.collect_rtl(_rtl_events(), run_id="n128")
+        tm.collect_rtl(_rtl_events(nwords=256, span=327), run_id="n256")
+        assert (tm.runs_dir / "n128" / "rtl_firings.csv").exists()
+        assert (tm.runs_dir / "n256" / "rtl_firings.csv").exists()
+
+    def test_rerunning_a_scenario_overwrites_not_duplicates(self, tm):
+        tm.collect_rtl(_rtl_events(span=183), run_id="n128")
+        tm.collect_rtl(_rtl_events(span=999), run_id="n128")   # same run_id
+        tm.collect_pysim(_pysim_firings(), run_id="n128")
+        corpus = tm.build_corpus()
+        assert corpus.df[tm._model.target].iloc[0] == pytest.approx(999 - 147 + 0)
+
+    def test_fit_globs_all_runs(self, tmp_path):
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        m.collect_rtl(_rtl_events(component="c", nwords=128, span=1128 + 2 * 8), run_id="a")
+        m.collect_pysim(_pysim_firings(nwords=128, span=1128), run_id="a")
+        m.collect_rtl(_rtl_events(component="c", nwords=512, span=1512 + 2 * 32), run_id="b")
+        m.collect_pysim(_pysim_firings(nwords=512, span=1512), run_id="b")
+        assert len(m.build_corpus()) == 2      # both runs joined
+
+
+class TestReset:
+    def test_reset_wipes_runs_by_default(self, tm):
+        tm.collect_rtl(_rtl_events(), run_id="n128")
+        assert tm.runs_dir.exists()
+        tm.reset()
+        assert not tm.runs_dir.exists()
+
+    def test_reset_params_falls_back_to_seed(self, tmp_path):
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        for nw in (128, 512):
+            m.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
+                          run_id=f"n{nw}")
+            m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw), run_id=f"n{nw}")
+        m.fit()
+        assert m.predict({"nwords": 256, "num_trans": 16})[0] == pytest.approx(32)
+
+        m.reset(runs=False, params=True)
+        assert not (m.calib_dir / "params.json").exists()
+        assert m.predict({"nwords": 256, "num_trans": 16})[0] == 0.0   # back to the zero seed
+
+    def test_reset_default_keeps_params(self, tmp_path):
+        m = StreamTimingModel(component="c", calib_dir=tmp_path)
+        for nw in (128, 512):
+            m.collect_rtl(_rtl_events(component="c", nwords=nw, span=1000 + nw + 2 * (nw // 16)),
+                          run_id=f"n{nw}")
+            m.collect_pysim(_pysim_firings(nwords=nw, span=1000 + nw), run_id=f"n{nw}")
+        m.fit()
+        m.reset()                              # runs only
+        assert (m.calib_dir / "params.json").exists()
+
+
+class TestMultiTargetGuard:
+    def test_construction_is_allowed(self, tmp_path):
+        """The API is carried — you can declare num_targets > 1..."""
+        m = StreamTimingModel(component="c", calib_dir=tmp_path, num_targets=3)
+        assert m.num_targets == 3
+
+    def test_every_operation_raises(self, tmp_path):
+        """...but nothing works until per-stage measurement (Tier-2) exists."""
+        m = StreamTimingModel(component="c", calib_dir=tmp_path, num_targets=3)
+        with pytest.raises(NotImplementedError, match="per-stage"):
+            m.predict({"nwords": 128, "num_trans": 8})
+        with pytest.raises(NotImplementedError):
+            m.collect_rtl(_rtl_events(), run_id="x")
+        with pytest.raises(NotImplementedError):
+            m.fit()

--- a/waveflow/calib/__init__.py
+++ b/waveflow/calib/__init__.py
@@ -21,10 +21,13 @@ from .calib import (
     InterpCalibModel,
     LinCalibModel,
 )
+from .timing_model import StreamTimingModel, TimingModel
 
 __all__ = [
     "CalibDataFrame",
     "CalibModel",
     "InterpCalibModel",
     "LinCalibModel",
+    "StreamTimingModel",
+    "TimingModel",
 ]

--- a/waveflow/calib/timing_model.py
+++ b/waveflow/calib/timing_model.py
@@ -6,31 +6,35 @@ layer: it collects a component's per-firing measurements from an RTL trace and f
 **residual** (the delay pysim is missing) with a composed :class:`~waveflow.calib.calib.CalibModel`,
 and exposes a ``predict`` the component's ``run_iter`` calls.
 
-See ``plans/timing_model.md``.  Two properties are load-bearing and easy to get wrong:
+See ``plans/timing_model.md``.  The design in four pieces, each earned the hard way:
 
-* **The target is the residual, corrected for the current prediction.**  The pysim span already
-  includes whatever the model predicted on that run, so the fit target is
-  ``rtl_span - pysim_span + current_dly``.  This makes the fit self-correcting: any run is a valid
-  datapoint (no model-disabled baseline needed), and calibration converges iteratively from a
-  0-seed.
-* **Validity is ``blocked == 0``.**  A firing that stalled on a full downstream channel measured
-  contention, not the component's own cost; those rows are dropped from the fit.  ``ExtractBurstsStep``
-  already computes ``blocked`` from FIFO occupancy.
-
-Everything is kept in **cycles** (the RTL table is in cycles; the component records its pysim spans
-and ``current_dly`` in cycles too), so the fit is clock-independent and ``predict`` returns cycles —
-the caller multiplies by ``clk.period`` for the ``timeout``.
+* **The target is the residual, corrected for the current prediction:**
+  ``residual = rtl_span - pysim_span + current_dly``.  The pysim span already includes whatever the
+  model predicted on that run, so without ``+ current_dly`` the fit would double-count.  With it the
+  fit is self-correcting — any run is a datapoint (no model-disabled baseline), and online
+  calibration converges from a 0-seed.
+* **Validity is per-firing and overridable** (:meth:`is_record_valid`, default ``blocked == 0``).  A
+  firing that stalled on a full downstream channel measured contention, not the component's own cost.
+  A subclass can inspect the run folder (the AXI trace) for a richer stall test.
+* **RTL and pysim are collected independently** into ``rtl/`` and ``pysim/`` trees — different
+  cadence (RTL is Vitis-expensive, pysim is every-edit-cheap).  They are joined at fit time on the
+  **feature point** (``nwords``, ``num_trans``), not the run id.  Feature points present on only one
+  side cannot yield a residual and are reported, not silently dropped.
+* **Everything internal is in CYCLES**, so ``params.json`` is clock-independent (reused unchanged
+  across a re-synth at a different clock).  Conversion is only at the boundary: RTL is natively
+  cycles; pysim is time, so :meth:`collect_pysim` divides by ``clk.period`` and :meth:`predict`
+  multiplies back.  With ``clk=None`` the data is assumed already in cycles (tests, pure analysis).
 """
 from __future__ import annotations
 
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
-import numpy as np
 import pandas as pd
 
-from waveflow.calib.calib import CalibDataFrame, LinCalibModel
+from waveflow.calib.calib import LinCalibModel
 
 #: Fit-target column name (the residual, in cycles).
 RESIDUAL = "residual"
@@ -44,35 +48,33 @@ class TimingModel:
     ----------
     component : str
         The identifier this component's firings carry in the timing table — the task-body ``id``
-        (``"mem_w_stream_framed_done_task"``) or the RTL ``inst``.  :meth:`collect_rtl` filters the
-        table by it.
-    features : list[str]
-        The regression basis, columns present in *both* the RTL table and the pysim firings
-        (``["nwords", "num_trans"]``).  ``predict`` takes a row over these.
+        (``"mem_w_stream_framed_done_task"``) or the RTL ``inst``.  :meth:`collect_rtl` filters by it.
     calib_dir : str | Path
-        The corpus + artifact directory.  Per-run folders under ``runs/``; the fitted params at
-        ``params.json`` (see the module plan for the layout and why per-run beats a shared csv).
+        Corpus + artifact directory: independent ``rtl/<run>/firings.csv`` and
+        ``pysim/<run>/firings.csv`` trees, the fitted ``params.json``, and a derived ``corpus.csv``
+        (the merged frame, a cache).
+    features : list[str]
+        The regression basis, columns present on *both* sides (``["nwords", "num_trans"]``).
     num_targets : int
-        How many delays ``predict`` returns (default 1).  ``> 1`` is the API for injecting a delay
-        *between* internal stages, but needs per-stage measurement (Tier-2 tracing), so every
-        operation raises ``NotImplementedError`` for now.
+        Delays :meth:`predict` returns (default 1).  ``> 1`` is the API for a delay *between*
+        internal stages, but needs per-stage measurement (Tier-2 tracing) — every op raises for now.
     placement : str
-        ``"leading"`` | ``"trailing"`` — where ``run_iter`` injects the delay.  Advisory metadata;
-        it does not change the fit, but records the intent (a writer's residual is a trailing
-        posted-write drain, a reader's is leading control setup).
+        ``"leading"`` | ``"trailing"`` — advisory: where ``run_iter`` injects the delay.
     seed : dict | None
-        Seed params for the model (its ``state_dict``), used by ``predict`` before any fit — so a
-        fresh component still simulates.  ``None`` seeds to zero additional delay.
+        Seed params (the ``state_dict``) used by :meth:`predict` before any fit, so a fresh component
+        still simulates.  ``None`` seeds to zero additional delay.
+    clk : Any
+        Anything with a ``.period``.  When set, :meth:`collect_pysim` converts its time spans to
+        cycles and :meth:`predict` returns time.  ``None`` = data already in cycles.
     """
 
     component: str
     calib_dir: str | Path
-    #: The regression basis.  Required in the base; a subclass (e.g. StreamTimingModel) may default
-    #: it — hence declared with a `None` sentinel so field order allows the override.
     features: list[str] | None = None
     num_targets: int = 1
     placement: str = "trailing"
     seed: dict | None = None
+    clk: Any = None
     _model: LinCalibModel = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -80,22 +82,29 @@ class TimingModel:
             raise ValueError(f"{type(self).__name__} requires `features` (the regression basis)")
         self.calib_dir = Path(self.calib_dir)
         self.features = [str(f) for f in self.features]
-        # A zero seed = "no additional delay" until calibrated: intercept 0, all coeffs 0.
+        #: Populated by :meth:`gen_data_frame`: {"matched", "rtl_only", "pysim_only"} feature points.
+        self.coverage: dict = {}
         seed = self.seed if self.seed is not None else {
             **{f: 0.0 for f in self.features}, "intercept": 0.0}
         self._model = LinCalibModel(
             basis=self.features, target=RESIDUAL, fit_intercept=True,
             coeff_names=self.features, seed=seed, path=self.calib_dir / "params.json")
 
-    # -- paths --------------------------------------------------------------
+    # -- paths & unit conversion -------------------------------------------
     @property
-    def runs_dir(self) -> Path:
-        return self.calib_dir / "runs"
+    def corpus_path(self) -> Path:
+        return self.calib_dir / "corpus.csv"
 
-    def _run_dir(self, run_id: str) -> Path:
-        d = self.runs_dir / str(run_id)
+    def _run_dir(self, side: str, run_id: str) -> Path:
+        d = self.calib_dir / side / str(run_id)
         d.mkdir(parents=True, exist_ok=True)
         return d
+
+    def _to_cycles(self, t: float) -> float:
+        return float(t) if self.clk is None else float(t) / self.clk.period
+
+    def _to_time(self, c: float) -> float:
+        return float(c) if self.clk is None else float(c) * self.clk.period
 
     def _guard_single(self) -> None:
         if self.num_targets != 1:
@@ -104,102 +113,154 @@ class TimingModel:
                 f"measurement (Tier-2 intra-component tracing). The API is carried; the "
                 f"implementation is single-target for now.")
 
-    # -- collection ---------------------------------------------------------
+    # -- validity (per firing; overridable) --------------------------------
+    def is_record_valid(self, firing: dict, run_dir: Path) -> bool:
+        """Is this **RTL** firing a clean measurement of the component's own cost?
+
+        Applied only to the RTL side (a pysim firing is the model being calibrated, not a
+        measurement to validate).  Default: ``blocked == 0`` — the column :class:`ExtractBurstsStep`
+        computes from FIFO occupancy.  Override to inspect *run_dir* (e.g. scan an ``m_axi`` bundle's
+        ``beat_type`` for stalls the FIFO counters do not see); an override may freely assume the RTL
+        firing columns (``index``, ``blocked``, …).
+        """
+        return int(firing.get("blocked", 0) or 0) == 0
+
+    # -- collection (independent rtl / pysim trees) ------------------------
     def collect_rtl(self, events: dict, run_id: str) -> Path:
         """Write this component's firings from an ``ExtractBurstsStep`` *events* dict into
-        ``runs/<run_id>/rtl_firings.csv``.  Keeps ALL firings (``blocked`` included) — the fit
-        filters; the full set is the debug trail.  Overwrites the run folder's file, so re-running
-        the same scenario replaces rather than duplicates."""
+        ``rtl/<run_id>/firings.csv`` (spans already in cycles).  Keeps ALL firings — the fit filters
+        via :meth:`is_record_valid`; the full set is the debug trail."""
         self._guard_single()
         rows = [f for f in events.get("firings", []) if f["component"] == self.component]
-        df = pd.DataFrame(rows)
-        out = self._run_dir(run_id) / "rtl_firings.csv"
-        df.to_csv(out, index=False)
+        out = self._run_dir("rtl", run_id) / "firings.csv"
+        pd.DataFrame(rows).to_csv(out, index=False)
         return out
 
     def collect_pysim(self, firings: list[dict], run_id: str) -> Path:
-        """Write this component's pysim firings into ``runs/<run_id>/pysim_firings.csv``.
+        """Write this component's pysim firings into ``pysim/<run_id>/firings.csv``.
 
-        Each firing is a mapping with the *features*, ``span`` (cycles), and ``current_dly`` (cycles
-        — what :meth:`predict` returned on this run, so the fit can subtract it back out).  The
-        component produces these from its own per-firing instrumentation."""
+        Each firing carries the *features*, ``span``, and ``current_dly`` (what :meth:`predict`
+        returned on this run).  ``span``/``current_dly`` arrive in **time** and are divided by
+        ``clk.period`` to cycles here (unless ``clk is None``), so the stored corpus is all-cycles."""
         self._guard_single()
-        df = pd.DataFrame(firings)
+        conv = []
+        for f in firings:
+            g = {**f, "span": self._to_cycles(f["span"])}
+            if "current_dly" in f:
+                g["current_dly"] = self._to_cycles(f["current_dly"])
+            conv.append(g)
+        df = pd.DataFrame(conv)
         missing = ({"span", "current_dly", *self.features}) - set(df.columns)
         if firings and missing:
-            raise ValueError(f"pysim firing rows are missing {sorted(missing)}; got {list(df.columns)}")
-        out = self._run_dir(run_id) / "pysim_firings.csv"
+            raise ValueError(f"pysim firings missing {sorted(missing)}; got {list(df.columns)}")
+        out = self._run_dir("pysim", run_id) / "firings.csv"
         df.to_csv(out, index=False)
         return out
 
-    # -- fit ----------------------------------------------------------------
-    def _load_all(self, name: str) -> pd.DataFrame:
-        """Concat ``runs/*/<name>`` (the per-run source of truth) into one frame."""
-        frames = [pd.read_csv(p) for p in sorted(self.runs_dir.glob(f"*/{name}")) if p.stat().st_size]
-        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    # -- parsing: one run -> its aggregated point --------------------------
+    def get_params(self, run_dir: Path, validate: bool = True) -> dict | None:
+        """Parse one run folder to a single ``{feature: value, measurement: median}`` row, or
+        ``None`` if it holds no valid firing.
 
-    def build_corpus(self) -> CalibDataFrame:
-        """Join RTL and pysim firings into the residual corpus: one row per feature point.
+        When *validate* (the RTL side), firings are filtered through :meth:`is_record_valid` first;
+        the pysim side passes ``validate=False`` (its firings are the model, not a measurement).
+        Survivors are aggregated (median span over the run's firings).  Features are constant within
+        a run (one run = one scenario), so they pass through as-is.  This is the per-model "how to
+        read a run" hook — a subclass whose run folder holds extra artifacts can override it."""
+        p = Path(run_dir) / "firings.csv"
+        if not p.exists() or p.stat().st_size == 0:
+            return None
+        df = pd.read_csv(p)
+        if df.empty:
+            return None
+        if validate:
+            df = df[[self.is_record_valid(r, Path(run_dir)) for r in df.to_dict("records")]]
+        valid = df
+        if len(valid) == 0:
+            return None
+        row = {f: float(valid[f].iloc[0]) for f in self.features}
+        for c in valid.columns:
+            if c not in self.features and pd.api.types.is_numeric_dtype(valid[c]):
+                row[c] = float(valid[c].median())
+        return row
 
-        RTL firings are filtered to ``blocked == 0`` (a stalled firing measured contention, not the
-        component's cost).  Both sides are aggregated by the *features* (16 jobs at one ``nwords``
-        collapse to one point — the median span), then joined so the target is
-        ``rtl_span - pysim_span + current_dly``."""
+    def _side_frame(self, side: str, value_cols: list[str]) -> pd.DataFrame:
+        """Every run under ``<side>/`` reduced to one row per feature point (median across runs at
+        the same point), keeping only *features* + *value_cols*."""
+        rows = []
+        base = self.calib_dir / side
+        for run_dir in sorted(p for p in base.glob("*") if p.is_dir()):
+            r = self.get_params(run_dir, validate=(side == "rtl"))
+            if r and all(c in r for c in value_cols):
+                rows.append({**{f: r[f] for f in self.features}, **{c: r[c] for c in value_cols}})
+        if not rows:
+            return pd.DataFrame(columns=[*self.features, *value_cols])
+        return pd.DataFrame(rows).groupby(self.features, as_index=False)[value_cols].median()
+
+    # -- assemble: the merged residual frame -------------------------------
+    def gen_data_frame(self) -> pd.DataFrame:
+        """Join the RTL and pysim corpora on the feature point into one inspectable, fittable frame:
+
+        ``features… | span_rtl | span_pysim | current_dly | residual``
+
+        Records coverage on :attr:`coverage` — which feature points matched, and which appear on
+        only one side (they cannot yield a residual, so a thin fit is a *visible* coverage gap, not a
+        silent one).  Caches the frame to ``corpus.csv``."""
         self._guard_single()
-        rtl, py = self._load_all("rtl_firings.csv"), self._load_all("pysim_firings.csv")
-        corpus = CalibDataFrame(columns=[*self.features, RESIDUAL])
+        rtl = self._side_frame("rtl", ["span"])
+        py = self._side_frame("pysim", ["span", "current_dly"])
+
+        def keys(df):
+            return {tuple(v) for v in df[self.features].to_numpy().tolist()}
+
+        kr, kp = keys(rtl), keys(py)
+        self.coverage = {"matched": sorted(kr & kp),
+                         "rtl_only": sorted(kr - kp), "pysim_only": sorted(kp - kr)}
+
+        cols = [*self.features, "span_rtl", "span_pysim", "current_dly", RESIDUAL]
         if rtl.empty or py.empty:
-            return corpus
+            return pd.DataFrame(columns=cols)
 
-        valid = rtl[rtl["blocked"] == 0]
-        rtl_g = valid.groupby(self.features)["span"].median()
-        py_g = py.groupby(self.features)[["span", "current_dly"]].median()
+        merged = rtl.merge(py, on=self.features, how="inner", suffixes=("_rtl", "_pysim"))
+        merged[RESIDUAL] = merged["span_rtl"] - merged["span_pysim"] + merged["current_dly"]
+        out = merged[cols]
+        self.corpus_path.parent.mkdir(parents=True, exist_ok=True)
+        out.to_csv(self.corpus_path, index=False)
+        return out
 
-        for key, rtl_span in rtl_g.items():
-            if key not in py_g.index:
-                continue                        # a feature point pysim never ran — no residual
-            feat = key if isinstance(key, tuple) else (key,)
-            row = {f: float(v) for f, v in zip(self.features, feat)}
-            row[RESIDUAL] = float(rtl_span) - float(py_g.loc[key, "span"]) \
-                + float(py_g.loc[key, "current_dly"])
-            corpus.add_datapoint(row)
-        return corpus
-
+    # -- fit / deploy ------------------------------------------------------
     def fit(self) -> "TimingModel":
-        """Build the corpus and fit the residual model; write ``params.json``.  Raises if the corpus
-        is empty (nothing joined) so a silent no-op fit cannot leave a stale/seed model looking
-        fitted."""
-        self._guard_single()
-        corpus = self.build_corpus()
-        if len(corpus) == 0:
+        """Build the merged frame and fit the residual model; write ``params.json``.  Raises if
+        nothing joined, so a silent no-op cannot leave a seed model looking fitted."""
+        df = self.gen_data_frame()
+        if len(df) == 0:
             raise RuntimeError(
-                f"{self.component}: no residual datapoints — RTL and pysim firings did not join on "
-                f"{self.features} (collect both, and check `blocked == 0` firings exist).")
-        self._model.fit(corpus)
+                f"{self.component}: no residual datapoints — RTL and pysim did not join on "
+                f"{self.features}. Coverage: {self.coverage}")
+        self._model.fit(df)
         self._model.save_model()
         return self
 
-    # -- deploy -------------------------------------------------------------
     def predict(self, row: dict) -> list[float]:
-        """Additional delay(s), in **cycles**, for a firing described by *row* (feature → value).
-
-        Returns a list of length :attr:`num_targets`.  A never-fitted model falls back to the seed
-        (``load_or_default``), so this is safe to call before any calibration — it just predicts the
-        seed delay (0 by default)."""
+        """Additional delay(s), in **time** (``clk`` set) or cycles (``clk=None``), for a firing
+        described by *row*.  Length :attr:`num_targets`.  An unfitted model falls back to the seed,
+        so this is safe before any calibration.  Clamped at 0 — a negative timeout is meaningless."""
         self._guard_single()
         if not self._model._fitted:
             self._model.load_or_default()
-        return [max(0.0, self._model.predict(row))]
+        return [self._to_time(max(0.0, self._model.predict(row)))]
 
-    # -- lifecycle ----------------------------------------------------------
-    def reset(self, runs: bool = True, params: bool = False) -> None:
+    # -- lifecycle ---------------------------------------------------------
+    def reset(self, corpus: bool = True, params: bool = False) -> None:
         """Wipe the corpus and/or the fitted params, to recalibrate from scratch.
 
-        ``runs=True`` (default) clears ``runs/`` — the common "re-sweep from scratch".
-        ``params=True`` deletes ``params.json`` so the next :meth:`predict` falls back to the seed.
-        The default leaves a fitted model deployable until the next :meth:`fit` replaces it."""
-        if runs and self.runs_dir.exists():
-            shutil.rmtree(self.runs_dir)
+        ``corpus=True`` (default) clears the ``rtl/`` and ``pysim/`` trees and ``corpus.csv`` — the
+        common "re-sweep from scratch".  ``params=True`` deletes ``params.json`` so the next
+        :meth:`predict` falls back to the seed."""
+        if corpus:
+            for side in ("rtl", "pysim"):
+                shutil.rmtree(self.calib_dir / side, ignore_errors=True)
+            self.corpus_path.unlink(missing_ok=True)
         if params:
             (self.calib_dir / "params.json").unlink(missing_ok=True)
             self._model._fitted = False
@@ -207,13 +268,9 @@ class TimingModel:
 
 @dataclass
 class StreamTimingModel(TimingModel):
-    """A mem-stream component's residual model: basis ``[nwords, num_trans]``.
-
-    The two features are the ones the RTL law moves on — ``nwords`` (words moved) and ``num_trans``
-    (AXI bursts).  A pure-write component (``MemWStream``) injects the residual *trailing* (the
-    posted-write drain); the default ``placement`` reflects that.  ``num_targets`` stays 1 until a
-    stream component needs a per-stage split.
-    """
+    """A mem-stream component's residual model: basis ``[nwords, num_trans]`` — the counts the RTL
+    law moves on (words moved, AXI bursts).  A pure-write component (``MemWStream``) injects the
+    residual *trailing* (the posted-write drain), which the default ``placement`` reflects."""
 
     def __post_init__(self) -> None:
         if not self.features:

--- a/waveflow/calib/timing_model.py
+++ b/waveflow/calib/timing_model.py
@@ -1,0 +1,221 @@
+"""timing_model.py — per-component timing calibration, orchestration over :mod:`calib`.
+
+:mod:`waveflow.calib.calib` has the *model* machinery (fit / predict / state_dict / seed) but, as its
+own docstring says, "no infrastructure for collecting data".  :class:`TimingModel` is that missing
+layer: it collects a component's per-firing measurements from an RTL trace and from pysim, fits the
+**residual** (the delay pysim is missing) with a composed :class:`~waveflow.calib.calib.CalibModel`,
+and exposes a ``predict`` the component's ``run_iter`` calls.
+
+See ``plans/timing_model.md``.  Two properties are load-bearing and easy to get wrong:
+
+* **The target is the residual, corrected for the current prediction.**  The pysim span already
+  includes whatever the model predicted on that run, so the fit target is
+  ``rtl_span - pysim_span + current_dly``.  This makes the fit self-correcting: any run is a valid
+  datapoint (no model-disabled baseline needed), and calibration converges iteratively from a
+  0-seed.
+* **Validity is ``blocked == 0``.**  A firing that stalled on a full downstream channel measured
+  contention, not the component's own cost; those rows are dropped from the fit.  ``ExtractBurstsStep``
+  already computes ``blocked`` from FIFO occupancy.
+
+Everything is kept in **cycles** (the RTL table is in cycles; the component records its pysim spans
+and ``current_dly`` in cycles too), so the fit is clock-independent and ``predict`` returns cycles —
+the caller multiplies by ``clk.period`` for the ``timeout``.
+"""
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from waveflow.calib.calib import CalibDataFrame, LinCalibModel
+
+#: Fit-target column name (the residual, in cycles).
+RESIDUAL = "residual"
+
+
+@dataclass
+class TimingModel:
+    """A component's timing residual model plus the corpus that fits it.
+
+    Parameters
+    ----------
+    component : str
+        The identifier this component's firings carry in the timing table — the task-body ``id``
+        (``"mem_w_stream_framed_done_task"``) or the RTL ``inst``.  :meth:`collect_rtl` filters the
+        table by it.
+    features : list[str]
+        The regression basis, columns present in *both* the RTL table and the pysim firings
+        (``["nwords", "num_trans"]``).  ``predict`` takes a row over these.
+    calib_dir : str | Path
+        The corpus + artifact directory.  Per-run folders under ``runs/``; the fitted params at
+        ``params.json`` (see the module plan for the layout and why per-run beats a shared csv).
+    num_targets : int
+        How many delays ``predict`` returns (default 1).  ``> 1`` is the API for injecting a delay
+        *between* internal stages, but needs per-stage measurement (Tier-2 tracing), so every
+        operation raises ``NotImplementedError`` for now.
+    placement : str
+        ``"leading"`` | ``"trailing"`` — where ``run_iter`` injects the delay.  Advisory metadata;
+        it does not change the fit, but records the intent (a writer's residual is a trailing
+        posted-write drain, a reader's is leading control setup).
+    seed : dict | None
+        Seed params for the model (its ``state_dict``), used by ``predict`` before any fit — so a
+        fresh component still simulates.  ``None`` seeds to zero additional delay.
+    """
+
+    component: str
+    calib_dir: str | Path
+    #: The regression basis.  Required in the base; a subclass (e.g. StreamTimingModel) may default
+    #: it — hence declared with a `None` sentinel so field order allows the override.
+    features: list[str] | None = None
+    num_targets: int = 1
+    placement: str = "trailing"
+    seed: dict | None = None
+    _model: LinCalibModel = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.features:
+            raise ValueError(f"{type(self).__name__} requires `features` (the regression basis)")
+        self.calib_dir = Path(self.calib_dir)
+        self.features = [str(f) for f in self.features]
+        # A zero seed = "no additional delay" until calibrated: intercept 0, all coeffs 0.
+        seed = self.seed if self.seed is not None else {
+            **{f: 0.0 for f in self.features}, "intercept": 0.0}
+        self._model = LinCalibModel(
+            basis=self.features, target=RESIDUAL, fit_intercept=True,
+            coeff_names=self.features, seed=seed, path=self.calib_dir / "params.json")
+
+    # -- paths --------------------------------------------------------------
+    @property
+    def runs_dir(self) -> Path:
+        return self.calib_dir / "runs"
+
+    def _run_dir(self, run_id: str) -> Path:
+        d = self.runs_dir / str(run_id)
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def _guard_single(self) -> None:
+        if self.num_targets != 1:
+            raise NotImplementedError(
+                f"num_targets={self.num_targets}: multi-target calibration needs per-stage "
+                f"measurement (Tier-2 intra-component tracing). The API is carried; the "
+                f"implementation is single-target for now.")
+
+    # -- collection ---------------------------------------------------------
+    def collect_rtl(self, events: dict, run_id: str) -> Path:
+        """Write this component's firings from an ``ExtractBurstsStep`` *events* dict into
+        ``runs/<run_id>/rtl_firings.csv``.  Keeps ALL firings (``blocked`` included) — the fit
+        filters; the full set is the debug trail.  Overwrites the run folder's file, so re-running
+        the same scenario replaces rather than duplicates."""
+        self._guard_single()
+        rows = [f for f in events.get("firings", []) if f["component"] == self.component]
+        df = pd.DataFrame(rows)
+        out = self._run_dir(run_id) / "rtl_firings.csv"
+        df.to_csv(out, index=False)
+        return out
+
+    def collect_pysim(self, firings: list[dict], run_id: str) -> Path:
+        """Write this component's pysim firings into ``runs/<run_id>/pysim_firings.csv``.
+
+        Each firing is a mapping with the *features*, ``span`` (cycles), and ``current_dly`` (cycles
+        — what :meth:`predict` returned on this run, so the fit can subtract it back out).  The
+        component produces these from its own per-firing instrumentation."""
+        self._guard_single()
+        df = pd.DataFrame(firings)
+        missing = ({"span", "current_dly", *self.features}) - set(df.columns)
+        if firings and missing:
+            raise ValueError(f"pysim firing rows are missing {sorted(missing)}; got {list(df.columns)}")
+        out = self._run_dir(run_id) / "pysim_firings.csv"
+        df.to_csv(out, index=False)
+        return out
+
+    # -- fit ----------------------------------------------------------------
+    def _load_all(self, name: str) -> pd.DataFrame:
+        """Concat ``runs/*/<name>`` (the per-run source of truth) into one frame."""
+        frames = [pd.read_csv(p) for p in sorted(self.runs_dir.glob(f"*/{name}")) if p.stat().st_size]
+        return pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+    def build_corpus(self) -> CalibDataFrame:
+        """Join RTL and pysim firings into the residual corpus: one row per feature point.
+
+        RTL firings are filtered to ``blocked == 0`` (a stalled firing measured contention, not the
+        component's cost).  Both sides are aggregated by the *features* (16 jobs at one ``nwords``
+        collapse to one point — the median span), then joined so the target is
+        ``rtl_span - pysim_span + current_dly``."""
+        self._guard_single()
+        rtl, py = self._load_all("rtl_firings.csv"), self._load_all("pysim_firings.csv")
+        corpus = CalibDataFrame(columns=[*self.features, RESIDUAL])
+        if rtl.empty or py.empty:
+            return corpus
+
+        valid = rtl[rtl["blocked"] == 0]
+        rtl_g = valid.groupby(self.features)["span"].median()
+        py_g = py.groupby(self.features)[["span", "current_dly"]].median()
+
+        for key, rtl_span in rtl_g.items():
+            if key not in py_g.index:
+                continue                        # a feature point pysim never ran — no residual
+            feat = key if isinstance(key, tuple) else (key,)
+            row = {f: float(v) for f, v in zip(self.features, feat)}
+            row[RESIDUAL] = float(rtl_span) - float(py_g.loc[key, "span"]) \
+                + float(py_g.loc[key, "current_dly"])
+            corpus.add_datapoint(row)
+        return corpus
+
+    def fit(self) -> "TimingModel":
+        """Build the corpus and fit the residual model; write ``params.json``.  Raises if the corpus
+        is empty (nothing joined) so a silent no-op fit cannot leave a stale/seed model looking
+        fitted."""
+        self._guard_single()
+        corpus = self.build_corpus()
+        if len(corpus) == 0:
+            raise RuntimeError(
+                f"{self.component}: no residual datapoints — RTL and pysim firings did not join on "
+                f"{self.features} (collect both, and check `blocked == 0` firings exist).")
+        self._model.fit(corpus)
+        self._model.save_model()
+        return self
+
+    # -- deploy -------------------------------------------------------------
+    def predict(self, row: dict) -> list[float]:
+        """Additional delay(s), in **cycles**, for a firing described by *row* (feature → value).
+
+        Returns a list of length :attr:`num_targets`.  A never-fitted model falls back to the seed
+        (``load_or_default``), so this is safe to call before any calibration — it just predicts the
+        seed delay (0 by default)."""
+        self._guard_single()
+        if not self._model._fitted:
+            self._model.load_or_default()
+        return [max(0.0, self._model.predict(row))]
+
+    # -- lifecycle ----------------------------------------------------------
+    def reset(self, runs: bool = True, params: bool = False) -> None:
+        """Wipe the corpus and/or the fitted params, to recalibrate from scratch.
+
+        ``runs=True`` (default) clears ``runs/`` — the common "re-sweep from scratch".
+        ``params=True`` deletes ``params.json`` so the next :meth:`predict` falls back to the seed.
+        The default leaves a fitted model deployable until the next :meth:`fit` replaces it."""
+        if runs and self.runs_dir.exists():
+            shutil.rmtree(self.runs_dir)
+        if params:
+            (self.calib_dir / "params.json").unlink(missing_ok=True)
+            self._model._fitted = False
+
+
+@dataclass
+class StreamTimingModel(TimingModel):
+    """A mem-stream component's residual model: basis ``[nwords, num_trans]``.
+
+    The two features are the ones the RTL law moves on — ``nwords`` (words moved) and ``num_trans``
+    (AXI bursts).  A pure-write component (``MemWStream``) injects the residual *trailing* (the
+    posted-write drain); the default ``placement`` reflects that.  ``num_targets`` stays 1 until a
+    stream component needs a per-stage split.
+    """
+
+    def __post_init__(self) -> None:
+        if not self.features:
+            self.features = ["nwords", "num_trans"]
+        super().__post_init__()


### PR DESCRIPTION
The **fitting** half of the timing-calibration arc (the measurement half shipped in #111/#112). `TimingModel` is the layer `waveflow.calib` deliberately lacked — its own docstring says "no infrastructure for collecting data" — composed over `CalibModel`/`LinCalibModel`, not a replacement.

Self-contained: touches nothing outside `waveflow/calib/`. The component + DAG wiring is the next arc.

## What it does

```python
tm = StreamTimingModel(component="mem_w_stream_framed_done_task", calib_dir=..., clk=self.clk)
tm.collect_rtl(events, run_id)      # this component's firings from ExtractBurstsStep
tm.collect_pysim(firings, run_id)   # its pysim spans + the current_dly it predicted
tm.fit()                            # join -> residual -> LinCalibModel -> params.json
dly = tm.predict({"nwords": n, "num_trans": ceil(n/16)})   # additional delay (time)
```

## Four load-bearing properties, all tested

- **Self-correcting residual** — target is `rtl_span - pysim_span + current_dly`. The pysim span already includes whatever the model added on that run, so `+ current_dly` prevents double-counting. Tested end-to-end: the fit lands on truth in round 1 and *stays* there in round 2 when pysim's span has grown by the added delay. Online calibration converges from a 0-seed; no model-disabled baseline needed.
- **Independent rtl/pysim cadence** — separate trees, joined on the *feature point* (not run id), because RTL is Vitis-expensive and pysim is every-edit-cheap. Unmatched points are reported on `.coverage`, not silently dropped.
- **Per-firing validity hook** — `is_record_valid` (RTL side, default `blocked == 0`, overridable for an AXI-stall scan). A stalled firing measured contention, not the component's own cost.
- **Cycles internal, convert at the boundary** — `params.json` is clock-independent; a re-synth at a different clock reuses the same fitted law. Tested with two clocks driving one param set.

Plus: the three-layer read (`is_record_valid` ⊂ `get_params` ⊂ `gen_data_frame`) producing a merged, inspectable `corpus.csv`; `num_targets` carried as API but gated at 1 (multi-stage needs Tier-2 tracing); `reset(corpus/params)` lifecycle.

## Verification

- 25 new tests + 24 existing calib tests, all green.
- No change outside `waveflow/calib/` and its tests, plus the design in `plans/timing_model.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)