### PR TITLE
calib: wire TimingModel into FreeRunComp, MemWStream, and the DAG

### DIFF
--- a/examples/mem_copy/mem_copy.py
+++ b/examples/mem_copy/mem_copy.py
@@ -206,6 +206,9 @@ class MemCopy(FreeRunComp):
 
     mem_dwidth: HwParam[int] = 64
     clk: Clock = field(default_factory=lambda: Clock(freq=100e6))
+    #: When set, the writer sub-component attaches a timing model at this directory (the writer is
+    #: the bottleneck the calibration targets).  ``None`` (default) leaves the composite uncalibrated.
+    calib_dir: "str | None" = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -219,7 +222,7 @@ class MemCopy(FreeRunComp):
                                   clk=self.clk)
         self.wstream = MemWStream(
             name=f"{self.name}_w", sim=self.sim, mem_dwidth=w, emit_done=True, inband=True,
-            clk=self.clk)
+            clk=self.clk, calib_dir=self.calib_dir)
         for c in (self.seq, self.rstream, self.wstream):
             self.add_comp(c)
 

--- a/examples/mem_copy/mem_copy_sim.py
+++ b/examples/mem_copy/mem_copy_sim.py
@@ -63,6 +63,9 @@ class MemCopyTB(FreeRunComp):
     #: tail is a testbench constant, not the design's latency -- see the cycles note in the checker).
     n_cycles: int = 3400
     clk: Clock = field(default_factory=lambda: Clock(freq=100e6))
+    #: Forwarded to the DUT's writer: when set, the pysim run records per-firing timing (and applies
+    #: any fitted delay).  ``None`` (default) is the plain, uncalibrated run.
+    calib_dir: "str | None" = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -86,7 +89,8 @@ class MemCopyTB(FreeRunComp):
         self.mem.load_segs = [MemSeg(0, 0, "vectors/mem_in")]
         self.mem.dump_segs = [MemSeg(0, int(self.mem.nwords_tot), "vectors/out")]
 
-        self.dut = MemCopy(name=f"{self.name}_copier", sim=self.sim, mem_dwidth=w)
+        self.dut = MemCopy(name=f"{self.name}_copier", sim=self.sim, mem_dwidth=w,
+                           calib_dir=self.calib_dir)
         # The testbench owns the schema: it serializes each command into raw stream words.  Those words
         # are the ONE source -- write_scenario materializes them to <root>/vectors/s_cmd, the driver
         # loads that bundle in pre_sim (pysim) exactly as the XSI AxisMaster loads in_bundle, and the
