### PR TITLE
calib: platform-scoped bus-transfer model — the two-level split realized

### DIFF
--- a/examples/mem_copy/mem_copy_sim.py
+++ b/examples/mem_copy/mem_copy_sim.py
@@ -66,6 +66,11 @@ class MemCopyTB(FreeRunComp):
     #: Forwarded to the DUT's writer: when set, the pysim run records per-firing timing (and applies
     #: any fitted delay).  ``None`` (default) is the plain, uncalibrated run.
     calib_dir: "str | None" = None
+    #: The PLATFORM's bus-transfer calibration directory.  When set, the memory's slave loads a
+    #: :class:`~waveflow.hw.memif.BusTiming` from it, so pysim charges the real m_axi burst cost —
+    #: the platform half of the two-level split, shared across accelerators.  ``None`` = the plain
+    #: word_bw fallback.
+    platform_dir: "str | None" = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -79,6 +84,12 @@ class MemCopyTB(FreeRunComp):
                                for job in self._jobs) + 16
         self.mem = MemComponent(name=f"{self.name}_mem", sim=self.sim, inline=False, clk=self.clk,
                                 word_size=w, addr_size=32, nwords_tot=self.arena_words * 4)
+        # Platform bus model: the memory's slave charges the calibrated m_axi transfer cost, so the
+        # component's residual is just its own control cost.  Shared across accelerators (fit once).
+        if self.platform_dir is not None:
+            from waveflow.calib.bus_model import BusCalib
+            self.mem.s_mm.bus_timing = BusCalib(self.platform_dir,
+                                                clk_freq=self.clk.freq).bus_timing()
         # Allocate the full capacity so the memory is the same size as the RTL FlatMemory and the whole
         # vectors/mem_in image loads directly in pre_sim (no clip).  The DUT still addresses only
         # [0, arena_words) -- the extra is headroom for the image.
