### PR TITLE
interface: FIFO depth as a physical property — and the calibration loop closes (0.0%)

### DIFF
--- a/plans/memcpy_timing_calibration.md
+++ b/plans/memcpy_timing_calibration.md
@@ -1,13 +1,27 @@
 # mem_copy timing calibration (VCD of internal streams)
 
-**Status: steps 1-4 DONE by hand; the model is derived and validated. What remains is implementing
-it in the framework and automating the fit (step 4's second half).** Everything else about
-`mem_copy` is done and gated (design, pysim, codegen, csynth, XSI gate 2908, docs).
+**Status: LOOP CLOSED.** The whole arc is built into the framework and validated end to end on real
+data: trace → measure → fit the writer's residual on uncontended firings → re-run pysim with the
+bounded `copy_data` channel → the calibrated pysim period reproduces the RTL period **to 0.0%** at
+both n_words=128 (183) and n_words=512 (615). The ~30 cycles/job of backpressure *emerge* from the
+depth-2 FIFO; they are never fitted.
 
-**The result in one line:** the 43-cycle/job gap is `20 + 2 × ceil(n_words/16)` — a fixed control
-cost plus **two cycles per AXI burst** — and once that and the real FIFO depth are in the model, the
-~30 cycles/job of backpressure *emerge* rather than being fitted, reproducing the RTL across a 16×
-range of job sizes to **1.1%**. See "The model".
+Shipped: measurement (#111/#112), the `TimingModel` engine (#113), the wiring
+(FreeRunComp/MemWStream/DAG, #114), the sweep parameterization (#115), and the FIFO-depth
+single-source change (this arc) — the last piece, because without a bounded `copy_data` the writer's
+fitted delay is absorbed into idle-wait and the period does not move. Committed proof:
+`tests/examples/test_mem_copy_calibration.py` (toolchain-free, using the measured RTL spans); the
+full real-data sweep (`scratchpad/close_loop.py`) gave 0.0% at both points.
+
+**The result in one line:** the 43-cycle/job gap is a fixed control cost + a per-AXI-burst term; with
+it and the real FIFO depth in the model, backpressure *emerges* rather than being fitted, reproducing
+the RTL across a 16× range of job sizes. See "The model".
+
+**One caveat on the decomposition:** two collinear features (`nwords`, `num_trans = nwords/16`) fit
+from two points are underdetermined — the automated fit landed on `~20 + 0.12·nwords`, the hand
+analysis on `20 + 2·num_trans`; both reproduce the sweep points exactly but attribute the slope
+differently. A third size (or fixing the burst coefficient from the measured AXI gap) would
+disambiguate bus-term vs control-term. Prediction at the swept sizes is exact regardless.
 
 ## Probe outcome — the de-risk below is settled
 

--- a/tests/examples/test_mem_copy_calibration.py
+++ b/tests/examples/test_mem_copy_calibration.py
@@ -1,0 +1,81 @@
+"""tests/examples/test_mem_copy_calibration.py — the calibration loop closes.
+
+The end-to-end proof, toolchain-free: given the writer's MEASURED RTL firing spans (183 cycles at
+n_words=128, 615 at n_words=512 — see plans/memcpy_timing_calibration.md), calibrate the writer on
+UNCONTENDED firings and check that a re-run of pysim reproduces the RTL *period* at both sizes.
+
+Two things make this a real test and not a tautology:
+
+* The residual is fit on uncontended firings only; the contention (~30 cycles/job at n=128) then
+  *emerges* from the depth-2 `copy_data` channel rather than being fitted — so the calibrated period
+  matching RTL is a prediction, not an identity.
+* It depends on the FIFO being bounded (the depth change).  With an unbounded `copy_data`, the
+  writer's trailing delay is absorbed into idle-wait and the period would NOT move — which is exactly
+  what an earlier iteration showed before depth-2 became the default.
+
+The synthetic part is only the RTL *numbers* (measured, and gated for real by the -m xsi run and the
+scratchpad sweep that produced 0.0% error).  The pysim side — collection, fit, the bounded channel,
+the injected delay — is all real.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from examples.mem_copy.mem_copy import CopyJob, xsi_jobs
+from examples.mem_copy.mem_copy_sim import MemCopySim
+from waveflow.calib.timing_model import StreamTimingModel
+from waveflow.hw.clock import Clock
+
+COMPONENT = "mem_w_stream_framed_done_task"
+#: The writer's measured RTL firing span (cycles), per n_words — the ap_done-anchored period.
+RTL_SPAN = {128: 183.0, 512: 615.0}
+
+
+def _rtl_events(n_words, span):
+    """A minimal ExtractBurstsStep-shaped events dict: one writer firing at this size (blocked==0)."""
+    return {"top": "mem_copy", "max_burst_len": 16,
+            "firings": [{"component": COMPONENT, "index": 0, "nwords": n_words,
+                         "num_trans": math.ceil(n_words / 16), "span": span, "blocked": 0}]}
+
+
+def _pysim_period(dut):
+    """The writer's steady-state firing cadence in cycles = median diff of ap_done-equivalent ends."""
+    period = 1.0 / dut.wstream.clk.freq
+    ends = np.asarray([r["end"] for r in dut.wstream.firing_records]) / period
+    d = np.diff(ends)
+    return float(np.median(d[len(d) // 2:]))
+
+
+def test_calibrated_pysim_reproduces_the_rtl_period(tmp_path):
+    calib = str(tmp_path / "wcalib")
+    tm = StreamTimingModel(component=COMPONENT, calib_dir=calib, clk=Clock(freq=100e6))
+
+    # --- collect: RTL spans (measured) + pysim firings (real runs), at two sizes ---
+    for nw in (128, 512):
+        k = 16 if nw == 128 else 4
+        tm.collect_rtl(_rtl_events(nw, RTL_SPAN[nw]), run_id=f"n{nw}")
+        dut = MemCopySim(jobs=xsi_jobs(nw, k), calib_dir=calib).run()   # writer records firings
+        tm.collect_pysim(dut.wstream.firing_records, run_id=f"n{nw}")
+
+    # --- fit the residual on the uncontended firings ---
+    tm.fit()
+    assert len(tm.coverage["matched"]) == 2, "both sizes must join for the slope"
+
+    # --- validate: re-run pysim with the fitted model; the period must match RTL ---
+    for nw in (128, 512):
+        k = 16 if nw == 128 else 4
+        dut = MemCopySim(jobs=xsi_jobs(nw, k), calib_dir=calib).run()
+        got = _pysim_period(dut)
+        assert got == pytest.approx(RTL_SPAN[nw], rel=0.03), (
+            f"n={nw}: calibrated pysim period {got:.1f} != RTL {RTL_SPAN[nw]} — the fitted delay did "
+            f"not reproduce the contended period (is copy_data still unbounded?)")
+
+
+def test_without_calibration_the_period_is_short(tmp_path):
+    """The gap the calibration closes: uncalibrated pysim runs optimistic (the writer's firing
+    cadence is well under the RTL 183), so the fix is real, not a no-op."""
+    dut = MemCopySim(jobs=xsi_jobs(128, 16), calib_dir=str(tmp_path / "c")).run()  # unfitted seed=0
+    assert _pysim_period(dut) < RTL_SPAN[128] - 20   # ~147 measured, comfortably short of 183

--- a/tests/hw/test_stream_depth.py
+++ b/tests/hw/test_stream_depth.py
@@ -1,0 +1,130 @@
+"""tests/hw/test_stream_depth.py — a StreamIF's depth is a single-source physical property.
+
+One number feeds both backends: pysim's slave queue_size (bounded at the real FIFO depth, so it
+backpressures faithfully) and codegen's `#pragma HLS STREAM depth`.  `None` is explicit-unbounded —
+allowed for pysim exploration, rejected when a synthesizable edge lowers.
+"""
+from __future__ import annotations
+
+import pytest
+
+from waveflow.build.composite_gen import FramedEdge, StreamEdge, derive_internal_edges
+from waveflow.build.hwcodegen import SynthesisError
+from waveflow.hw.clock import Clock
+from waveflow.hw.interface import (
+    DEFAULT_STREAM_DEPTH,
+    StreamIF,
+    StreamIFMaster,
+    StreamIFSlave,
+)
+from waveflow.simulation.simulation import Simulation
+
+
+def _bound_if(depth="default", slave_queue=None):
+    sim = Simulation()
+    kw = {} if depth == "default" else {"depth": depth}
+    iface = StreamIF(name="ch", sim=sim, bitwidth=64, clk=Clock(freq=100e6), **kw)
+    m = StreamIFMaster(name="m", sim=sim, bitwidth=64, has_tlast=False)
+    s = StreamIFSlave(name="s", sim=sim, bitwidth=64, has_tlast=False, queue_size=slave_queue)
+    iface.bind("master", m)
+    iface.bind("slave", s)
+    return iface, s
+
+
+class TestPysimReadsDepth:
+    def test_unset_slave_gets_the_channel_depth(self):
+        _, s = _bound_if()
+        assert s.queue_size == DEFAULT_STREAM_DEPTH
+        assert s.nrx.capacity == DEFAULT_STREAM_DEPTH
+
+    def test_explicit_depth_is_applied(self):
+        _, s = _bound_if(depth=1024)
+        assert s.queue_size == 1024 and s.nrx.capacity == 1024
+
+    def test_endpoint_queue_size_wins(self):
+        """A testbench sink that declared its own buffering keeps it — the channel depth applies
+        only when the endpoint left it unset."""
+        _, s = _bound_if(depth=2, slave_queue=64)
+        assert s.queue_size == 64 and s.nrx.capacity == 64
+
+    def test_explicit_unbounded_leaves_the_slave_unbounded(self):
+        import math
+        _, s = _bound_if(depth=None)
+        assert s.queue_size is None and s.nrx.capacity == math.inf
+
+
+class TestSynthesisRejectsUnbounded:
+    def _comp_with_edge(self, depth):
+        """A tiny composite: two leaves wired by one StreamIF at *depth*."""
+        from dataclasses import dataclass
+        from waveflow.hw.hw_freerun import FreeRunComp
+
+        @dataclass
+        class Prod(FreeRunComp):
+            def __post_init__(self):
+                super().__post_init__()
+                self.out = StreamIFMaster(name=f"{self.name}_out", sim=self.sim, bitwidth=64,
+                                          has_tlast=False)
+                self.add_endpoint(self.out)
+
+            def run_iter(self):
+                yield self.timeout(1)
+
+        @dataclass
+        class Cons(FreeRunComp):
+            def __post_init__(self):
+                super().__post_init__()
+                self.inp = StreamIFSlave(name=f"{self.name}_in", sim=self.sim, bitwidth=64,
+                                         has_tlast=False)
+                self.add_endpoint(self.inp)
+
+            def run_iter(self):
+                yield self.timeout(1)
+
+        @dataclass
+        class Top(FreeRunComp):
+            def __post_init__(self):
+                super().__post_init__()
+                self.p = Prod(name=f"{self.name}_p", sim=self.sim)
+                self.c = Cons(name=f"{self.name}_c", sim=self.sim)
+                self.add_comp(self.p)
+                self.add_comp(self.c)
+                kw = {} if depth == "default" else {"depth": depth}
+                iface = StreamIF(name=f"{self.name}_e", sim=self.sim, bitwidth=64,
+                                 clk=Clock(freq=100e6), **kw)
+                iface.bind("master", self.p.out)
+                iface.bind("slave", self.c.inp)
+                self.add_if(iface)
+
+        return Top(name="t", sim=Simulation())
+
+    def test_default_depth_lowers_to_an_edge(self):
+        edges = derive_internal_edges(self._comp_with_edge("default"))
+        assert len(edges) == 1 and edges[0].depth == DEFAULT_STREAM_DEPTH
+
+    def test_unbounded_internal_edge_is_a_synthesis_error(self):
+        with pytest.raises(SynthesisError, match="unbounded"):
+            derive_internal_edges(self._comp_with_edge(None))
+
+
+class TestCodegenEmitsOnlyNonDefault:
+    def test_default_depth_emits_no_pragma(self):
+        """The HLS default IS DEFAULT_STREAM_DEPTH, so a pragma for it would only churn the C++ for
+        identical RTL."""
+        assert "#pragma HLS STREAM" not in StreamEdge("x", None, None, depth=DEFAULT_STREAM_DEPTH).decl(64)
+        assert "#pragma HLS STREAM" not in FramedEdge("x", None, None, depth=DEFAULT_STREAM_DEPTH).decl(64)
+
+    def test_non_default_depth_emits_the_pragma(self):
+        d = StreamEdge("x", None, None, depth=1024).decl(64)
+        assert "#pragma HLS STREAM variable=x depth=1024" in d
+
+
+class TestMemCopyChannelsAreBounded:
+    def test_internal_framed_edges_bound_to_two_in_pysim(self):
+        """The whole point: mem_copy's cmd / copy_data slaves are now depth-2, matching the RTL
+        fifo_w65_d2 -- so pysim backpressures where the RTL does."""
+        from examples.mem_copy.mem_copy import MemCopy
+
+        dut = MemCopy(name="mc", sim=Simulation(), mem_dwidth=64)
+        assert dut.rstream.s_cmd.queue_size == DEFAULT_STREAM_DEPTH   # cmd edge slave
+        assert dut.wstream.s_in.queue_size == DEFAULT_STREAM_DEPTH    # copy_data edge slave

--- a/waveflow/build/composite_gen.py
+++ b/waveflow/build/composite_gen.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from waveflow.build.hwcodegen import SynthesisError
+from waveflow.hw.interface import DEFAULT_STREAM_DEPTH
+
 #: Output-directory convention shared by the generated tops and their csynth .tcl.
 INCLUDE_DIR = "include"
 GEN_DIR = "gen"
@@ -373,7 +376,9 @@ class StreamEdge:
 
     def decl(self, width: int) -> str:
         line = f"hls_thread_local hls::stream<ap_uint<{width}> > {self.name};"
-        if self.depth is not None:
+        if self.depth is not None and self.depth != DEFAULT_STREAM_DEPTH:
+            # The HLS default IS DEFAULT_STREAM_DEPTH, so emitting a pragma for it would only churn
+            # the generated C++ (and force a re-csynth) for identical RTL.  Emit only a non-default.
             line += f"\n    #pragma HLS STREAM variable={self.name} depth={self.depth}"
         return line
 
@@ -398,7 +403,9 @@ class FramedEdge:
     def decl(self, width: int) -> str:
         line = (f"hls_thread_local hls::stream<streamutils::framed_word<{width}> > "
                 f"{self.name};")
-        if self.depth is not None:
+        if self.depth is not None and self.depth != DEFAULT_STREAM_DEPTH:
+            # See StreamEdge.decl: the default depth is HLS's own, so no pragma for it (keeps the
+            # generated C++ and its RTL byte-identical).
             line += f"\n    #pragma HLS STREAM variable={self.name} depth={self.depth}"
         return line
 
@@ -505,10 +512,20 @@ def derive_internal_edges(comp) -> list:
         elif isinstance(iface, StreamIF):
             # A framed StreamIF lowers to a FramedEdge (framed_word FIFO, carries the packet
             # boundary); a plain one to a StreamEdge (ap_uint FIFO).  See plans/memstream_inband.md.
+            # The channel's `depth` is single-source (pysim queue_size + this pragma).  `None` is
+            # explicit-unbounded -- fine for pysim exploration, but a FIFO going to hardware must
+            # have a depth, so reject it at the synthesis boundary rather than emit an unsized FIFO.
+            depth = getattr(iface, "depth", DEFAULT_STREAM_DEPTH)
+            if depth is None:
+                raise SynthesisError(
+                    f"derive_internal_edges: internal channel {name!r} on {type(comp).__name__} has "
+                    f"depth=None (explicit unbounded). An unbounded FIFO is not synthesizable — give "
+                    f"the StreamIF a depth (default {DEFAULT_STREAM_DEPTH}), or keep it unbounded only "
+                    f"for pysim exploration, not for codegen.")
             if getattr(iface, "framed", False):
-                edges.append(FramedEdge(name, master, slave))
+                edges.append(FramedEdge(name, master, slave, depth=depth))
             else:
-                edges.append(StreamEdge(name, master, slave))
+                edges.append(StreamEdge(name, master, slave, depth=depth))
         else:
             raise ValueError(
                 f"derive_internal_edges: no edge lowering for interface type "

--- a/waveflow/hw/hw_freerun.py
+++ b/waveflow/hw/hw_freerun.py
@@ -216,7 +216,11 @@ class FreeRunComp(HwComponent):
             self._pending_firing = None                 # timed_delay sets this if the body predicts
             yield from self.run_iter()
             if self._pending_firing is not None:
+                # `end` (absolute sim time of firing completion) mirrors the RTL table's ap_done
+                # column, so the pysim firing cadence -- the period -- is diff(ends), the same way
+                # the RTL period is measured.  `span` is the firing's own duration.
                 self._pending_firing["span"] = self.now - t0
+                self._pending_firing["end"] = self.now
                 self.firing_records.append(self._pending_firing)
 
     def run_iter(self) -> ProcessGen[None]:

--- a/waveflow/hw/interface.py
+++ b/waveflow/hw/interface.py
@@ -99,6 +99,11 @@ def port_write(fn):
 _PORT_DIR_READ_HINTS = ('read', 'get', 'peek', 'poll')
 _PORT_DIR_WRITE_HINTS = ('write', 'put')
 
+#: Default FIFO depth of a :class:`StreamIF` channel — the HLS default (``#pragma HLS STREAM`` uses
+#: 2 when unspecified).  Both backends read it, so pysim backpressures at the same depth the RTL
+#: FIFO has.  See :attr:`StreamIF.depth`.
+DEFAULT_STREAM_DEPTH = 2
+
 
 def _classify_port_dir(name, attr):
     """Classify endpoint attribute *name* as ``'R'`` / ``'W'`` / ``None``.
@@ -563,6 +568,19 @@ class StreamIF(QueuedTransferIF):
     (Vitis HLS 214-208), hence the ``framed_word`` struct.  Implies packet framing, so a framed stream
     is also ``has_tlast`` in pysim (burst boundaries)."""
 
+    depth: int | None = DEFAULT_STREAM_DEPTH
+    """The channel's FIFO **depth** — a *physical* property, single-source for both backends.
+
+    A FIFO has a depth; an unbounded queue is not synthesizable.  So this one number feeds pysim (the
+    slave's ``queue_size``, applied at :meth:`bind` when the endpoint did not set its own) and codegen
+    (``#pragma HLS STREAM depth=N``).  The default is :data:`DEFAULT_STREAM_DEPTH` — the HLS default —
+    so pysim is *faithful by default* (it backpressures at the real depth, catching deadlocks that an
+    unbounded queue would hide) and the RTL is unchanged (the default depth is what HLS already used).
+
+    ``None`` is **explicit unbounded** — a legitimate exploration mode in pysim, but
+    :func:`~waveflow.build.composite_gen.derive_internal_edges` rejects it for a synthesizable edge:
+    a FIFO going to hardware must have a depth."""
+
     type_name = 'stream_if'
 
     def __init_subclass__(cls, **kwargs):
@@ -610,6 +628,14 @@ class StreamIF(QueuedTransferIF):
                 f"interface has_tlast={self.has_tlast}"
             )
         self._validate_and_set_bitwidth(endpoint)
+        # Apply the channel's physical depth to the slave's RX queue, unless the endpoint declared
+        # its own (a testbench sink that wants deep buffering keeps it; an internal-edge slave, made
+        # without a queue_size, gets the channel depth).  The queue container is built at
+        # construction, but nothing has transferred yet at bind, so rebuilding it at level 0 is safe.
+        if (ep_name == "slave" and self.depth is not None
+                and getattr(endpoint, "queue_size", None) is None):
+            endpoint.queue_size = self.depth
+            endpoint.nrx = simpy.Container(endpoint.env, init=0, capacity=self.depth)
         super().bind(ep_name, endpoint)
 
 


### PR DESCRIPTION
The last piece of the timing-calibration arc, plus the capstone: **calibrated pysim reproduces the RTL period to 0.0%** on real mem_copy data.

## The principle

A FIFO has a depth; an unbounded queue is not synthesizable. pysim defaulted `queue_size` to **unbounded** while HLS defaults to **2** — the same physical thing, opposite defaults — so pysim silently failed to backpressure where the RTL does. That's the gap behind the whole calibration story: a fitted writer delay was absorbed into idle-wait instead of growing the period.

## The change

`StreamIF` now carries `depth` (default `DEFAULT_STREAM_DEPTH = 2`, the HLS default), read by **both** backends:

- **pysim**: `bind()` applies it to the slave's `queue_size` — unless the endpoint declared its own (a testbench sink keeps its deep buffer; an internal-edge slave gets the channel depth).
- **codegen**: `derive_internal_edges` passes it to the edge; the pragma emits **only for a non-default depth**, so generated C++/RTL is byte-identical (mem_copy `80e3a0f0`, interleaver `70cbf332` — the IntChannel hashes).

`depth=None` = **explicit unbounded** — fine for pysim exploration, but `derive_internal_edges` raises `SynthesisError` when a synthesizable edge lowers with it. Scoped to internal edges; a testbench queue is never synthesized.

Two payoffs beyond consistency: pysim is **faithful by default** (backpressures at the real depth), and bounding surfaces deadlocks an unbounded queue would hide.

## The loop closes

With the bounded channel, the whole arc works end to end on real data — trace → measure (writer 183 @ n=128, 615 @ n=512) → fit the residual on **uncontended** firings → re-run pysim → **the calibrated period matches RTL to 0.0%** at both sizes (up from uncalibrated 147/531). The ~30 cycles/job of backpressure **emerge** from the depth-2 FIFO; they're never fitted. That's the two-level premise demonstrated: a component calibrated in isolation predicts the contended system.

- `tests/examples/test_mem_copy_calibration.py` — committed, toolchain-free proof (measured RTL spans + real pysim collection/fit/validate within 3%, plus a no-op guard).
- Full real-data sweep (`scratchpad`, needs Vitis) gave 0.0% at both points.

## Verification

- Generated RTL byte-identical; `-m xsi` gates unchanged (2908 / 3469).
- Full non-toolchain suite at the same 6 baseline failures — **no design broke under bounded-by-default queues** (they were all correct at depth 2).
- New: 9 depth tests + 2 calibration-loop tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)