@@ -142,8 +146,9 @@ class MemCopySim:
     """
 
     def __init__(self, jobs=(CopyJob(src_off=16, dst_off=512, n_words=128),),
-                 mem_dwidth: int = 64, name: str = "tb") -> None:
-        self.tb = MemCopyTB(name=name, sim=Simulation(), jobs=tuple(jobs), mem_dwidth=mem_dwidth)
+                 mem_dwidth: int = 64, name: str = "tb", calib_dir: "str | None" = None) -> None:
+        self.tb = MemCopyTB(name=name, sim=Simulation(), jobs=tuple(jobs), mem_dwidth=mem_dwidth,
+                            calib_dir=calib_dir)
         #: The per-job source patterns, filled by :meth:`write_scenario` and read back by :meth:`check`.
         self.expected: list[np.ndarray] = []
 

--- a/tests/build/test_calib_steps.py
+++ b/tests/build/test_calib_steps.py
@@ -1,0 +1,130 @@
+"""tests/build/test_calib_steps.py — the collect + fit DAG steps.
+
+The TimingModel engine and the FreeRunComp instrumentation are unit-tested elsewhere; this checks the
+two build steps wire them: CollectTimingStep walks the design's attached models and appends a run's
+rtl+pysim firings; FitTimingStep fits each from the accumulated corpus (skipping, not failing, the
+ones that do not yet join).  A synthetic single-leaf design stands in for a real example.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from waveflow.build.build import BuildConfig
+from waveflow.build.calib_steps import CollectTimingStep, FitTimingStep
+from waveflow.calib.timing_model import StreamTimingModel
+from waveflow.hw.hw_freerun import FreeRunComp
+from waveflow.simulation.simulation import Simulation
+
+
+@dataclass
+class _Leaf(FreeRunComp):
+    """A leaf whose one firing takes `base + nwords` time, so its pysim span tracks the feature."""
+    nwords: int = 128
+    base: float = 1000.0
+    _count: int = field(default=0)
+
+    def run_iter(self):
+        if self._count >= 1:
+            yield self.timeout(10_000)
+            return
+        self._count += 1
+        yield self.timeout(self.base + self.nwords)
+        yield self.timeout(self.timed_delay(
+            {"nwords": self.nwords, "num_trans": math.ceil(self.nwords / 16)}))
+
+
+def _run_leaf(calib_dir, nwords):
+    """Build a calibrated leaf and run one firing in pysim (populating firing_records)."""
+    sim = Simulation()
+    comp = _Leaf(name="c", sim=sim, nwords=nwords)
+    comp.add_timing_model(StreamTimingModel(component="c", calib_dir=calib_dir))
+    sim.env.process(comp._run_iter_forever())
+    sim.env.run(until=nwords + 2000)
+    return comp
+
+
+def _events(nwords, span):
+    """A synthetic ExtractBurstsStep events dict for component 'c' at one size."""
+    return {"top": "t", "max_burst_len": 16,
+            "firings": [{"component": "c", "index": 0, "nwords": nwords,
+                         "num_trans": math.ceil(nwords / 16), "span": span, "blocked": 0}]}
+
+
+def _write_events(tmp_path, nwords, span):
+    p = tmp_path / f"events_{nwords}.json"
+    p.write_text(json.dumps(_events(nwords, span)))
+    return p
+
+
+class TestCollect:
+    def test_collect_appends_both_sides(self, tmp_path):
+        calib = tmp_path / "cal"
+        step = CollectTimingStep(name="collect", run_id="n128",
+                                 run_pysim=lambda: _run_leaf(calib, 128))
+        ev = _write_events(tmp_path, 128, span=1183)
+        out = step.run(BuildConfig(root_dir=str(tmp_path)), timing_events=ev)
+
+        assert (calib / "rtl" / "n128" / "firings.csv").exists()
+        assert (calib / "pysim" / "n128" / "firings.csv").exists()
+        assert out["timing_collected"].exists()
+        report = json.loads(out["timing_collected"].read_text())
+        assert report["models"][0] == {"component": "c", "pysim_firings": 1}
+
+    def test_no_models_is_an_error(self, tmp_path):
+        """A design built without calib_dir has no models — the step should say so, not no-op."""
+        def bare():
+            sim = Simulation()
+            return _Leaf(name="c", sim=sim)     # no add_timing_model
+
+        step = CollectTimingStep(name="collect", run_id="x", run_pysim=bare)
+        ev = _write_events(tmp_path, 128, 1183)
+        with pytest.raises(RuntimeError, match="no attached TimingModel"):
+            step.run(BuildConfig(root_dir=str(tmp_path)), timing_events=ev)
+
+
+class TestFit:
+    def test_fit_after_two_points_writes_params(self, tmp_path):
+        calib = tmp_path / "cal"
+        # Two sweep points; RTL span = pysim span + (10 + 2*num_trans) residual.
+        for nw in (128, 512):
+            nt = math.ceil(nw / 16)
+            CollectTimingStep(name="c", run_id=f"n{nw}",
+                              run_pysim=lambda nw=nw: _run_leaf(calib, nw)).run(
+                BuildConfig(root_dir=str(tmp_path)),
+                timing_events=_write_events(tmp_path, nw, span=(1000 + nw) + 10 + 2 * nt))
+
+        fit = FitTimingStep(name="fit",
+                            build_design=lambda: _run_leaf(calib, 128),
+                            output_path="results/fit.json")
+        out = fit.run(BuildConfig(root_dir=str(tmp_path)))
+
+        assert (calib / "params.json").exists()
+        report = json.loads(out["timing_fit"].read_text())
+        assert report["skipped"] == []
+        assert report["fitted"][0]["component"] == "c"
+        assert report["fitted"][0]["points"] == 2
+
+    def test_a_model_that_cannot_join_is_skipped_not_fatal(self, tmp_path):
+        """Only RTL collected (no pysim overlap) -> fit has no residual; skip with a report."""
+        calib = tmp_path / "cal"
+        tm = StreamTimingModel(component="c", calib_dir=calib)
+        tm.collect_rtl(_events(128, 1183), run_id="n128")   # rtl only
+
+        fit = FitTimingStep(name="fit", build_design=lambda: _leaf_with(calib))
+        out = fit.run(BuildConfig(root_dir=str(tmp_path)))
+        report = json.loads(out["timing_fit"].read_text())
+        assert report["fitted"] == []
+        assert report["skipped"][0]["component"] == "c"
+        assert not (calib / "params.json").exists()
+
+
+def _leaf_with(calib_dir):
+    """A built (un-run) leaf carrying a model at *calib_dir* — enough for FitTimingStep to discover."""
+    comp = _Leaf(name="c", sim=Simulation())
+    comp.add_timing_model(StreamTimingModel(component="c", calib_dir=calib_dir))
+    return comp