@@ -146,9 +157,10 @@ class MemCopySim:
     """
 
     def __init__(self, jobs=(CopyJob(src_off=16, dst_off=512, n_words=128),),
-                 mem_dwidth: int = 64, name: str = "tb", calib_dir: "str | None" = None) -> None:
+                 mem_dwidth: int = 64, name: str = "tb", calib_dir: "str | None" = None,
+                 platform_dir: "str | None" = None) -> None:
         self.tb = MemCopyTB(name=name, sim=Simulation(), jobs=tuple(jobs), mem_dwidth=mem_dwidth,
-                            calib_dir=calib_dir)
+                            calib_dir=calib_dir, platform_dir=platform_dir)
         #: The per-job source patterns, filled by :meth:`write_scenario` and read back by :meth:`check`.
         self.expected: list[np.ndarray] = []
 

--- a/tests/calib/test_bus_model.py
+++ b/tests/calib/test_bus_model.py
@@ -1,0 +1,63 @@
+"""tests/calib/test_bus_model.py — platform-scoped bus-transfer calibration.
+
+BusCalib fits a per-direction span(num_trans, nwords) model from the memory ports and stores it in a
+platform directory, so every accelerator on that platform reuses it without recalibrating.  This
+checks fit -> persist -> load -> a configured BusTiming that predicts the span; and the
+load-or-default degrade when a platform has no fit yet.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from waveflow.calib.bus_model import BUS_MODEL_FILE, BusCalib
+
+
+def _points(law):
+    """{num_trans, nwords, span} datapoints from a span law, at a few sizes."""
+    return [{"num_trans": nt, "nwords": nw, "span": law(nt, nw)}
+            for nw, nt in [(128, 8), (256, 16), (512, 32), (64, 4)]]
+
+
+class TestFitPersistLoad:
+    def test_fit_writes_the_platform_model(self, tmp_path):
+        bc = BusCalib(platform_dir=tmp_path)
+        bc.fit(read_points=_points(lambda nt, nw: nw + 2 * (nt - 1)),
+               write_points=_points(lambda nt, nw: nw + 2 * (nt - 1)))
+        assert (tmp_path / BUS_MODEL_FILE).exists()
+        data = json.loads((tmp_path / BUS_MODEL_FILE).read_text())
+        assert set(data["models"]) == {"read", "write"}
+        assert data["basis"] == ["num_trans", "nwords"]
+
+    def test_loaded_bus_timing_predicts_the_span(self, tmp_path):
+        """The fitted model reproduces the law: span = nwords + 2*(num_trans-1) cycles."""
+        BusCalib(platform_dir=tmp_path, clk_freq=100e6).fit(
+            None, write_points=_points(lambda nt, nw: nw + 2 * (nt - 1)))
+        bt = BusCalib(platform_dir=tmp_path, clk_freq=100e6).bus_timing()
+        # write_span_secs -> cycles/clk_freq; 128 words in 8 bursts = 128 + 14 = 142 cycles.
+        assert bt.write_span_secs(num_trans=8, nwords=128) == pytest.approx(142 / 100e6, rel=1e-6)
+        assert bt.read_span_secs(num_trans=8, nwords=128) is None   # read never fit -> no model
+
+    def test_a_write_only_platform_fits_only_write(self, tmp_path):
+        BusCalib(platform_dir=tmp_path).fit(None, _points(lambda nt, nw: nw))
+        data = json.loads((tmp_path / BUS_MODEL_FILE).read_text())
+        assert set(data["models"]) == {"write"}
+
+
+class TestLoadOrDefault:
+    def test_uncalibrated_platform_degrades_to_the_word_bw_fallback(self, tmp_path):
+        """No mm_bus.json -> an unconfigured BusTiming (both directions None), so a slice falls back
+        to the plain per-word span rather than crashing."""
+        bt = BusCalib(platform_dir=tmp_path / "never_calibrated").bus_timing()
+        assert bt.read is None and bt.write is None
+        assert bt.read_span_secs(num_trans=8, nwords=128) is None
+
+    def test_reuse_across_projects_needs_no_refit(self, tmp_path):
+        """The whole point: fit once, then a *different* BusCalib pointed at the same platform dir
+        loads the model without any datapoints."""
+        BusCalib(platform_dir=tmp_path).fit(None, _points(lambda nt, nw: nw + 2 * (nt - 1)))
+        # A fresh instance (as a new project would build) -- no fit, just load.
+        reused = BusCalib(platform_dir=tmp_path).bus_timing()
+        assert reused.write_span_secs(num_trans=32, nwords=512) == pytest.approx(
+            (512 + 62) / 100e6, rel=1e-6)

