### PR TITLE
docs(calib): document the platform-calibration system

### DIFF
--- a/docs/examples/memcpy/timing.md
+++ b/docs/examples/memcpy/timing.md
@@ -107,7 +107,8 @@ same structure appears as a two-level split in the table itself: subtract the bu
 
 Same bus law, different per-component constants. The burst term is a *platform* property of the
 `m_axi` adapter — it belongs on a [`BusTiming`](../../guide/timing/aximm.md) model shared by every
-accelerator; the constant is the component's own control cost.
+accelerator (now fit and stored by [`BusCalib`](../../guide/calib/bus_model.md)); the constant is the
+component's own control cost.
 
 ## Why this is a model, not a fit
 
@@ -117,12 +118,20 @@ the SimPy model, give the internal channels their real depth of 2, and the 30 cy
 versus 27% for a single-point fit. That is the payoff of getting the measurement window right: a
 component model calibrated in isolation that still predicts the contended system.
 
-Implementing that split in the framework — `BusTiming` on the memory slave, the fixed latency on the
-component, channel depth from the same declaration codegen uses — and automating the fit, is the next
-arc. See [`plans/memcpy_timing_calibration.md`](https://github.com/sdrangan/waveflow/tree/main/plans/memcpy_timing_calibration.md).
+## This split is now the calibration system
+
+Everything on this page — the platform bus term, the per-component control constant, the
+uncontended-only measurement window, the fit — is now framework machinery, not a one-off analysis. The
+burst term is fit and shared by [`BusCalib`](../../guide/calib/bus_model.md); the component constant is a
+[`StreamTimingModel`](../../guide/calib/component_residual.md) residual; both are stored in a
+[platform library](../../guide/calib/platform.md) keyed by FPGA part + clock and promoted from an
+untracked work dir by [`publish_calib`](../../guide/calib/workflow.md). In fact the writer residual in
+the reference `zynq7020_bfm_100mhz` platform is fit from exactly these mem_copy numbers. See the
+[Calibration guide](../../guide/calib/) for the whole system.
 
 ## See also
 
+- [Calibration](../../guide/calib/) — the two-level split, generalized and automated
 - [Tracing a kernel run](../../guide/timing/trace_steps.md) — the four steps, in general
 - [Trace pitfalls](../../guide/timing/trace_pitfalls.md) — the three traps this relied on avoiding
 - [RTL simulation](./rtlsim.md) — the run this instruments

--- a/docs/guide/build/corecomp.md
+++ b/docs/guide/build/corecomp.md
@@ -10,7 +10,7 @@ This page is the reference for everything the build framework exports from [wave
 
 | Class / function | Purpose |
 |---|---|
-| `BuildConfig` | Per-build settings: root directory, Vitis version, free-form `params` dict |
+| `BuildConfig` | Per-build settings: root directory, Vitis version, calibration platform, free-form `params` dict |
 | `BuildArtifact` (ABC) | Base for `FileArtifact` and `ObjectArtifact` |
 | `FileArtifact` | A file on disk; freshness via mtime |
 | `ObjectArtifact` | An in-memory Python object; freshness via creation timestamp |
@@ -34,13 +34,28 @@ from pathlib import Path
 config = BuildConfig(
     root_dir="path/to/project",      # all relative paths are resolved against this
     vitis_version="2025.1",          # affects which compatibility files codegen emits
-    params={"clk_freq": 100e6, "nsamp": 100},   # free-form, consumed by steps via params
+    platform="zynq7020_bfm_100mhz",  # the calibration platform (part + clock identity)
+    part="xc7z020clg484-1",          # this build's FPGA part — confirmed against the platform
+    clk_freq=100e6,                  # synthesis clock (Hz); its period drives HLS scheduling
+    params={"nsamp": 100},           # free-form, consumed by steps via params
 )
 ```
 
 - `root_dir` defaults to `Path.cwd()`. Absolute paths in step `produces` declarations are used as-is; relative paths are joined with `root_dir`.
 - `vitis_version` is parsed into `(major, minor)` via `config.vitis_version_tuple()`. `None` means "be conservative" — `config.needs_legacy_streamutils_cpp()` returns `True` in that case so `StreamUtilsStep` also writes `streamutils.cpp`.
 - `params` is a free-form dict. Steps that declare a key in their `params` class attribute can read its value out of `config.params` at run time (see [BuildStep.params](#params) below).
+
+### Platform selection
+
+`platform` names a [calibration platform](../calib/platform.md) — the FPGA part + synthesis clock the build targets and calibrates for. When set, it is resolved at construction into `config.platform_info` (a `Platform`): an absent platform is created and **seeded** with `part` / `clk_freq`; an existing one is **confirmed** against them.
+
+- `platform` — the platform name (a directory under `platforms_root`). `None` (default) = no platform: components degrade to the plain per-word timing.
+- `part` — the `set_part` string, e.g. `"xc7z020clg484-1"`.
+- `clk_freq` — synthesis clock in Hz. Its *period* drives HLS scheduling, so it (with the part) determines the cycle counts — this is why a platform is keyed by both.
+- `platforms_root` — where platform directories live; defaults to `calib/platforms` (the tracked library).
+- `allow_platform_mismatch` — when the selected platform's stored part/clock differ from this build's, warn instead of raising `PlatformMismatchError` (default `False` = raise).
+
+`config.platform_info` is the single source both the calibration steps and codegen read — codegen's `set_part` / `create_clock` come from it (via `tcl_target`), so the synthesised part cannot drift from the calibrated one. See [Platforms](../calib/platform.md).
 
 ---
 

--- a/docs/guide/calib/bus_model.md
+++ b/docs/guide/calib/bus_model.md
@@ -1,0 +1,115 @@
+---
+title: The bus-transfer model
+parent: Calibration
+nav_order: 3
+audience: python
+api: [BusCalib, BusTiming, CalibBusStep]
+summary: "BusCalib fits the platform's m_axi transfer law — span(num_trans, nwords) per direction — and stores it in mm_bus.json beside the platform manifest. The datapoints are measured component-independently off the memory port (measure_bus_span groups beats into transfers by idle gaps); a sweep accumulates a per-run corpus (add_run -> points/) then fits. bus_timing() hands back a configured BusTiming the memory slave charges during pysim, or an unconfigured one (word_bw fallback) on an uncalibrated platform. CalibBusStep automates it as a DAG step."
+---
+# The bus-transfer model
+
+The first level of the [two-level split](./index.md#two-levels-what-is-a-platform-property-what-is-a-component-property):
+how long the `m_axi` interconnect takes to move `n` words in `k` bursts. This is a property of the
+**platform** — the memory system and AXI adapter — so it is fit **once** and every accelerator on that
+platform reuses it. `BusCalib` is that fit; `mm_bus.json` is where it lands.
+
+## The law
+
+A contiguous transfer of `n` words is issued as `k = ceil(n / MEM_AXI_MAX_BURST)` bursts (HLS's
+`max_burst_length` is 16). `BusCalib` fits a per-direction span from those two features:
+
+```
+span(num_trans, nwords)  =  a·num_trans  +  b·nwords  +  c        # cycles
+```
+
+On the reference BFM platform the measured laws are `nwords + (num_trans − 1)` (read) and
+`nwords + 2·(num_trans − 1)` (write) — one cycle per word, plus a per-burst-boundary gap read straight
+off the trace. The intercept and coefficients capture whatever the *real* interconnect does; an
+idealized BFM gives these clean laws, a real DDR controller would widen them — which is the point of
+*measuring* rather than assuming.
+
+## Measuring, component-independently
+
+The bus law is read off the **memory port**, not any kernel's firing — so it is genuinely a platform
+property, independent of which accelerator generated the traffic. `measure_bus_span` does this:
+
+```python
+from waveflow.calib.bus_model import measure_bus_span
+
+point = measure_bus_span(bound_trace, "gmem1", "write")
+# -> {"num_trans": 32, "nwords": 512, "span": 574}
+```
+
+It samples the bundle's AR/AW/R/W handshakes from the trace, groups the beats into per-transfer runs by
+idle gaps (a gap wider than `idle_gap` ends a transfer), and returns the **median** transfer's
+`{num_trans, nwords, span}`. Measuring one transfer — not the whole run — keeps inter-firing idle out of
+the bus span.
+
+## Fitting and storing
+
+`BusCalib` accumulates a per-run corpus across a sweep, then fits:
+
+```python
+from waveflow.calib.bus_model import BusCalib
+
+bus = BusCalib(platform_dir="calib/work/zynq7020_bfm_100mhz", clk_freq=100e6)
+bus.add_run("n128", write={"num_trans": 8,  "nwords": 128, "span": 142})   # -> points/n128.json
+bus.add_run("n512", write={"num_trans": 32, "nwords": 512, "span": 574})   # -> points/n512.json
+bus.fit()                                                                  # no args -> read the corpus
+```
+
+- `add_run(run_id, read=…, write=…)` writes one distilled `points/<run_id>.json` — a re-run overwrites
+  its own point, so the corpus is concurrency-safe and a sweep is `add_run`-per-size then one `fit()`.
+- `fit()` with no arguments reads the accumulated corpus; `fit(read_points=…, write_points=…)` takes
+  points directly (the one-shot case). A direction with no points is simply absent — a write-only
+  accelerator calibrates only the write channel.
+- The result is written to `mm_bus.json`:
+
+```json
+{ "clk_freq": 100000000.0, "basis": ["num_trans", "nwords"],
+  "models": { "read":  { "num_trans": 0.066, "nwords": 1.058, "intercept": -1.0 },
+              "write": { "num_trans": 0.070, "nwords": 1.121, "intercept": -2.0 } } }
+```
+
+A bus law needs **≥2 distinct sizes** to fit the slope, so a sweep is the natural unit. (With only two
+*proportional* sizes `num_trans` and `nwords` are collinear — see the
+[workflow&#39;s note](./workflow.md#a-known-limitation-collinear-sizes).)
+
+## Deploying: `bus_timing()`
+
+The calibration side fits and persists; the *runtime* side is a `BusTiming` the memory slave consults
+during pysim. `bus_timing()` bridges them — `load_or_default`:
+
+```python
+bt = BusCalib(platform_dir="calib/platforms/zynq7020_bfm_100mhz").bus_timing()
+```
+
+- On a **calibrated** platform it returns a `BusTiming` configured from `mm_bus.json`, so pysim charges
+  the real burst cost.
+- On an **uncalibrated** platform (no `mm_bus.json`) it returns an *unconfigured* `BusTiming` — both
+  directions `None` — so a slice degrades to the plain per-word span rather than crashing.
+
+Charging the bus term in pysim is what lets the [component residual](./component_residual.md) shrink to
+the component's own control cost: on the reference platform the writer's residual drops from ~36
+(bus + control lumped) to ~22 (control only), and the 14-cycle burst term moves onto this shared model.
+
+## Automating it: `CalibBusStep`
+
+In a build DAG, `CalibBusStep` does the measure → `add_run` → refit loop from a traced run — no design
+factory, because the bus law is in the trace, not a pysim run:
+
+```
+… -> RtlSimStep -> trace (manifest + vcd) -> CalibBusStep   (per m_axi bundle: measure_bus_span -> add_run -> fit)
+```
+
+It consumes the [trace manifest + VCD](../timing/trace_steps.md), walks each boundary `m_axi` bundle,
+measures the direction(s) it carries, adds the run to the platform corpus, and refits `mm_bus.json`.
+Across a sweep (one step per size) the corpus grows until the model fits.
+
+## See also
+
+- [Platforms](./platform.md) — where `mm_bus.json` lives and how the platform is keyed.
+- [Component residuals](./component_residual.md) — the second level, which assumes the bus term is
+  already charged.
+- [`BusTiming` / AXI-MM timing](../timing/aximm.md) — the runtime model the slave applies.
+- [Tracing a kernel run](../timing/trace_steps.md) — where `measure_bus_span`'s input comes from.

--- a/docs/guide/calib/component_residual.md
+++ b/docs/guide/calib/component_residual.md
@@ -1,0 +1,126 @@
+---
+title: Component residuals
+parent: Calibration
+nav_order: 4
+audience: python
+api: [TimingModel, StreamTimingModel, CollectTimingStep, FitTimingStep]
+summary: "A component's control residual is the delay pysim is MISSING once the bus term is charged: residual = rtl_span - pysim_span + current_dly, fit per (component, platform). TimingModel collects RTL firings (from a trace) and pysim firings (from a run) into independent trees, joins them on the feature point (nwords, num_trans), and fits a CalibModel; predict() returns the delay a FreeRunComp injects via timed_delay. Stored shared (platform_dir -> the committed library) or custom (calib_dir -> a project dir). CollectTimingStep / FitTimingStep automate it."
+---
+# Component residuals
+
+The second level of the [split](./index.md#two-levels-what-is-a-platform-property-what-is-a-component-property):
+once the [bus term](./bus_model.md) is charged, what remains is the component's own **control cost** —
+the per-firing overhead the loosely-timed pysim does not already account for. A `TimingModel` fits that
+remainder and a `FreeRunComp` injects it.
+
+## The residual is what pysim *misses*
+
+Crucially, the fitted quantity is not the component's *total* control cost — it is the **residual**
+between what the RTL did and what pysim already predicts:
+
+```
+residual = rtl_span − pysim_span + current_dly        # all in cycles
+```
+
+The `+ current_dly` corrects for whatever delay the model *already* injected on that run, so the fit is
+self-correcting: any run is a datapoint (no model-disabled baseline needed), and online calibration
+converges from a zero seed. Because pysim already models the fill and the overlapped drain, the residual
+is small — on the reference platform the writer's is ~22 cycles, even though its *total* control cost
+measured in RTL is ~41; pysim was already accounting for the rest.
+
+## Where the model lives
+
+A calibrated component **carries its own** `StreamTimingModel` — `MemWStream.__post_init__` creates it
+and calls `add_timing_model`, so during a run the component *predicts* its delay through that attached
+instance (via `timed_delay`) and accumulates `firing_records` on it. But the corpus and fitted params
+live **on disk**, keyed by `calib_dir` — the object itself is almost stateless.
+
+That means collection and fitting can be done by *either* the component's attached instance — what the
+[DAG steps](#automating-it-collecttimingstep--fittimingstep) do, reaching it via
+`discover_timing_models(design)` — *or* a **separate** `StreamTimingModel` pointed at the same
+`calib_dir`. The directory is the coordination point: the component-side instance predicts, a
+calibration-side instance fits, and the two never need to be the same object. (This is how
+`calibrate_platform.py` works — the run attaches one model to the writer, and the driver holds a second
+at the same dir to collect and fit.)
+
+## Collect, join, fit
+
+RTL and pysim are collected **independently** — different cadence (RTL is synthesis-expensive, pysim is
+every-edit-cheap) — into `rtl/` and `pysim/` trees, then joined at fit time on the **feature point**
+(`nwords`, `num_trans`), not the run id. Here from a standalone instance (the DAG steps do the same
+calls on the component's attached one):
+
+```python
+from waveflow.calib.timing_model import StreamTimingModel
+from waveflow.hw.clock import Clock
+
+tm = StreamTimingModel(component="mem_w_stream_framed_done_task",
+                       calib_dir="…/components/mem_w_stream_framed_done_task", clk=Clock(freq=100e6))
+
+for nw in (128, 512):
+    tm.collect_rtl(events, run_id=f"n{nw}")                 # one row per firing, from ExtractBurstsStep
+    tm.collect_pysim(writer.firing_records, run_id=f"n{nw}")  # writer = the calibrated component, run with the bus law active
+tm.fit()                                                    # -> corpus.csv + params.json
+```
+
+- **`collect_rtl`** filters an [`ExtractBurstsStep`](../timing/trace_steps.md) events dict to this
+  component's firings. Only *uncontended* firings are calibratable — `is_record_valid` (default
+  `blocked == 0`) drops any firing that stalled on a full downstream channel, because that measured
+  contention, not the component's own cost.
+- **`collect_pysim`** records the firings a pysim run populated (via `timed_delay`, below). Spans arrive
+  in time and are divided by `clk.period` to cycles, so the stored corpus is all-cycles and
+  clock-independent.
+- **`gen_data_frame`** joins them into `corpus.csv` — `features… | span_rtl | span_pysim | current_dly | residual` — and records `coverage` (`matched` / `rtl_only` / `pysim_only` feature points), so a thin
+  fit is a *visible* gap, not a silent one.
+- **`fit`** fits a `CalibModel` residual and writes `params.json`; it **raises** if nothing joined, so a
+  no-op can't leave a seed model looking fitted. `predict(row)` returns the additional delay (length
+  `num_targets`, default 1), clamped at 0. `reset(corpus=…, params=…)` wipes the trees / the fit to
+  recalibrate from scratch.
+
+> **The `run_iter` side** — attaching the model and charging its delay with `timed_delay` — is covered
+> in [Adding a timing model to a component](./insertion.md); the `firing_records` that page's
+> `timed_delay` accumulates are exactly the pysim corpus `collect_pysim` reads. `MemRStream` /
+> `MemWStream` both carry that hook (the writer's is the posted-write drain, the reader's its own
+> control cost), inert until a model is fit.
+
+## Two kinds of component: where the residual lives
+
+The fit is identical; only the storage scope differs (the
+[two kinds](./index.md#two-kinds-of-component-shared-infra-vs-custom)):
+
+|                        | Shared-infra component                   | Custom component                      |
+| ---------------------- | ---------------------------------------- | ------------------------------------- |
+| e.g.                   | `MemRStream`, `MemWStream`           | your accelerator's kernel             |
+| stored in              | the committed**platform library**  | a**project-local dir you pick** |
+| selected by            | `platform_dir` (keyed by task-body id) | an explicit`calib_dir`              |
+| reused across projects | yes — no recalibration                  | no — specific to your design         |
+
+Both mem-streams take both knobs; `_resolve_calib_dir` gives `calib_dir` precedence (the project-local
+override) and otherwise resolves `platform_dir` into `<platform>/components/<task-body>/`. Neither set
+→ uncalibrated.
+
+## Automating it: `CollectTimingStep` / `FitTimingStep`
+
+In a build DAG these two steps drive collection and fitting from a **design factory** — a callable
+returning the built (and, for collect, pysim-run) component tree — so they are generic and never mention
+a particular design:
+
+```
+ExtractBurstsStep -> CollectTimingStep   (collect_rtl + collect_pysim for every attached model)
+                  -> FitTimingStep        (fit each from its corpus; skip, not fail, the ones that don't yet join)
+```
+
+`CollectTimingStep` appends one run's RTL + pysim firings to every attached model's corpus;
+`FitTimingStep` fits each from the accumulated corpus, **skipping with a report** any model whose corpus
+does not yet join (a sweep in progress has partial coverage — forcing a fit there would only raise).
+`discover_timing_models` walks the component tree to find which models to collect for.
+
+## See also
+
+- [Adding a timing model to a component](./insertion.md) — the usage side: attaching the model and
+  charging its delay, which this page fits.
+- [The bus-transfer model](./bus_model.md) — the level this one assumes is already charged.
+- [Platforms](./platform.md) — where a shared component's residual is keyed and stored.
+- [The calibration workflow](./workflow.md) — collecting a sweep and publishing the result.
+- [Tracing a kernel run](../timing/trace_steps.md) — the `ExtractBurstsStep` firing table `collect_rtl`
+  reads, including the `blocked` column and the ap_done window.

--- a/docs/guide/calib/dataframe.md
+++ b/docs/guide/calib/dataframe.md
@@ -1,7 +1,7 @@
 ---
 title: The corpus — CalibDataFrame
 parent: Calibration
-nav_order: 1
+nav_order: 6
 audience: python
 api: [CalibDataFrame]
 summary: "CalibDataFrame is the calibration corpus: a thin wrapper composing a pandas.DataFrame, one row per synth/cosim measurement. It adds only what a raw frame lacks — a per-row measured_at timestamp and a save/load storage path — and otherwise exposes the underlying frame as .df for native pandas filter/select."

--- a/docs/guide/calib/example.md
+++ b/docs/guide/calib/example.md
@@ -1,7 +1,7 @@
 ---
 title: A worked example
 parent: Calibration
-nav_order: 3
+nav_order: 8
 audience: python
 api: [CalibDataFrame, LinCalibModel, InterpCalibModel]
 summary: "A minimal end-to-end calibration: build a CalibDataFrame from a few (size, cycles) measurements, fit a LinCalibModel, read its coefficients, score it, hold a point out, and plot it; then calibrate a saturating curve with InterpCalibModel."

--- a/docs/guide/calib/index.md
+++ b/docs/guide/calib/index.md
@@ -4,65 +4,132 @@ parent: Guide
 nav_order: 12
 has_children: true
 audience: python
-api: [CalibDataFrame, CalibModel, LinCalibModel, InterpCalibModel]
-summary: "The waveflow.calib package: a small, reusable corpus + model layer for fitting physically-reasonable timing and resource models from synth/cosim measurements. A CalibDataFrame holds one row per measurement; per-target models (LinCalibModel, InterpCalibModel) fit, predict, score, and report held-out error — deliberately a DataFrame wrapper plus sklearn/interp models, not an ML framework."
+api: [CalibDataFrame, CalibModel, LinCalibModel, InterpCalibModel, BusCalib, StreamTimingModel, Platform, PlatformCalib]
+summary: "The waveflow.calib package: fit physically-reasonable timing models from synth/cosim measurement so the fast loosely-timed sim tracks the slow RTL. A CalibModel / CalibDataFrame layer holds the corpus and fits one target; on top of it a two-level split calibrates the m_axi bus law once per PLATFORM (BusCalib) and each reusable component's control residual per (component, platform) (StreamTimingModel), stored in a git-tracked platform library keyed by an FPGA-part identity (Platform / platform.json) and promoted from an untracked work dir by publish_calib."
 ---
 
 # Calibration
 
 A Waveflow component's timing model is **loosely-timed** (see [Timing Models](../timing_model/)): it
-predicts a timeline from a few numbers — a latency, an initiation interval, a per-row depth. Those
+predicts a timeline from a few numbers — a latency, an initiation interval, a per-transfer cost. Those
 numbers are properties of the *synthesized* hardware. **Calibration** is the discipline of *fitting
 them from measurement* — running the kernel through synthesis or RTL cosim at a range of sizes,
-recording the resulting cycle counts (and resource usage), and fitting a model so the fast LT
-simulation tracks the slow RTL without you transcribing report numbers by hand.
+recording the resulting cycle counts, and fitting a model so the fast LT simulation reproduces the slow
+RTL without you transcribing report numbers by hand.
 
-The same machinery calibrates **timing** (cycles vs. size) and **resources** (LUT/FF/BRAM vs. a
-parameter) — both are "fit a small model to a table of measurements."
+## Two levels: what is a platform property, what is a component property
 
-The `waveflow.calib` package is deliberately **bare-bones**: a thin `pandas.DataFrame` wrapper for the
-corpus, plus sklearn-backed and interpolation models with held-out-error / R² / plot helpers. It is
-*not* an ML framework — the models are small and physically motivated.
-
-## The workflow
+The cost of a run splits into two parts that live at two different scopes:
 
 ```
-synth / cosim sweep   →   CalibDataFrame   →   fit a per-target model   →   predict in the LT sim
- (one row per run)        (the corpus)         (Lin / Interp)               (and validate held-out)
+        RTL cycles  =  bus transfer  +  component control
+                        └─ PLATFORM ─┘   └── COMPONENT ──┘
+                        (the m_axi law,   (this kernel's own
+                         shared by every   overhead, per
+                         accelerator)       component + platform)
 ```
 
-1. **Measure.** Run the kernel at several sizes; each run is one datapoint (features like `n_row`,
-   `n_col`, and measured targets like `cycles` or `bram`).
-2. **Collect** the runs into a `CalibDataFrame` — the structured corpus, one row per measurement.
-3. **Fit** a [model](./models.md) per target. Targets have different shapes, so each gets its own
-   model (a linear fit for an affine cycle count, a calibrated lookup for a saturating curve).
-4. **Predict** inside the component's timing model, and **validate** on a held-out point so you know
-   the fit *generalizes* rather than memorizes.
+- The **bus transfer** — how long the `m_axi` interconnect takes to move `n` words in `k` bursts — is
+  a property of the **platform** (the memory system + AXI adapter), not of any one accelerator. Fit it
+  **once per platform** and every accelerator on that platform reuses it. This is [`BusCalib`](./bus_model.md).
+- The **component control** cost — the kernel's own per-firing overhead once the bus term is charged —
+  is a property of the **`(component, platform)`** pair. This is the residual a
+  [`StreamTimingModel`](./component_residual.md) fits, stored *with* the platform so the next project
+  reusing the component inherits it.
+
+Splitting them means a new accelerator loads the platform's bus law for free and fits only its own
+small residual — instead of re-measuring the interconnect every time.
+
+## Two kinds of component: shared infra vs custom
+
+The component-control residual is fit the *same way* for two kinds of component — they differ only in
+**where the fitted data lives**:
+
+- **Shared-infra components** — the reusable framework kernels (`MemRStream` / `MemWStream`, and more
+  to come). Their residual is a `(component, platform)` property, so it is stored in the **committed
+  platform library** and shipped with the repo: reuse the component on a calibrated platform and you
+  inherit its timing with **no re-calibration**.
+- **Custom components** — your accelerator's own kernels. Their residual is specific to your design,
+  not shared infra, so it is stored in a **project-local directory you choose** (typically beside the
+  component).
+
+The package serves both through one knob: a component takes a `platform_dir` (resolve into the shared
+library, keyed by the component id) *or* an explicit `calib_dir` (your project-local path, which wins
+if both are given). [The bus law](./bus_model.md) sits above this split — it is always platform-scoped,
+because it is the shared interconnect, owned by no single component.
+
+## One calibration layer
+
+`BusCalib` and `StreamTimingModel` are the **same underlying fit** — a [`CalibModel`](./models.md) over
+a corpus — wrapped with the collection, storage, and scoping each level needs. They differ only in what
+they attach to (the shared `m_axi` interface vs. a `FreeRunComp`) and at what scope they are stored
+(platform vs. component). A single timing model attachable to *any* `SimObj`, with `FreeRunComp`
+specialization, is a natural future unification; today the two entry points cover the cases that exist,
+and the platform-vs-component scoping is intrinsic — the bus is a shared resource — not an accident of
+having two classes.
+
+## Everything is in cycles
+
+The fitted numbers are stored in **cycles**, not seconds, so `params.json` is clock-independent — a
+re-deploy at a different simulation frequency needs no refit. The sim `Clock` is only a cycles ↔
+seconds converter at the boundary. The one clock that *does* change the numbers is the **synthesis**
+clock (`create_clock -period`): HLS schedules to meet it, so a different target period can change the
+cycle counts. That is why a platform is keyed by part **and** clock — see [Platforms](./platform.md).
+
+## The platform library
+
+A calibrated platform is a directory keyed by an FPGA-part identity, holding both levels:
+
+```
+calib/platforms/<name>/
+    platform.json                     # identity: {part, clk_freq_hz}   (Platform)
+    mm_bus.json  +  points/            # the bus-transfer law            (BusCalib)
+    components/<task-body>/            # a component's control residual  (StreamTimingModel)
+        params.json  +  corpus.csv
+```
+
+Calibration data is **two-tier**: sweeps write a churny, untracked `calib/work/<name>/`; only the
+`publish_calib` command promotes the stable artifacts into the tracked `calib/platforms/<name>/`. So a
+stray run can never clobber shared parameters, and a deterministic re-fit produces no git diff. See
+[The calibration workflow](./workflow.md).
 
 ## The pieces
 
-The corpus and the models are documented on their own pages. In brief: the corpus is a
-[`CalibDataFrame`](./dataframe.md) — a thin `pandas.DataFrame` wrapper holding one timestamped row per
-synth/cosim measurement; the [models](./models.md) fit a single target (e.g. `cycles`) from a basis of
-its columns.
+The corpus and the single-target models are the primitive layer the two levels compose over: the
+corpus is a [`CalibDataFrame`](./dataframe.md) — a thin `pandas.DataFrame` wrapper, one row per
+measurement — and the [models](./models.md) fit one target (e.g. `cycles`) from a basis of its columns.
+The [bus model](./bus_model.md) and [component residuals](./component_residual.md) build on them with
+the collection, storage, and scoping that turn a raw sweep into a reusable, checked-in library.
 
 ## In this section
 
-- [The corpus — `CalibDataFrame`](./dataframe.md) — one timestamped row per measurement, a
-  `pandas.DataFrame` under `.df`, with `save` / `load`.
-- [Models](./models.md) — the per-target fit / predict / score interface (`CalibModel`), the linear
-  model (`LinCalibModel`), and the calibrated lookup (`InterpCalibModel`).
-- [A worked example](./example.md) — fit a line to `(size, cycles)`, score it, plot it, hold a point
-  out; then a saturating curve with `InterpCalibModel`.
-- [Instrumenting a calibration](./instrumentation.md) — the playbook for collecting *real* data:
-  where to log events in the sim, how to extract timing from a cosim sweep, and how to feed the
-  fitted model back in (worked against the FIR example).
+The platform-calibration system, then the primitive layer it composes over:
+
+- [Adding a timing model to a component](./insertion.md) — usage-first: where a `TimingModel` plugs
+  into a `FreeRunComp`, how `timed_delay` charges the delay, and why read-stalls emerge from the sim
+  rather than the model.
+- [Platforms](./platform.md) — the platform identity (`platform.json`, `Platform`), why a platform is
+  keyed by FPGA part **and** synthesis clock, and how `BuildConfig` selects and confirms one.
+- [The bus-transfer model](./bus_model.md) — `BusCalib`: the `m_axi` span law fit once per platform
+  (`mm_bus.json`), measured component-independently off the ports (`measure_bus_span`).
+- [Component residuals](./component_residual.md) — `StreamTimingModel`: fitting the model you attached,
+  per `(component, platform)`, with the bus term already charged.
+- [The calibration workflow](./workflow.md) — the two-tier `work` → `publish_calib` → `platforms`
+  flow, the DAG steps that populate it, and the reference `zynq7020_bfm_100mhz` platform end to end.
+- [The corpus — `CalibDataFrame`](./dataframe.md) — the primitive corpus: one timestamped row per
+  measurement, a `pandas.DataFrame` under `.df`, with `save` / `load`.
+- [Models](./models.md) — the primitive per-target fit / predict / score interface (`CalibModel`), the
+  linear model (`LinCalibModel`), and the calibrated lookup (`InterpCalibModel`).
+- [A worked example](./example.md) — the primitive layer alone: fit a `LinCalibModel` to
+  `(size, cycles)`, score it, hold a point out; then a saturating curve with `InterpCalibModel`.
+- [Instrumenting a calibration](./instrumentation.md) — the playbook for collecting *real* data and
+  closing the LT-vs-RTL loop (worked against the FIR example).
 
 ## See also
 
-- [Fitting a timing model](../timing_model/fit.md) — the conceptual fit (recovering `latency` / `ii`
-  from a line) that `LinCalibModel` performs.
 - [Timing Analysis Tools](../timing/) — the *measurement* side: extracting cycle counts and bus spans
   from a VCD / cosim run (where the datapoints come from).
-- [`examples/rowwise_fir`](../../../examples/rowwise_fir/fir_calibrate.py) — the richest worked case:
-  a physical, near-fit-free decomposition with a single calibrated `InterpCalibModel` curve.
+- [Fitting a timing model](../timing_model/fit.md) — the conceptual fit (recovering `latency` / `ii`
+  from a line) that `LinCalibModel` performs.
+- [`BuildConfig`](../build/corecomp.md) — the `platform` / `part` / `clk_freq` selector that names the
+  platform a build synthesizes and calibrates for.

--- a/docs/guide/calib/insertion.md
+++ b/docs/guide/calib/insertion.md
@@ -1,0 +1,108 @@
+---
+title: Adding a timing model to a component
+parent: Calibration
+nav_order: 1
+audience: python
+api: [TimingModel, FreeRunComp, FreeRunComp.add_timing_model, FreeRunComp.timed_delay]
+summary: "Where a timing model plugs into a component, usage-first — before any fitting. A FreeRunComp attaches a TimingModel in __post_init__ and, in run_iter, charges the delay it predicts with self.timeout. The model adds only this component's OWN compute/control cost; waiting on inputs and downstream backpressure emerge from the simulation itself, so a model fit in isolation still predicts the contended system. timed_delay is the one-call idiom that predicts AND records the firing for later fitting; an unfitted model predicts 0, so attaching one is a no-op until calibrated."
+---
+
+# Adding a timing model to a component
+
+The [forward timing models](../timing_model/) predict a component's timeline from a few numbers —
+`latency`, `ii`, a per-transfer cost. On those pages the numbers are set by hand. This page is the
+other half: how a component **sources that delay from a model object** attached to it, so the numbers
+can later be [fit from measurement](./component_residual.md) instead of transcribed. We show the usage
+first — where it plugs in and what it does — before any fitting.
+
+## Where it plugs in
+
+A `FreeRunComp` runs a `run_iter` loop: read inputs, compute, write outputs. In pysim the *compute*
+takes no simulated time — the value is produced instantly — so the component must **charge the time
+that computation would take in hardware**. A timing model turns a description of the firing (how many
+words, how many bursts) into that delay.
+
+It attaches in `__post_init__` and is called in `run_iter`:
+
+```python
+from waveflow.calib.timing_model import TimingModel
+from waveflow.hw.hw_freerun import FreeRunComp
+
+class MyCompute(FreeRunComp):
+    def __post_init__(self):
+        super().__post_init__()
+        # ... declare ports: s_cmd, m_mem, m_out ...
+
+        # attach a timing model — features describe a firing, the target is the added delay
+        self.tm = TimingModel(component="my_compute", calib_dir=self.calib_dir,
+                              features=["nwords"], clk=self.clk)
+        self.add_timing_model(self.tm)
+
+    def run_iter(self):
+        cmd = yield from self.s_cmd.get(MyCmd)     # blocks until a command arrives
+        x   = yield from self.m_mem.read(cmd.addr, cmd.n)   # blocks on the read
+
+        y = compute(x)                             # the value — computed instantly in pysim
+
+        # charge the time the compute would take in hardware
+        yield self.timeout(self.timed_delay({"nwords": cmd.n}))
+
+        yield from self.m_out.write(y)             # blocks if the downstream FIFO is full
+```
+
+## What the delay is — and what it is *not*
+
+This is the point that makes the whole approach work: the model adds **only this component's own
+compute/control cost**. It does **not** model waiting on inputs or downstream backpressure — those
+**emerge from the simulation itself**:
+
+- `s_cmd.get()` blocks until a command actually arrives.
+- `m_mem.read()` blocks for the [bus transfer](./bus_model.md) and any contention on the shared memory.
+- `m_out.write()` blocks when the downstream FIFO is full.
+
+So a firing that stalls waiting on the read or a full output is *the simulation* modeling congestion,
+not the timing model. The model's job is just the extra delay of *this* component's work. That is why a
+model calibrated in isolation still predicts the **contended** system — the contention is simulated, not
+baked into the model — and why fitting uses only *uncontended* firings
+([`blocked == 0`](./component_residual.md#collect-join-fit)).
+
+## `predict` vs `timed_delay`
+
+There are two ways to call it, and the difference is *recording*:
+
+```python
+# explicit: predict the delay and charge it
+dly = self.tm.predict({"nwords": cmd.n})[0]
+yield self.timeout(dly)
+
+# the idiom: predict AND record this firing (features + the delay) for later fitting
+yield self.timeout(self.timed_delay({"nwords": cmd.n}))
+```
+
+`timed_delay` is the one you want: it predicts through the attached model *and* appends the firing to
+`self.firing_records`, which is the corpus a [fitting](./component_residual.md) run collects. `predict`
+alone just returns the number. Call `timed_delay` unconditionally — with no model attached it returns
+`0.0` and records nothing, so it is a no-op on an uncalibrated component.
+
+## Cycles vs. time
+
+Internally the model works in **cycles** — that is what keeps its fitted parameters clock-independent
+(see [the index](./index.md#everything-is-in-cycles)). Because it carries `clk`, `predict` /
+`timed_delay` convert to *time* for you, so the result drops straight into `self.timeout`. (Without a
+`clk` the model returns cycles, and you scale by `self.clk.period` yourself.)
+
+## Before it is fit
+
+Attaching a model does **not** require a fit. An unfitted model predicts from its seed — zero added
+delay — so the component simulates exactly as before, while `timed_delay` quietly records each firing.
+That is deliberate: you attach the model, run the sim to *collect* firings, then
+[fit](./component_residual.md) — and only then does `predict` start returning a non-zero delay. The
+mem-streams (`MemRStream` / `MemWStream`) carry exactly this hook, inert until calibrated.
+
+## See also
+
+- [Component residuals](./component_residual.md) — the next step: fitting the model you just attached.
+- [Timing Models](../timing_model/) — the forward-model shapes (block / streaming / double-buffered)
+  whose delays this sources from a fitted model.
+- [Simulation timing model](../sim/timing.md) — `Clock`, `self.timeout`, and where compute vs. transfer
+  latency is charged.

--- a/docs/guide/calib/instrumentation.md
+++ b/docs/guide/calib/instrumentation.md
@@ -1,7 +1,7 @@
 ---
 title: Instrumenting a calibration
 parent: Calibration
-nav_order: 4
+nav_order: 9
 audience: python
 api: [CalibDataFrame, InterpCalibModel, LinCalibModel]
 summary: "The calibration playbook: how to actually collect the data and close the loop so the LT simulation reproduces the RTL timeline. Instrument the sim with begin/end events at the top level, fit each block's primitive in isolation, let the sim compose the end-to-end timing, extract the datapoints from a cosim sweep, and feed the fitted model back into the component. Worked against the FIR example."

--- a/docs/guide/calib/models.md
+++ b/docs/guide/calib/models.md
@@ -1,7 +1,7 @@
 ---
 title: Models
 parent: Calibration
-nav_order: 2
+nav_order: 7
 audience: python
 api: [CalibModel, LinCalibModel, InterpCalibModel]
 summary: "The per-target calibration models. CalibModel is the fit / predict / score / holdout interface over column-name basis and target. LinCalibModel is an sklearn LinearRegression with coeffs, plot, and a through-origin knob. InterpCalibModel is a calibrated 1-D lookup (a measured table, not a curve fit) for smooth, saturating physical curves."

--- a/docs/guide/calib/platform.md
+++ b/docs/guide/calib/platform.md
@@ -1,0 +1,117 @@
+---
+title: Platforms
+parent: Calibration
+nav_order: 2
+audience: python
+api: [Platform, PlatformCalib, BuildConfig]
+summary: "A calibration platform is a named directory with an identity manifest (platform.json = FPGA part + synthesis clock) plus the fitted models valid for that target. Platform.resolve is the create-or-confirm gate: a new platform is seeded from the build's part/clock, an existing one is confirmed against them (PlatformMismatchError, or a warning under allow_platform_mismatch). BuildConfig.platform selects one; the same identity drives the csynth set_part / create_clock, so the synthesised part cannot drift from the calibrated part."
+---
+
+# Platforms
+
+A calibrated timing model is only valid for the hardware it was measured on. **What counts as "the
+hardware"** — the thing you fix, calibrate against, and then reuse — is a *platform*: an FPGA **part**,
+a **synthesis clock**, and a **memory system**. A `Platform` bundles that identity with the fitted
+models valid for it.
+
+## Why part *and* clock (and memory)
+
+The fitted numbers are cycle counts, and three things move them:
+
+- **The part.** Different device *families* (7-series → UltraScale+ → Versal) have different primitive
+  latencies (DSP, BRAM/URAM cascades), so op latencies — and cycle counts — can shift. Within a family
+  a faster/slower speed grade usually does *not* change the schedule, as long as the part still meets
+  the target clock.
+- **The synthesis clock.** HLS schedules to meet `create_clock -period`. Tighten the period and it
+  inserts pipeline stages — so the *same* C at a different target period can synthesize to a *different*
+  cycle count on the *same* part. The clock is a first-class determinant, not a footnote.
+- **The memory system.** The `m_axi` [bus law](./bus_model.md) depends on the interconnect + memory
+  controller (an idealized BFM vs. a real DDR controller), which the part number does not capture at
+  all. This is why a platform name usually tags the memory (`..._bfm_...`).
+
+Because two of these (part, clock) fix the kernel cycles and one (memory) fixes the bus law, a platform
+is **human-named** with a manifest, not a bare part-number directory — a raw part string collides
+across clock targets and can't express the memory system.
+
+### The two clocks
+
+There are two clocks, and only one of them changes the numbers:
+
+| Clock | Role | Effect on cycles |
+|---|---|---|
+| sim `Clock(freq=…)` | cycles ↔ seconds converter at the sim boundary | none — residuals are stored in **cycles**, so a re-deploy at a new sim frequency needs no refit |
+| synthesis `create_clock -period` | the target HLS schedules to | **changes the schedule → changes the cycles** |
+
+So the platform key needs the **synthesis** clock. `Platform.synth_period_ns` is exactly the
+`create_clock -period` the TCL emits (`1e9 / clk_freq`).
+
+## The identity manifest
+
+Each platform directory opens with `platform.json`:
+
+```json
+{ "part": "xc7z020clg484-1", "clk_freq_hz": 100000000.0 }
+```
+
+This is the **one** source both synthesis and calibration read, so the synthesised part can never drift
+from the calibrated part. (Before this manifest existed, the two disagreed — codegen baked `clg484`
+while a CLI default said `clg400`.)
+
+## `Platform.resolve` — create or confirm
+
+```python
+from waveflow.calib.platform import Platform
+
+plat = Platform.resolve("calib/platforms", "zynq7020_bfm_100mhz",
+                        part="xc7z020clg484-1", clk_freq=100e6)
+```
+
+`resolve` is the gate:
+
+- **Absent** (no `platform.json`): create the directory and **seed** the manifest from the build's
+  part/clock. The platform now exists, ready to be populated by a sweep + publish.
+- **Present**: load the stored manifest and **confirm** the build's part/clock against it. A mismatch
+  raises `PlatformMismatchError`; under `allow_mismatch=True` it downgrades to a
+  `PlatformMismatchWarning`. The **stored** values — what the fit is valid for — win either way.
+
+The returned `Platform` exposes `part`, `clk_freq`, `synth_period_ns`, `dir`, and
+`component_dir(<task-body>)` — where a [component residual](./component_residual.md) is stored, keyed by
+the component's task-body id.
+
+## Selecting a platform on a build
+
+A build names its platform through [`BuildConfig`](../build/corecomp.md), which resolves it at
+construction into `config.platform_info`:
+
+```python
+config = BuildConfig(
+    root_dir="…",
+    platform="zynq7020_bfm_100mhz",   # the platform name
+    part="xc7z020clg484-1",           # this build's target — confirmed against the manifest
+    clk_freq=100e6,
+    platforms_root="calib/platforms", # default; the tracked library
+    allow_platform_mismatch=False,    # raise (default) vs warn on a part/clock mismatch
+)
+```
+
+Every step then reads `config.platform_info.dir`; nothing restates the part per-step. The same identity
+flows into codegen — `render_tcl` takes its `set_part` / `create_clock` from `config.platform_info`
+(via `tcl_target`) — so the RTL a calibration measures is synthesised for exactly the part+clock the
+platform's fit is valid for.
+
+## The reference platform
+
+`calib/platforms/zynq7020_bfm_100mhz/` is the first tracked platform: part `xc7z020clg484-1`, 100 MHz,
+idealized XSI BFM memory (hence `bfm` in the name). It is the *default* a project can reuse without
+recalibrating — accepting that if its own part differs, the cycle counts may not reproduce (the
+mismatch guard makes that a deliberate, visible choice). See
+[the workflow](./workflow.md#the-reference-platform-end-to-end) for how it was built.
+
+## See also
+
+- [The bus-transfer model](./bus_model.md) — the platform-scoped `m_axi` law that lives beside the
+  manifest.
+- [Component residuals](./component_residual.md) — the per-`(component, platform)` fits under
+  `components/`.
+- [The calibration workflow](./workflow.md) — the two-tier `work` → `publish_calib` → `platforms` flow.
+- [`BuildConfig`](../build/corecomp.md) — the `platform` / `part` / `clk_freq` selector in full.

--- a/docs/guide/calib/workflow.md
+++ b/docs/guide/calib/workflow.md
@@ -1,0 +1,105 @@
+---
+title: The calibration workflow
+parent: Calibration
+nav_order: 5
+audience: python
+api: [BusCalib, StreamTimingModel, Platform, CalibBusStep, CollectTimingStep, FitTimingStep]
+summary: "Calibration storage is two-tier: sweeps write a churny untracked calib/work/<name>/; the publish_calib command promotes the stable artifacts (platform.json, mm_bus.json, points/, component params + corpus -- never the raw firing trees) into the tracked calib/platforms/<name>/. publish is dry-run by default, a byte-compare no-op on unchanged files, and refuses a coverage regression (a thinner re-fit) unless forced. The reference zynq7020_bfm_100mhz platform is built end-to-end by examples/mem_copy/calibrate_platform.py and reproduces the writer RTL period to 0.0%."
+---
+
+# The calibration workflow
+
+Calibration parameters are **infra-wide**: once a shared component is calibrated, every project reuses
+it. That makes two things matter — a stray run must never clobber shared parameters, and a
+re-run that produces the *same* fit must not churn git. Both fall out of a **two-tier** storage split.
+
+## Two tiers: work vs. tracked
+
+```
+calib/work/<name>/        untracked (gitignored).  Sweeps, tests, and the DAG calib steps write here
+                          freely — it churns.
+        │  publish_calib
+        ▼
+calib/platforms/<name>/   tracked (committed).  The shared parameters. EXACTLY ONE writer: publish.
+```
+
+A sweep points the [`BusCalib`](./bus_model.md) / [`StreamTimingModel`](./component_residual.md) fits at
+the **work** dir. When you are satisfied, one command promotes the result into the **tracked** library.
+Because the tracked dir has a single writer, a test can't reach it; because a re-fit on the same corpus
+is deterministic, an unchanged promotion writes nothing.
+
+## `publish_calib`
+
+```bash
+publish_calib calib/work/<name> calib/platforms/<name>            # dry-run: print the plan, write nothing
+publish_calib calib/work/<name> calib/platforms/<name> --apply    # write only the changed files
+```
+
+- **Dry-run by default.** It prints a plan — `+ created`, `~ updated`, `= unchanged` — and writes
+  nothing. `--apply` performs it.
+- **No-op when unchanged.** Each artifact is byte-compared against the tracked copy; identical files are
+  never rewritten, so a deterministic re-publish produces **0 files written** and no git diff.
+- **Only the stable artifacts** are promoted; the churny raw firing trees stay behind:
+
+  | Published | Left in the work dir |
+  |---|---|
+  | `platform.json` (identity) | `components/<c>/rtl/` |
+  | `mm_bus.json` + `points/*.json` | `components/<c>/pysim/` |
+  | `components/<c>/params.json` + `corpus.csv` | |
+
+- **Coverage-regression guard.** publish refuses (exit 1) to replace a fit with one built from *fewer*
+  datapoints — bus point files, or a component's `corpus.csv` rows — so a thin re-sweep can't silently
+  clobber a richer library. `--force` overrides it.
+
+Under the hood `build_plan(work, tracked)` computes the plan (pure inspection) and `apply_plan(plan,
+force=…)` writes the changed files; the CLI is a thin wrapper.
+
+### Why publish is not a DAG step
+
+Promotion to shared infra is a deliberate "I'm satisfied" act, not a build side effect. The DAG steps
+([`CalibBusStep`](./bus_model.md#automating-it-calibbusstep),
+[`CollectTimingStep` / `FitTimingStep`](./component_residual.md#automating-it-collecttimingstep--fittimingstep))
+populate the **work** dir; `publish_calib` is the manual gate to the tracked one.
+
+## The `.gitignore` rules
+
+Two rules encode the split — `/calib/work/` is ignored, and the tracked library is re-included past the
+global `*.json` ignore:
+
+```gitignore
+/calib/work/                    # the churny work tier — never committed
+!/calib/platforms/**/*.json     # ...but the tracked library IS committed (params + identity)
+```
+
+## The reference platform, end to end
+
+`calib/platforms/zynq7020_bfm_100mhz/` is built reproducibly by
+[`examples/mem_copy/calibrate_platform.py`](https://github.com/sdrangan/waveflow/tree/main/examples/mem_copy/calibrate_platform.py):
+
+1. **Seed the identity** — `Platform.resolve` writes `platform.json` (`xc7z020clg484-1`, 100 MHz).
+2. **Fit the bus law** — `add_run` the measured burst laws (write `nwords + 2·(num_trans−1)`, read
+   `nwords + (num_trans−1)`) at two sizes, then `fit()` → `mm_bus.json`.
+3. **Fit the writer residual** — `collect_rtl` the measured RTL spans (183 cyc at n=128, 615 at n=512)
+   and `collect_pysim` a run **with the bus law active**, so the residual is control-only (~22 cyc),
+   then `fit()` → `components/mem_w_stream_framed_done_task/`.
+4. **Publish** — `publish_calib calib/work/zynq7020_bfm_100mhz calib/platforms/zynq7020_bfm_100mhz
+   --apply`.
+
+The pysim runs live (no toolchain); only the RTL spans are measured constants (gated for real by the
+`-m xsi` run that produced 0.0% error). Loading the committed platform reproduces the writer RTL period
+to **0.0%** at both sizes — a test pins it, so the committed params can't silently drift.
+
+## A known limitation: collinear sizes
+
+The reference platform was swept at two sizes whose `num_trans` and `nwords` are proportional
+(`num_trans = nwords / 16`), so the two features are collinear: the fit **reproduces the measured
+points exactly** but its split between a per-word and a per-burst slope is underdetermined (the writer's
+residual reads as 23 at n=128, 0 at n=512). A third, non-collinear sweep size is the follow-up before
+trusting the model to *extrapolate* beyond the swept range.
+
+## See also
+
+- [Platforms](./platform.md) — the identity the workflow seeds and confirms.
+- [The bus-transfer model](./bus_model.md) / [Component residuals](./component_residual.md) — the two
+  fits the sweep produces.
+- [Build system](../build/) — the DAG the calibration steps plug into.


### PR DESCRIPTION
Documents the calibration system merged in #118. Extends `docs/guide/calib/` from the old ad-hoc `CalibDataFrame` framing to the full platform-calibration model, and reconciles the stale spots.

## New pages (usage → system → primitives)
- **insertion.md** — usage-first: where a `TimingModel` plugs into a `FreeRunComp`, charging its delay with `timed_delay`, and why read-stalls emerge from the sim rather than the model.
- **platform.md** — the `Platform` identity (`platform.json` = part + clock), why a platform is keyed by part **and** synthesis clock (HLS scheduling), `BuildConfig` selection + mismatch guard.
- **bus_model.md** — `BusCalib`: the `m_axi` span law, `measure_bus_span`, `mm_bus.json`, `bus_timing()`, `CalibBusStep`.
- **component_residual.md** — `StreamTimingModel`: `residual = rtl − pysim + current_dly`, collect/join/fit, where the model lives (on-disk `calib_dir`, so a component's attached instance and a separate fitting instance coordinate through the directory), shared vs custom storage, `Collect`/`FitTimingStep`.
- **workflow.md** — two-tier `work` → `publish_calib` → `platforms`, the regression guard, and the reference `zynq7020_bfm_100mhz` platform end to end.

## Reconciles
- `index.md` rewritten around three ideas: the two-level split (platform bus vs component control), the two kinds of component (shared-infra vs custom storage), and one calibration layer.
- `build/corecomp.md` documents `BuildConfig.platform` / `part` / `clk_freq` / `platforms_root` / `allow_platform_mismatch`.
- `examples/memcpy/timing.md` — the closing "next arc" now points at the built `BusCalib` / calibration guide.
- Primitive pages (`dataframe` / `models` / `example` / `instrumentation`) renumbered after the platform system.

Docs-only; no code changes. Section reads `insertion → platform → bus_model → component_residual → workflow → dataframe → models → example → instrumentation` (nav 1–9), all cross-links and anchors verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)