--- a/tests/examples/test_mem_copy_timing.py
+++ b/tests/examples/test_mem_copy_timing.py
@@ -1,0 +1,78 @@
+"""tests/examples/test_mem_copy_timing.py — the writer records per-firing timing in a real pysim run.
+
+The FreeRunComp mechanism and the TimingModel engine are unit-tested elsewhere; this is the
+integration: MemCopy(calib_dir=...) attaches a StreamTimingModel to its writer, and a full
+MemCopySim run populates firing_records with one row per job, shaped for collect_pysim.  With no
+fitted params the delay is 0, so correctness and timing are unchanged — attaching a model only
+*observes* until it is calibrated.
+"""
+from __future__ import annotations
+
+import pytest
+
+from examples.mem_copy.mem_copy import CopyJob
+from examples.mem_copy.mem_copy_sim import MemCopySim
+
+
+def test_uncalibrated_run_is_unchanged_and_records_nothing():
+    """Default (no calib_dir): the writer has no model, no firing_records — the plain path."""
+    sim = MemCopySim(jobs=(CopyJob(16, 512, 128),))
+    dut = sim.run()
+    assert dut.wstream.timing_model is None
+    assert not hasattr(dut.wstream, "firing_records")
+
+
+def test_calibrated_run_records_one_firing_per_job(tmp_path):
+    jobs = (CopyJob(16, 4096, 128), CopyJob(200, 4300, 64), CopyJob(400, 4500, 128))
+    sim = MemCopySim(jobs=jobs, calib_dir=str(tmp_path))
+    dut = sim.run()
+
+    recs = dut.wstream.firing_records
+    assert len(recs) == len(jobs)
+    # features track each job's word count; num_trans = ceil(nwords/16).
+    assert [r["nwords"] for r in recs] == [128, 64, 128]
+    assert [r["num_trans"] for r in recs] == [8, 4, 8]
+    for r in recs:
+        assert r["current_dly"] == 0.0            # unfitted seed -> no delay
+        assert r["span"] > 0                       # a real firing span (seconds)
+        assert {"nwords", "num_trans", "current_dly", "span"} <= set(r)
+
+
+def _same_size_jobs(n, nwords=128):
+    """n jobs of one size at DISTINCT, non-overlapping src+dst regions (a shared src or dst would
+    let jobs clobber each other's patterns; stride 200 > 128 words keeps them apart)."""
+    return tuple(CopyJob(16 + j * 200, 4096 + j * 200, nwords) for j in range(n))
+
+
+def test_records_round_trip_through_collect_pysim(tmp_path):
+    """firing_records is exactly what TimingModel.collect_pysim consumes."""
+    sim = MemCopySim(jobs=_same_size_jobs(4), calib_dir=str(tmp_path))
+    dut = sim.run()
+    tm = dut.wstream.timing_model
+
+    tm.collect_pysim(dut.wstream.firing_records, run_id="n128")
+    pt = tm.get_params(tm.calib_dir / "pysim" / "n128", validate=False)
+    assert pt["nwords"] == 128 and pt["num_trans"] == 8
+    assert pt["span"] > 0 and pt["current_dly"] == 0.0
+
+
+def test_a_fitted_model_injects_its_predicted_delay(tmp_path):
+    """With fitted params the writer applies the delay per firing — the `timeout` in `run_iter`.
+
+    Seed a constant 20-cycle residual and confirm every firing records (and the sim applies) that
+    delay as time.  This is the mechanism that will close the 140->183 gap once the params come from
+    a real fit.
+
+    Note what is NOT asserted: that the *period* grows by 20 cycles.  It need not — a trailing delay
+    on a stage that is not (yet) the bottleneck is absorbed into reduced idle-wait rather than added
+    to the period.  That the period responds through the pipeline dynamics, not by mechanical
+    addition, is the emergent-contention property the whole calibration rests on; validating the
+    period is the job of the real RTL-vs-pysim closing-the-loop check, not this unit test."""
+    sim = MemCopySim(jobs=_same_size_jobs(3), calib_dir=str(tmp_path))
+    sim.tb.dut.wstream.timing_model._model.load_params(
+        {"nwords": 0.0, "num_trans": 0.0, "intercept": 20.0})
+    dut = sim.run()
+
+    period = 1.0 / 100e6
+    recs = dut.wstream.firing_records
+    assert recs and all(r["current_dly"] == pytest.approx(20 * period) for r in recs)