--- a/tests/examples/test_mem_copy_calibration.py
+++ b/tests/examples/test_mem_copy_calibration.py
@@ -79,3 +79,48 @@ def test_without_calibration_the_period_is_short(tmp_path):
     cadence is well under the RTL 183), so the fix is real, not a no-op."""
     dut = MemCopySim(jobs=xsi_jobs(128, 16), calib_dir=str(tmp_path / "c")).run()  # unfitted seed=0
     assert _pysim_period(dut) < RTL_SPAN[128] - 20   # ~147 measured, comfortably short of 183
+
+
+def _writer_span(dut):
+    period = 1.0 / dut.wstream.clk.freq
+    return float(np.median([r["span"] for r in dut.wstream.firing_records]) * dut.wstream.clk.freq)
+
+
+def test_platform_bus_model_takes_the_burst_term_off_the_component(tmp_path):
+    """The two-level split, realized: a PLATFORM bus model charges the m_axi burst cost, so the
+    component's residual shrinks to its own control cost.
+
+    Bus law = nwords + 2·(num_trans-1) cycles (the measured burst gaps).  Configuring it on the
+    memory grows the writer's pysim span by exactly the burst term (2 cyc × 7 gaps = 14 at n=128),
+    so the RTL-vs-pysim residual the *component* must carry drops by that 14 — from ~36 (bus+control
+    lumped) to ~22 (control only).  The bus term now lives on the shared platform model, calibrated
+    once and reused by every accelerator; only the 22 is per-accelerator."""
+    from waveflow.calib.bus_model import BusCalib
+
+    platform = tmp_path / "platform"
+    BusCalib(platform_dir=platform, clk_freq=100e6).fit(
+        None, [{"num_trans": nt, "nwords": nw, "span": nw + 2 * (nt - 1)}
+               for nw, nt in [(128, 8), (512, 32)]])
+
+    no_bus = _writer_span(MemCopySim(jobs=xsi_jobs(128, 16),
+                                     calib_dir=str(tmp_path / "a")).run())
+    with_bus = _writer_span(MemCopySim(jobs=xsi_jobs(128, 16), calib_dir=str(tmp_path / "b"),
+                                       platform_dir=str(platform)).run())
+
+    burst_term = 2 * (8 - 1)                       # 7 gaps × 2 cycles
+    assert with_bus - no_bus == pytest.approx(burst_term, abs=1.0)
+    # the component residual shrinks by exactly the burst term the platform now owns
+    assert (RTL_SPAN[128] - no_bus) - (RTL_SPAN[128] - with_bus) == pytest.approx(burst_term, abs=1.0)
+
+
+def test_platform_bus_model_preserves_correctness(tmp_path):
+    """Charging the calibrated bus span must not corrupt the data (it regressed once: the spanned
+    write path defaulted word_bw=32 and truncated 64-bit words)."""
+    from waveflow.calib.bus_model import BusCalib
+
+    platform = tmp_path / "platform"
+    BusCalib(platform_dir=platform, clk_freq=100e6).fit(
+        None, [{"num_trans": 8, "nwords": 128, "span": 142}])
+    # MemCopySim.run() asserts every copy is bit-exact; a truncation would raise here.
+    MemCopySim(jobs=xsi_jobs(128, 4), calib_dir=str(tmp_path / "c"),
+               platform_dir=str(platform)).run()

--- a/waveflow/calib/bus_model.py
+++ b/waveflow/calib/bus_model.py
@@ -1,0 +1,154 @@
+"""bus_model.py — platform-scoped m_axi bus-transfer calibration.
+
+The two-level calibration split (``project-two-level-calibration``) as a *storage* decision: the bus
+transfer cost is a property of the **platform** (the ``m_axi`` adapter + memory system), not of any
+one accelerator, so it is calibrated **once per platform** and every accelerator on that platform
+reuses it *without recalibrating*.
+
+``BusCalib`` fits a per-direction ``span(num_trans, nwords)`` model from the memory ports (component
+-independent — the datapoints come from AR/AW/R/W activity, not from a kernel's firing) and stores it
+in a platform directory.  ``BusTiming`` (``waveflow/hw/memif.py``) already owns the *runtime* side —
+a :class:`~waveflow.calib.calib.CalibModel`-like ``read``/``write`` predictor a
+:class:`~waveflow.hw.memif.Region` slice consults through the interconnect.  This module is the
+*calibration* side: fit those predictors, persist them, and hand back a configured ``BusTiming``.
+
+Contrast with :mod:`waveflow.calib.timing_model`: that fits a *component's* control residual into the
+component's own ``calib_dir``; this fits the *platform's* bus law into a shared platform dir.  A new
+accelerator loads the platform bus model (no recalibration) and then fits only its own residual —
+which is now small, because pysim's bus model already charges the transfer.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from waveflow.calib.calib import LinCalibModel
+
+#: Where a fit lands / loads within a platform directory.
+BUS_MODEL_FILE = "mm_bus.json"
+
+
+@dataclass
+class BusCalib:
+    """Fit + persist a platform's per-direction bus-transfer span model.
+
+    Parameters
+    ----------
+    platform_dir : str | Path
+        The platform's calibration directory — shared across accelerators on this board/BFM.  The
+        fitted model lives at ``<platform_dir>/mm_bus.json``.
+    clk_freq : float
+        Clock the spans are expressed against (the model is fit in **cycles**; the produced
+        :class:`~waveflow.hw.memif.BusTiming` converts to seconds with this freq).
+    basis : tuple[str, ...]
+        Regression features — the structural facts of a transfer.  ``(num_trans, nwords)`` = burst
+        count and words moved, exactly the row a ``Region`` slice supplies.
+    """
+
+    platform_dir: str | Path
+    clk_freq: float = 100e6
+    basis: tuple = ("num_trans", "nwords")
+
+    @property
+    def path(self) -> Path:
+        return Path(self.platform_dir) / BUS_MODEL_FILE
+
+    def _model(self) -> LinCalibModel:
+        # span = a*num_trans + b*nwords + c: through-a-fit intercept captures fixed per-burst setup,
+        # the coeffs the per-burst and per-word rates.  cycles in, cycles out.
+        return LinCalibModel(basis=list(self.basis), target="span", fit_intercept=True,
+                             coeff_names=list(self.basis))
+
+    # -- fit / persist -----------------------------------------------------
+    def fit(self, read_points: list[dict] | None, write_points: list[dict] | None) -> dict:
+        """Fit read and/or write from ``{num_trans, nwords, span}`` datapoints (span in cycles),
+        write ``mm_bus.json``, and return the stored ``{direction: state_dict}``.
+
+        A direction with no points is simply absent — a write-only accelerator calibrates only the
+        write channel."""
+        stored: dict[str, dict] = {}
+        for direction, pts in (("read", read_points), ("write", write_points)):
+            if pts:
+                m = self._model().fit(pd.DataFrame(pts))
+                stored[direction] = m.to_params()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps({"clk_freq": self.clk_freq, "basis": list(self.basis),
+                                         "models": stored}, indent=2) + "\n", encoding="utf-8")
+        return stored
+
+    # -- load / deploy -----------------------------------------------------
+    def _load_direction(self, models: dict, direction: str):
+        if direction not in models:
+            return None
+        return self._model().load_params(models[direction])
+
+    def bus_timing(self):
+        """A :class:`~waveflow.hw.memif.BusTiming` configured from the stored model, or an
+        *unconfigured* one (both directions ``None`` → the word_bw fallback) when no fit exists.
+
+        This is the ``load_or_default`` a fresh design calls: on a calibrated platform it inherits
+        the bus law; on an uncalibrated one it degrades to the plain per-word span, never crashes."""
+        from waveflow.hw.memif import BusTiming
+
+        if not self.path.exists():
+            return BusTiming(clk_freq=self.clk_freq)
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        models = data.get("models", {})
+        return BusTiming(read=self._load_direction(models, "read"),
+                         write=self._load_direction(models, "write"),
+                         clk_freq=data.get("clk_freq", self.clk_freq))
+
+
+def measure_bus_span(bt, bundle: str, direction: str, idle_gap: int = 8) -> dict | None:
+    """Measure a ``m_axi`` bundle's **per-transfer** bus span as a ``{num_trans, nwords, span}``
+    datapoint — **component-independently**, from the bundle's own activity in *bt* (a
+    :class:`~waveflow.utils.trace.BoundTrace`).
+
+    The bus law is read off the memory port, not any kernel's firing.  Beats are grouped into
+    transfers by idle gaps (a gap ``> idle_gap`` cycles ends a transfer — bigger than the ~2-cycle
+    inter-burst gaps within one transfer, smaller than the idle between firings), and the **median**
+    transfer is returned: ``num_trans`` = address handshakes in its window, ``nwords`` = its data
+    beats, ``span`` = its cycle extent.  Measuring one transfer (not the whole run) keeps inter-firing
+    idle out of the bus span.  The idealised BFM memory yields ``~nwords + gap·(num_trans-1)``; a real
+    board's DRAM latency would widen it — the point of measuring rather than assuming.
+    """
+    import numpy as np
+
+    from waveflow.utils.vcd import clock_sample_times, extract_clock_times, resample_signal
+
+    p = bt.port(bundle)
+    if p["kind"] != "maxi":
+        return None
+    sig_names = {k: bt.resolved[v] for k, v in p["signals"].items() if v in bt.resolved}
+    grid = clock_sample_times(extract_clock_times(bt.parser.sig_info[bt.clock]))
+
+    def hs(v_key, r_key):
+        if v_key not in sig_names or r_key not in sig_names:
+            return np.array([], dtype=int)
+        for n in (sig_names[v_key], sig_names[r_key]):
+            bt.parser.sig_info[n].get_values()
+        v = np.asarray(resample_signal(bt.parser.sig_info[sig_names[v_key]], grid))
+        r = np.asarray(resample_signal(bt.parser.sig_info[sig_names[r_key]], grid))
+        return np.nonzero((v != 0) & (r != 0))[0]
+
+    addr = hs("AWVALID", "AWREADY") if direction == "write" else hs("ARVALID", "ARREADY")
+    beat = hs("WVALID", "WREADY") if direction == "write" else hs("RVALID", "RREADY")
+    if not len(beat) or not len(addr):
+        return None
+
+    # Split the beats into per-transfer groups on idle gaps.
+    groups = np.split(beat, np.nonzero(np.diff(beat) > idle_gap)[0] + 1)
+    rows = []
+    for g in groups:
+        lo, hi = int(g[0]), int(g[-1])
+        nt = int(((addr >= lo - idle_gap) & (addr <= hi)).sum())   # AW/AR precede/overlap the beats
+        rows.append((nt, len(g), hi - lo + 1))
+    if not rows:
+        return None
+    rows.sort(key=lambda r: r[2])
+    nt, nw, span = rows[len(rows) // 2]                            # the median transfer
+    return {"num_trans": int(nt), "nwords": int(nw), "span": int(span)}

--- a/waveflow/hw/mem_stream.py
+++ b/waveflow/hw/mem_stream.py
@@ -337,7 +337,8 @@ class MemRStream(FreeRunComp):
         # Region (base = the bound physical base) by [addr, addr+len).  Region owns byte↔word
         # (byte_of()/word_bw), so no hand-rolled byte_addr_to_word_index / align.
         region = self.m_mem.region(self._base, self._word_t, word_bw=self._mem_bw)
-        words, t0 = yield from region.read_slice_pipelined(w0, w0 + nw)
+        words, t0 = yield from region.read_slice_pipelined(
+            w0, w0 + nw, num_trans=math.ceil(nw / MEM_AXI_MAX_BURST))
         # early-anchor the output at the first-word-available time + pipeline fill: the read and
         # write OVERLAP (write_pipelined shortens its wait when the anchor is already past).
         yield from self.m_out.write_pipelined(words, t_out_start=t0 + self._fill)
@@ -364,7 +365,8 @@ class MemRStream(FreeRunComp):
             yield from self.m_out.write(np.asarray(burst))
         w0, nw = int(cmd.addr), int(cmd.len)
         region = self.m_mem.region(self._base, self._word_t, word_bw=self._mem_bw)
-        words, t0 = yield from region.read_slice_pipelined(w0, w0 + nw)
+        words, t0 = yield from region.read_slice_pipelined(
+            w0, w0 + nw, num_trans=math.ceil(nw / MEM_AXI_MAX_BURST))
         yield from self.m_out.write_pipelined(words, t_out_start=t0 + self._fill)
         self.transfer_spans.append(self.now - t_start)
 
@@ -497,7 +499,8 @@ class MemWStream(FreeRunComp):
         # bound physical base) at [addr, ...).  Region owns byte↔word (no hand conversion).
         region = self.m_mem.region(self._base, self._word_t, word_bw=self._mem_bw)
         yield from region.write_slice_pipelined(
-            w0, words, t_out_start=t0 + self._fill, element_type=self._word_t)
+            w0, words, t_out_start=t0 + self._fill, element_type=self._word_t,
+            num_trans=math.ceil(nw / MEM_AXI_MAX_BURST))
         self.transfer_spans.append(self.now - t_start)
         if self.emit_done:
             complete = self._complete_cls(len=nw, xfer_len=int(cmd.xfer_len), xfer_msg=cmd.xfer_msg)
