### PR TITLE
mem_copy: parameterize the XSI scenario for a timing sweep

### DIFF
--- a/examples/mem_copy/mem_copy.py
+++ b/examples/mem_copy/mem_copy.py
@@ -304,16 +304,41 @@ def gen_headers(config: BuildConfig) -> None:
 #: overlap, which is the ~1.9x the gate measures.
 XSI_N        = 128
 XSI_NUM_CMDS = 16
-XSI_SRC_W = [64 + 128 * j for j in range(XSI_NUM_CMDS)]
-XSI_DST_W = [4096 + 128 * j for j in range(XSI_NUM_CMDS)]
-
-#: The same scenario as ``MemCopyTB``'s own ``jobs`` parameter.  This is what "one statement, two
-#: backends" actually means: **one class, two instantiations** — pysim builds a ``MemCopyTB`` with
-#: its jobs, the XSI generator builds one with these.  Nothing about the scenario is stated twice.
-XSI_JOBS = tuple(CopyJob(s, d, XSI_N) for s, d in zip(XSI_SRC_W, XSI_DST_W))
 
 
-def make_xsi_tb(width: int = DEFAULT_MEM_DW):
+def xsi_jobs(n_words: int = XSI_N, num_cmds: int = XSI_NUM_CMDS) -> tuple:
+    """The XSI scenario as ``num_cmds`` back-to-back copies of ``n_words`` words, at non-overlapping
+    src/dst regions.  Parameterized so a **timing sweep** can vary the job size — the RTL is
+    scenario-independent (``len`` is a runtime command field), so only the vectors change.
+
+    The defaults reproduce the committed gate scenario exactly (``16 × 128``, src base 64, dst base
+    4096); ``dst_base`` only grows past 4096 when ``num_cmds × n_words`` would otherwise reach into
+    the destination, so a larger sweep point stays non-overlapping."""
+    src = [64 + n_words * j for j in range(num_cmds)]
+    dst_base = max(4096, 64 + num_cmds * n_words + 64)
+    dst = [dst_base + n_words * j for j in range(num_cmds)]
+    return tuple(CopyJob(s, d, n_words) for s, d in zip(src, dst))
+
+
+def xsi_run_cycles(n_words: int = XSI_N, num_cmds: int = XSI_NUM_CMDS) -> int:
+    """A generous ``h.run(N)`` bound covering the scenario's time-to-last-completion.
+
+    From the measured law (``~41 + n + 2·ceil(n/16)`` per job, plus pipeline fill and drain), with
+    margin.  The harness runs *exactly* this many cycles, so it must clear completion; overshoot is
+    only wasted sim cycles.  The default (``16 × 128``) lands ~3600, comfortably past the 2908 gate —
+    but the gate keeps its own committed 3400 (this is for sweep points that need more)."""
+    period = 60 + n_words + 3 * ((n_words + 15) // 16)
+    return 300 + num_cmds * period
+
+
+#: The committed gate scenario — the default of :func:`xsi_jobs`.  "One statement, two backends":
+#: pysim builds a ``MemCopyTB`` with its jobs, the XSI generator builds one with these.
+XSI_JOBS = xsi_jobs()
+XSI_SRC_W = [j.src_off for j in XSI_JOBS]
+XSI_DST_W = [j.dst_off for j in XSI_JOBS]
+
+
+def make_xsi_tb(width: int = DEFAULT_MEM_DW, jobs=None, n_cycles: int | None = None):
     """The :class:`~examples.mem_copy.mem_copy_sim.MemCopyTB` instance the XSI testbench is
     generated from.
 
@@ -323,7 +348,9 @@ def make_xsi_tb(width: int = DEFAULT_MEM_DW):
     from waveflow.simulation.simulation import Simulation
     from examples.mem_copy.mem_copy_sim import MemCopyTB
 
-    return MemCopyTB(name="xsi_tb", sim=Simulation(), mem_dwidth=width, jobs=XSI_JOBS)
+    kw = {} if n_cycles is None else {"n_cycles": int(n_cycles)}
+    return MemCopyTB(name="xsi_tb", sim=Simulation(), mem_dwidth=width,
+                     jobs=XSI_JOBS if jobs is None else tuple(jobs), **kw)
 
 
 def _done_words(width: int) -> int:
@@ -332,7 +359,7 @@ def _done_words(width: int) -> int:
     return CopyResp.nwords_per_inst(width)
 
 
-def render_xsi_vectors(width: int = DEFAULT_MEM_DW) -> str:
+def render_xsi_vectors(width: int = DEFAULT_MEM_DW, jobs=None) -> str:
     """Render ``mem_copy_vectors.h``'s contents **from the testbench graph**.
 
     Everything here is read off a real :class:`~examples.mem_copy.mem_copy_sim.MemCopyTB` — the same
@@ -347,7 +374,7 @@ def render_xsi_vectors(width: int = DEFAULT_MEM_DW) -> str:
     """
     from waveflow.build.composite_gen import render_vectors_h
 
-    tb = make_xsi_tb(width)
+    tb = make_xsi_tb(width, jobs=jobs)
     jobs = [CopyJob.coerce(j) for j in tb.jobs]
 
     return render_vectors_h(
@@ -374,7 +401,7 @@ def render_xsi_vectors(width: int = DEFAULT_MEM_DW) -> str:
     )
 
 
-def write_mem_copy_xsi_bundles(xsi_dir: Path, width: int = DEFAULT_MEM_DW) -> None:
+def write_mem_copy_xsi_bundles(xsi_dir: Path, width: int = DEFAULT_MEM_DW, jobs=None) -> None:
     """Write mem_copy's XSI input + golden **bundles** into ``<xsi_dir>/vectors/``.
 
     - ``vectors/s_cmd``  — the command stream (the StreamDriver's own bursts, schema-packed); the
@@ -392,10 +419,12 @@ def write_mem_copy_xsi_bundles(xsi_dir: Path, width: int = DEFAULT_MEM_DW) -> No
     """
     from examples.mem_copy.mem_copy_sim import MemCopySim
 
-    MemCopySim(jobs=XSI_JOBS, mem_dwidth=width).write_scenario(Path(xsi_dir))
+    MemCopySim(jobs=XSI_JOBS if jobs is None else tuple(jobs),
+               mem_dwidth=width).write_scenario(Path(xsi_dir))
 
 
-def check_mem_copy_xsi_outputs(xsi_dir: Path, want_cycles: int, width: int = DEFAULT_MEM_DW) -> None:
+def check_mem_copy_xsi_outputs(xsi_dir: Path, want_cycles: int, width: int = DEFAULT_MEM_DW,
+                               jobs=None) -> None:
     """Check mem_copy's XSI run from the dumped output bundles — the golden, in Python.
 
     The generated C++ main only runs and dumps; every check lives here.  Reads what the run wrote:
@@ -414,7 +443,7 @@ def check_mem_copy_xsi_outputs(xsi_dir: Path, want_cycles: int, width: int = DEF
     from waveflow.utils.burst_io import read_burst_bundle
 
     vdir = Path(xsi_dir) / "vectors"
-    tb = make_xsi_tb(width)
+    tb = make_xsi_tb(width, jobs=jobs)
     jobs = [CopyJob.coerce(j) for j in tb.jobs]
     done_words = _done_words(width)
 
@@ -446,7 +475,7 @@ def check_mem_copy_xsi_outputs(xsi_dir: Path, want_cycles: int, width: int = DEF
         f"change (regression, or an improvement worth re-recording).")
 
 
-def gen_xsi_vectors(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW) -> Path:
+def gen_xsi_vectors(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW, jobs=None) -> Path:
     """Emit ``xsi/mem_copy_vectors.h`` — the XSI testbench's scenario + its command words.
 
     The command words come from :meth:`CopyCmd.serialize`, the same call the pysim golden packs with.
@@ -464,7 +493,7 @@ def gen_xsi_vectors(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW) -> Path:
     drifted *pattern* still tests a copy, whereas a drifted *packing rule* sends malformed commands
     and makes the test meaningless.  The latter is what this function removes.
     """
-    h = render_xsi_vectors(width)
+    h = render_xsi_vectors(width, jobs=jobs)
     path = out_dir / "xsi" / "mem_copy_vectors.h"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(h, encoding="utf-8")
@@ -501,8 +530,14 @@ def generate_dut(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW) -> dict[str,
     return {spec.top_name: cpp}
 
 
-def generate_tb(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW) -> dict[str, Path]:
+def generate_tb(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW, jobs=None,
+                n_cycles: int | None = None) -> dict[str, Path]:
     """Generate the XSI **testbench**: the scenario constants + the BFM harness + the two-line main.
+
+    ``jobs`` / ``n_cycles`` default to the committed gate scenario (:data:`XSI_JOBS`, 3400).  A timing
+    sweep overrides them per point (:func:`xsi_jobs`, :func:`xsi_run_cycles`) — the harness arena and
+    the ``h.run(N)`` bound then size to that scenario, while the DUT RTL (``len`` is runtime) is
+    unchanged and need not be re-synthesized.
 
     All three are derived from the :class:`~examples.mem_copy.mem_copy_sim.MemCopyTB` **graph**
     (:func:`~waveflow.build.composite_gen.tb_top_spec`): the harness instantiates the BFM models on the
@@ -510,8 +545,8 @@ def generate_tb(out_dir: Path = HERE, width: int = DEFAULT_MEM_DW) -> dict[str, 
     just construct-run-close (participants load/dump bundles).  The only hand-written half is Python:
     the scenario (:func:`write_mem_copy_xsi_bundles`) and the golden checker."""
     top = "mem_copy"
-    vec_h = gen_xsi_vectors(out_dir, width=width)
-    tb = make_xsi_tb(width)
+    vec_h = gen_xsi_vectors(out_dir, width=width, jobs=jobs)
+    tb = make_xsi_tb(width, jobs=jobs, n_cycles=n_cycles)
     tb_spec = tb_top_spec(tb)
     harness_h = out_dir / "xsi" / f"{top}_tb_harness.h"
     harness_h.write_text(render_tb_harness(tb_spec), encoding="utf-8")

--- a/tests/examples/test_mem_copy_sweep.py
+++ b/tests/examples/test_mem_copy_sweep.py
@@ -1,0 +1,48 @@
+"""tests/examples/test_mem_copy_sweep.py — the XSI scenario parameterizes for a timing sweep.
+
+The RTL is scenario-independent (``len`` is a runtime command field), so a timing sweep varies only
+the vectors + the harness arena + the ``h.run(N)`` bound.  These check the two knobs (``xsi_jobs`` /
+``xsi_run_cycles``) generalize while the defaults reproduce the committed gate scenario exactly — so
+the 2908 gate is untouched.  No toolchain needed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from examples.mem_copy.mem_copy import XSI_JOBS, xsi_jobs, xsi_run_cycles
+
+
+class TestDefaultsPreserveTheGate:
+    def test_default_jobs_are_the_committed_scenario(self):
+        j = xsi_jobs()
+        assert j == XSI_JOBS
+        assert len(j) == 16 and all(x.n_words == 128 for x in j)
+        assert [x.src_off for x in j[:3]] == [64, 192, 320]
+        assert [x.dst_off for x in j[:3]] == [4096, 4224, 4352]
+
+    def test_default_run_bound_clears_the_gate(self):
+        # The gate completes at 2908; the derived bound must sit past it (the committed main still
+        # bakes its own 3400 -- this is for sweep points that need more).
+        assert xsi_run_cycles() > 2908
+
+
+class TestSweepPoints:
+    @pytest.mark.parametrize("n,k", [(32, 16), (64, 16), (256, 8), (512, 4)])
+    def test_regions_do_not_overlap(self, n, k):
+        j = xsi_jobs(n_words=n, num_cmds=k)
+        assert len(j) == k and all(x.n_words == n for x in j)
+        spans = sorted((x.src_off, x.src_off + n) for x in j) + \
+                sorted((x.dst_off, x.dst_off + n) for x in j)
+        spans.sort()
+        for (a0, a1), (b0, b1) in zip(spans, spans[1:]):
+            assert a1 <= b0, f"regions overlap at n={n} k={k}: [{a0},{a1}) vs [{b0},{b1})"
+
+    def test_run_bound_scales_with_the_scenario(self):
+        # Bigger jobs -> more cycles; the bound is monotone in words moved.
+        assert xsi_run_cycles(512, 4) > xsi_run_cycles(128, 4)
+        assert xsi_run_cycles(128, 16) > xsi_run_cycles(128, 4)
+
+    def test_larger_scenarios_push_dst_past_src(self):
+        """When num_cmds*n_words reaches past 4096, dst_base grows so src and dst stay apart."""
+        j = xsi_jobs(n_words=512, num_cmds=16)     # srcs run to 64 + 16*512 = 8256
+        assert min(x.dst_off for x in j) >= max(x.src_off + 512 for x in j)


### PR DESCRIPTION
Calibration needs measurements at several job sizes — one point can't fit a slope — but the XSI testbench baked one scenario (`XSI_JOBS` = 16×128, `h.run(3400)`). Since the RTL is scenario-independent (`len` is runtime), a sweep varies only the vectors, the harness arena, and the run bound.

## Two knobs, both defaulting to the committed gate scenario

- `xsi_jobs(n_words, num_cmds)` — the jobs tuple, non-overlapping src/dst. **Defaults reproduce `XSI_JOBS` exactly**; `dst_base` only grows past 4096 when `num_cmds×n_words` would reach into it.
- `xsi_run_cycles(n_words, num_cmds)` — a generous `h.run(N)` bound from the measured law.

`jobs`/`n_cycles` are threaded through `make_xsi_tb`, `render/gen_xsi_vectors`, `write_mem_copy_xsi_bundles`, `check_mem_copy_xsi_outputs`, and `generate_tb` — every one defaulting to the committed scenario, so the `-m xsi` gate is untouched. The harness arena already auto-sizes from the jobs; `n_cycles` now flows to the generated main.

## Verification

- `xsi_jobs() == XSI_JOBS` byte-for-byte; mem_copy pysim + timing tests pass.
- **The `-m xsi` gate still measures exactly 2908** — the parameterization did not disturb the committed scenario.
- 8 new sweep tests (non-overlap, run-bound scaling) — no toolchain needed.

A sweep driver calls `generate_tb(jobs=…, n_cycles=…)` per point over one csynth. Closing the loop on real data (sweep → collect → fit → validate calibrated pysim) is the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)