--- a/tests/hw/test_freerun_timing.py
+++ b/tests/hw/test_freerun_timing.py
@@ -1,0 +1,118 @@
+"""tests/hw/test_freerun_timing.py — FreeRunComp's opt-in per-firing timing record.
+
+Attaching a TimingModel turns on recording: the base loop times each firing and keeps a row of
+{features, current_dly, span} whenever the body called `timed_delay`.  A component with no model
+takes the plain path and pays nothing.  See plans/timing_model.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from waveflow.calib.timing_model import StreamTimingModel
+from waveflow.hw.hw_freerun import FreeRunComp, discover_timing_models
+from waveflow.simulation.simulation import Simulation
+
+
+@dataclass
+class _Leaf(FreeRunComp):
+    """A minimal leaf: each firing does `base` units of work, then a model-predicted delay."""
+    n_firings: int = 3
+    base: float = 10.0
+    _count: int = field(default=0)
+
+    def run_iter(self):
+        if self._count >= self.n_firings:
+            yield self.timeout(10_000)          # idle; the `until` bound cuts this off
+            return
+        self._count += 1
+        yield self.timeout(self.base)           # the "work"
+        yield self.timeout(self.timed_delay({"nwords": 128, "num_trans": 8}))
+
+
+def _run(comp, sim, until):
+    sim.env.process(comp._run_iter_forever())
+    sim.env.run(until=until)
+
+
+class TestRecording:
+    def test_firings_are_recorded_with_span_features_and_dly(self, tmp_path):
+        sim = Simulation()
+        comp = _Leaf(name="c", sim=sim, n_firings=3, base=10.0)
+        # clk=None -> predict returns cycles; seed gives a constant 5-cycle delay.
+        tm = StreamTimingModel(component="c", calib_dir=tmp_path,
+                               seed={"nwords": 0.0, "num_trans": 0.0, "intercept": 5.0})
+        comp.add_timing_model(tm)
+
+        _run(comp, sim, until=100)
+
+        assert len(comp.firing_records) == 3
+        for r in comp.firing_records:
+            assert r["span"] == pytest.approx(15.0)      # 10 work + 5 delay
+            assert r["current_dly"] == pytest.approx(5.0)
+            assert r["nwords"] == 128 and r["num_trans"] == 8
+
+    def test_records_feed_collect_pysim(self, tmp_path):
+        """The whole point: firing_records is exactly what collect_pysim consumes."""
+        sim = Simulation()
+        comp = _Leaf(name="c", sim=sim, n_firings=4, base=8.0)
+        tm = StreamTimingModel(component="c", calib_dir=tmp_path,
+                               seed={"nwords": 0.0, "num_trans": 0.0, "intercept": 0.0})
+        comp.add_timing_model(tm)
+        _run(comp, sim, until=100)
+
+        tm.collect_pysim(comp.firing_records, run_id="n128")
+        pt = tm.get_params(tm.calib_dir / "pysim" / "n128", validate=False)
+        assert pt["span"] == pytest.approx(8.0)          # median firing span
+        assert pt["current_dly"] == pytest.approx(0.0)
+
+
+class TestNoModel:
+    def test_uncalibrated_component_takes_the_plain_path(self):
+        """No model attached: no firing_records, no error — the loop is unchanged."""
+        sim = Simulation()
+        comp = _Leaf(name="c", sim=sim, n_firings=2, base=5.0)
+        assert comp.timing_model is None
+        _run(comp, sim, until=30)
+        assert not hasattr(comp, "firing_records")
+
+    def test_timed_delay_is_a_noop_without_a_model(self):
+        sim = Simulation()
+        comp = _Leaf(name="c", sim=sim)
+        assert comp.timed_delay({"nwords": 128, "num_trans": 8}) == 0.0
+
+
+class TestDiscovery:
+    def test_finds_models_across_the_tree(self):
+        @dataclass
+        class Child(FreeRunComp):
+            def run_iter(self):
+                yield self.timeout(1)
+
+        @dataclass
+        class Parent(FreeRunComp):
+            def __post_init__(self):
+                super().__post_init__()
+                self.add_comp(Child(name=f"{self.name}_kid", sim=self.sim))
+
+        sim = Simulation()
+        parent = Parent(name="p", sim=sim)
+        child = parent.sub_comps["p_kid"]
+
+        class _FakeTM:
+            pass
+
+        tm = _FakeTM()
+        child.add_timing_model(tm)
+
+        found = discover_timing_models(parent)
+        assert found == [(child, tm)]
+
+    def test_empty_when_none_attached(self):
+        @dataclass
+        class Leaf(FreeRunComp):
+            def run_iter(self):
+                yield self.timeout(1)
+
+        assert discover_timing_models(Leaf(name="c", sim=Simulation())) == []

--- a/waveflow/build/calib_steps.py
+++ b/waveflow/build/calib_steps.py
@@ -1,0 +1,141 @@
+"""calib_steps.py — the DAG steps that drive timing calibration.
+
+Extends the timing rung (``ExtractBurstsStep`` → this) with the collect-and-fit half from
+``plans/timing_model.md``:
+
+    ExtractBurstsStep -> CollectTimingStep -> FitTimingStep
+                         (per registered TM:   (per registered TM:
+                          collect_rtl +         gen_data_frame join,
+                          collect_pysim)        fit, save params.json)
+
+Both are driven by a **design factory** — a callable returning the built (and, for collect,
+pysim-run) component tree.  The step is generic: it walks
+:func:`~waveflow.hw.hw_freerun.discover_timing_models` for every attached model and never mentions a
+particular design.  The example supplies the factory (how to build and run *its* pysim), exactly as
+:class:`~waveflow.build.trace_steps.RtlSimStep` takes a ``prepare`` hook.
+
+These are most useful across a **sweep** — one point cannot fit a slope — which needs the testbench's
+baked run-bound + arena parameterized first (the prerequisite in ``plans/memcpy_timing_calibration.md``).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, ClassVar
+
+from waveflow.build.build import BuildConfig, BuildStep
+from waveflow.hw.hw_freerun import discover_timing_models
+
+
+@dataclass(kw_only=True)
+class CollectTimingStep(BuildStep):
+    """Append one run's RTL + pysim measurements to every attached model's corpus.
+
+    For each ``(component, model)`` on the design, calls ``model.collect_rtl(events, run_id)`` and
+    ``model.collect_pysim(component.firing_records, run_id)``.  The RTL side is the
+    :class:`~waveflow.build.trace_steps.ExtractBurstsStep` table; the pysim side is the
+    ``firing_records`` a calibrated pysim run populated (see
+    :meth:`~waveflow.hw.hw_freerun.FreeRunComp.timed_delay`).
+
+    Construction parameters
+    -----------------------
+    run_pysim : callable
+        Returns a built component tree whose pysim has been RUN — so ``firing_records`` are populated
+        and the models are attached.  The design must carry ``calib_dir`` on its calibrated
+        components (that is what attaches the models).
+    run_id : str
+        Scenario key for this run's folders (e.g. ``"n128"``).  A re-run of the same scenario
+        overwrites, so a sweep uses one ``run_id`` per point.
+    events_artifact : str
+        Upstream artifact naming the ``ExtractBurstsStep`` timing JSON.
+    """
+
+    description: str = "Collect a run's RTL + pysim firings into each timing model's corpus."
+    params: ClassVar[dict] = {}
+
+    run_pysim: Callable[[], Any]
+    run_id: str
+    events_artifact: str = "timing_events"
+
+    @property
+    def consumes(self) -> list:  # type: ignore[override]
+        return [self.events_artifact]
+
+    @property
+    def produces(self) -> dict:  # type: ignore[override]
+        # A sentinel marking the collection done for this run_id; the real outputs are the per-model
+        # corpus folders (declared by the models, not this step).
+        return {"timing_collected": Path("results") / f"collected_{self.run_id}.json"}
+
+    def run(self, config: BuildConfig, **artifacts) -> dict[str, Any]:
+        events = json.loads(Path(artifacts[self.events_artifact]).read_text(encoding="utf-8"))
+        design = self.run_pysim()
+        found = discover_timing_models(design)
+        if not found:
+            raise RuntimeError(
+                "CollectTimingStep: the design has no attached TimingModel — did the factory build "
+                "it with `calib_dir` set on the components to calibrate?")
+
+        report = []
+        for comp, tm in found:
+            tm.collect_rtl(events, self.run_id)
+            tm.collect_pysim(getattr(comp, "firing_records", []), self.run_id)
+            report.append({"component": tm.component,
+                           "pysim_firings": len(getattr(comp, "firing_records", []))})
+
+        root = Path(config.root_dir) if config.root_dir is not None else Path.cwd()
+        out = root / "results" / f"collected_{self.run_id}.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"run_id": self.run_id, "models": report}, indent=2) + "\n",
+                       encoding="utf-8")
+        return {"timing_collected": out}
+
+
+@dataclass(kw_only=True)
+class FitTimingStep(BuildStep):
+    """Fit every attached model from its accumulated corpus, writing each ``params.json``.
+
+    A model whose corpus does not yet join (RTL and pysim never overlapped on a feature point) is
+    **skipped with a report**, not fatal — a sweep in progress has partial coverage, and forcing a
+    fit there would only raise.  The skipped models keep predicting from their seed.
+
+    Construction parameters
+    -----------------------
+    build_design : callable
+        Returns a built component tree (no pysim run needed — ``fit`` reads the on-disk corpus).  Its
+        attached models carry the ``calib_dir`` the corpus lives in.
+    """
+
+    description: str = "Fit each timing model from its corpus; write params.json."
+    params: ClassVar[dict] = {}
+
+    build_design: Callable[[], Any]
+    output_path: str = "results/timing_fit.json"
+
+    @property
+    def consumes(self) -> list:  # type: ignore[override]
+        return []
+
+    @property
+    def produces(self) -> dict:  # type: ignore[override]
+        return {"timing_fit": Path(self.output_path)}
+
+    def run(self, config: BuildConfig, **artifacts) -> dict[str, Any]:
+        found = discover_timing_models(self.build_design())
+        fitted, skipped = [], []
+        for _comp, tm in found:
+            try:
+                tm.fit()
+                fitted.append({"component": tm.component,
+                               "points": len(tm.coverage.get("matched", []))})
+            except RuntimeError as exc:
+                skipped.append({"component": tm.component, "reason": str(exc),
+                                "coverage": tm.coverage})
+
+        root = Path(config.root_dir) if config.root_dir is not None else Path.cwd()
+        out = root / self.output_path
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"fitted": fitted, "skipped": skipped}, indent=2) + "\n",
+                       encoding="utf-8")
+        return {"timing_fit": out}