@@ -532,7 +535,8 @@ class MemWStream(FreeRunComp):
         words, t0 = yield from self.s_in.get_pipelined(self._word_t, count=nw)
         region = self.m_mem.region(self._base, self._word_t, word_bw=self._mem_bw)
         yield from region.write_slice_pipelined(
-            w0, words, t_out_start=t0 + self._fill, element_type=self._word_t)
+            w0, words, t_out_start=t0 + self._fill, element_type=self._word_t,
+            num_trans=math.ceil(nw / MEM_AXI_MAX_BURST))
         self.transfer_spans.append(self.now - t_start)
         if self.emit_done:
             for burst in fwd:

--- a/waveflow/hw/memif.py
+++ b/waveflow/hw/memif.py
@@ -899,7 +899,7 @@ class Region:
                 elements, et, self.byte_of(i0), word_bw=self.word_bw, t_out_start=t_out_start)
         else:
             t0, t1 = yield from self.master.write_spanned(
-                elements, et, self.byte_of(i0),
+                elements, et, self.byte_of(i0), word_bw=self.word_bw,
                 t_out_start=t_out_start, num_trans=num_trans, min_span=min_span)
         if self.on_transfer is not None:
             self.on_transfer("write", int(i0), nw, t0, t1)


### PR DESCRIPTION
The bus-transfer cost is a **platform** property (the m_axi adapter + memory), not an accelerator's — so it should be calibrated once and reused. The timing-calibration arc (#113–#116) closed the loop but *lumped* bus+control into the writer's per-component residual, so it wouldn't transfer to the next accelerator. This splits it out and gives it a shared home.