--- a/waveflow/hw/hw_freerun.py
+++ b/waveflow/hw/hw_freerun.py
@@ -161,6 +161,41 @@ class FreeRunComp(HwComponent):
     def internal_edges(self, value) -> None:
         self.__dict__['_internal_edges'] = value
 
+    # -- timing calibration (opt-in) -----------------------------------------------------------------
+    #
+    # A leaf that wants its pysim timing calibrated against RTL attaches a TimingModel with
+    # :meth:`add_timing_model`.  Its presence turns on per-firing recording: the base loop times each
+    # firing (first input -> end of run_iter) and, when the body called :meth:`timed_delay`, keeps a
+    # row of {features, current_dly, span} on :attr:`firing_records`.  A component with no model pays
+    # nothing (the attributes do not exist and the loop takes the plain path).  See
+    # ``plans/timing_model.md``; the DAG's CollectTimingStep reads firing_records after a pysim run.
+
+    def add_timing_model(self, tm) -> None:
+        """Attach a :class:`~waveflow.calib.timing_model.TimingModel`, enabling per-firing recording.
+        The model itself is built by the component (it knows its ``clk`` and calib dir)."""
+        self._timing_model = tm
+        self.firing_records: list[dict] = []
+
+    @property
+    def timing_model(self):
+        """The attached model, or ``None`` — the signal the collection steps discover on."""
+        return getattr(self, "_timing_model", None)
+
+    def timed_delay(self, features: dict) -> float:
+        """Predict this firing's additional delay from the attached model AND record the firing for
+        later calibration.  Returns 0.0 (recording nothing) when no model is attached, so the body
+        can call it unconditionally — ``yield self.timeout(self.timed_delay({...}))`` is a no-op on
+        an uncalibrated component and the current firing's delay on a calibrated one.
+
+        The delay is in the model's output unit — time when the model carries a ``clk`` (the usual
+        case), so it goes straight to :meth:`timeout`."""
+        tm = self.timing_model
+        if tm is None:
+            return 0.0
+        dly = tm.predict(features)[0]
+        self._pending_firing = {**features, "current_dly": dly}
+        return dly
+
     # -- simulation ----------------------------------------------------------------------------------
 
     def run_proc(self) -> ProcessGen[None] | None:
@@ -173,8 +208,16 @@ class FreeRunComp(HwComponent):
         return self._run_iter_forever() if self._kind() == 'standalone' else None
 
     def _run_iter_forever(self) -> ProcessGen[None]:
+        if self.timing_model is None:
+            while True:                                 # plain path: no recording overhead
+                yield from self.run_iter()
         while True:
+            t0 = self.now
+            self._pending_firing = None                 # timed_delay sets this if the body predicts
             yield from self.run_iter()
+            if self._pending_firing is not None:
+                self._pending_firing["span"] = self.now - t0
+                self.firing_records.append(self._pending_firing)
 
     def run_iter(self) -> ProcessGen[None]:
         """One firing of the free-running loop — the ``hls::task`` body.  **Override this for a leaf.**
@@ -185,3 +228,24 @@ class FreeRunComp(HwComponent):
             f"run_iter; a composite must not call it (it has no body — its children do the work)."
         )
         yield  # unreachable: marks this a generator function so an accidental call yields cleanly
+
+
+def discover_timing_models(root) -> list[tuple["FreeRunComp", object]]:
+    """Walk *root* and its ``sub_comps`` for every attached ``TimingModel``.
+
+    Returns ``[(component, model), ...]``.  Mirrors ``discover_dyn_params`` (per-object) lifted to a
+    tree walk — the DAG's collect/fit steps use it to find which components to collect for, and a
+    component with no model is simply absent from the list."""
+    out: list[tuple[FreeRunComp, object]] = []
+    seen: set[int] = set()
+    stack = [root]
+    while stack:
+        c = stack.pop()
+        if id(c) in seen:
+            continue
+        seen.add(id(c))
+        tm = getattr(c, "timing_model", None)
+        if tm is not None:
+            out.append((c, tm))
+        stack.extend(getattr(c, "sub_comps", {}).values())
+    return out

--- a/waveflow/hw/mem_stream.py
+++ b/waveflow/hw/mem_stream.py
@@ -43,7 +43,9 @@ struct share one source.
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import ClassVar
 
 import numpy as np
@@ -210,6 +212,12 @@ WORD_BW_SUPPORTED = [32, 64]
 #: Pipeline-fill latency (cycles) between the a2s/s2a read and its overlapped write — the small
 #: ramp before the first word is forwarded.  Loosely-timed; the burst then costs ~n_words + fill.
 FILL_CYCLES = 8
+
+#: HLS ``max_read_burst_length`` / ``max_write_burst_length`` — a contiguous transfer of ``n`` words
+#: is issued as ``ceil(n / MEM_AXI_MAX_BURST)`` bursts.  This is ``num_trans``, the timing feature the
+#: RTL law moves on (see ``plans/memcpy_timing_calibration.md``); it must match
+#: ``ExtractBurstsStep.max_burst_len``.
+MEM_AXI_MAX_BURST = 16
 
 
 def _word_type(mem_dwidth: int) -> type[IntField]:
@@ -397,6 +405,12 @@ class MemWStream(FreeRunComp):
     #: Default ``False`` keeps the legacy protocol.
     inband: HwParam[bool] = False
     clk: Clock = field(default_factory=lambda: Clock(freq=100e6))
+    #: When set, attach a :class:`~waveflow.calib.timing_model.StreamTimingModel` at this directory
+    #: and inject its predicted (trailing) delay per firing — the posted-write drain the RTL law
+    #: captures.  ``None`` (default) leaves the component uncalibrated: no model, no delay, and the
+    #: pysim timing is exactly as before.  A model with an unfitted / zero-seed predicts 0, so
+    #: attaching one only records firings (for collection) until ``params.json`` exists.
+    calib_dir: "str | Path | None" = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -428,6 +442,12 @@ class MemWStream(FreeRunComp):
         #: :meth:`MemRStream.bind_base`.  Default 0: the flat single-arena mode (sim & BFM).
         self._base = 0
         self.transfer_spans: list[float] = []
+        if self.calib_dir is not None:
+            from waveflow.calib.timing_model import StreamTimingModel
+            # `component` must match the id this stream's firings carry in the RTL timing table — the
+            # task-body name, which kernel_task() already knows.
+            self.add_timing_model(StreamTimingModel(
+                component=self.kernel_task().task_fn, calib_dir=self.calib_dir, clk=self.clk))
 
     def bind_base(self, base: int = 0) -> None:
         """Set the bound buffer's physical base (the ``offset=slave`` register, host domain) — the