## What's here

- **`BusCalib(platform_dir)`** (`waveflow/calib/bus_model.py`) — fits a per-direction `span(num_trans, nwords)` model (a `LinCalibModel`), persists it to `<platform_dir>/mm_bus.json`, and returns a configured `BusTiming`. `bus_timing()` is the load-or-default: a calibrated platform inherits the law; an uncalibrated one degrades to the word_bw fallback. **A new project loads the model with no datapoints — fit once, reuse everywhere.**
- **`measure_bus_span(trace, bundle, direction)`** — the platform measurement, read **component-independently** off the m_axi port (beats grouped into per-transfer bursts by idle gaps; the median transfer's `{num_trans, nwords, span}`). A real board's DRAM latency shows here; the BFM's doesn't.
- **Wiring** — the runtime infra already existed (`BusTiming` on `MMIFSlave`, `Region` slice `num_trans`, the fallback). Added: `MemRStream`/`MemWStream` pass `num_trans=ceil(nwords/16)` (inert until a model is configured); `MemCopyTB`/`Sim` take a `platform_dir` that loads the memory's `BusTiming`.

## The split, demonstrated

With the platform bus law (`nwords + 2·(num_trans−1)`), the writer's pysim span grows **147 → 161** (the +14 burst term), so the component's residual drops **36 → 22** — the burst term moves onto the shared platform model, leaving only the 22-cycle control cost per-accelerator.

## A pre-existing bug fixed en route

`write_slice_pipelined` called `write_spanned` **without `word_bw`**, so the spanned path defaulted `word_bw=32` and **truncated 64-bit words**. Never hit before because no 64-bit design used a `bus_timing` model (the read path already passed it). mem_copy's copy is now bit-exact under the bus model, with a committed correctness guard.

## Verification

- Full non-toolchain suite at the same 6 baseline failures; `-m xsi` gate still **2908** (pysim-only change, RTL untouched).
- New: 5 `BusCalib` tests + 2 split-demonstration tests + a correctness guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)