@@ -517,3 +537,9 @@ class MemWStream(FreeRunComp):
         if self.emit_done:
             for burst in fwd:
                 yield from self.s_done.write(burst)
+        # Trailing calibration delay: the posted-write drain the RTL keeps running after s_done, so
+        # the firing is not really done -- and the next cannot start -- until it completes.  A no-op
+        # (0, but still records the firing) when uncalibrated; see FreeRunComp.timed_delay.
+        dly = self.timed_delay({"nwords": nw, "num_trans": math.ceil(nw / MEM_AXI_MAX_BURST)})
+        if dly:
+            yield self.timeout(dly)


### PR DESCRIPTION
Wires the `TimingModel` engine (#113) into live code: base-class per-firing recording, the mem_copy writer, and the collect/fit DAG rung. The measurement→fit chain now exists end to end.

Builds on #113 (engine) and #112/#111 (measurement).

## What's here

- **`FreeRunComp`** gains opt-in per-firing recording. `add_timing_model(tm)` turns it on; the base `run_iter` loop times each firing and keeps `{features, current_dly, span}` on `firing_records` whenever the body called `timed_delay`. No model → plain path, zero cost. `discover_timing_models(root)` walks the tree (mirrors `discover_dyn_params`).
- **`MemWStream`/`MemCopy`** gain an opt-in `calib_dir`. When set, the writer attaches a `StreamTimingModel` and injects its predicted delay **trailing** (the posted-write drain the RTL law captures). `MemCopyTB`/`MemCopySim` thread it through so a pysim run calibrates end to end.
- **`CollectTimingStep` + `FitTimingStep`** — the collect/fit rung, driven by a design factory (generic, like `RtlSimStep`'s `prepare`). Collect appends a run's rtl+pysim firings per attached model; fit fits each, **skipping** (not failing) models whose corpus doesn't yet join.

## Two properties confirmed by the wiring

- **`calib_dir=None` is a true no-op** — mem_copy / mem_stream gates byte-identical. Calibration is purely additive.
- **Emergent contention, re-confirmed in pysim** — a seeded trailing delay on the writer does *not* mechanically grow the period; on a non-bottleneck stage it's absorbed into reduced idle-wait. The period responds through pipeline dynamics — the property the whole approach rests on. So the unit test asserts the delay is applied and recorded, not that the period moved.

## Verification

- New tests: `test_freerun_timing` (6), `test_mem_copy_timing` (4), `test_calib_steps` (4) — all green.
- Full `not vitis and not xsi` suite at the same 6 pre-existing baseline failures.

## Not yet done (next)

The loop isn't closed on real data — synthetic residuals are fitted, not the actual 140→183 mem_copy gap through these classes. Remaining: parameterize the TB's baked `h.run(3400)` + arena for the `n_words` sweep (one point can't fit a slope), then run the real sweep. See `plans/memcpy_timing_calibration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)